### PR TITLE
Use oras.land vanity import

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Using the ORAS Go library, you can develop your own push/pull experience: `myclient push artifacts.azurecr.io/myartifact:1.0 ./mything.thang`
 
-The package `github.com/oras-project/oras-go/pkg/oras` can quickly be imported in other Go-based tools that
+The package `oras.land/oras-go` can quickly be imported in other Go-based tools that
 wish to benefit from the ability to store arbitrary content in container registries.
 
 ### ORAS Go Library Example
@@ -26,11 +26,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oras-project/oras-go/pkg/content"
-	"github.com/oras-project/oras-go/pkg/oras"
-
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"oras.land/oras-go/pkg/content"
+	"oras.land/oras-go/pkg/oras"
 )
 
 func check(e error) {

--- a/examples/simple_push_pull.go
+++ b/examples/simple_push_pull.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/oras-project/oras-go/pkg/content"
-	"github.com/oras-project/oras-go/pkg/oras"
-
 	"github.com/containerd/containerd/remotes/docker"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"oras.land/oras-go/pkg/content"
+	"oras.land/oras-go/pkg/oras"
 )
 
 func check(e error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oras-project/oras-go
+module oras.land/oras-go
 
 go 1.16
 

--- a/pkg/auth/docker/client.go
+++ b/pkg/auth/docker/client.go
@@ -18,12 +18,12 @@ package docker
 import (
 	"os"
 
-	"github.com/oras-project/oras-go/pkg/auth"
-
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/pkg/errors"
+
+	"oras.land/oras-go/pkg/auth"
 )
 
 // Client provides authentication operations for docker registries.

--- a/pkg/auth/docker/client_test.go
+++ b/pkg/auth/docker/client_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/crypto/bcrypt"
 
-	iface "github.com/oras-project/oras-go/pkg/auth"
+	iface "oras.land/oras-go/pkg/auth"
 )
 
 var (

--- a/pkg/auth/docker/login.go
+++ b/pkg/auth/docker/login.go
@@ -22,7 +22,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/registry"
 
-	iface "github.com/oras-project/oras-go/pkg/auth"
+	iface "oras.land/oras-go/pkg/auth"
 )
 
 // Login logs in to a docker registry identified by the hostname.

--- a/pkg/auth/docker/logout.go
+++ b/pkg/auth/docker/logout.go
@@ -18,9 +18,9 @@ package docker
 import (
 	"context"
 
-	"github.com/oras-project/oras-go/pkg/auth"
-
 	"github.com/docker/cli/cli/config/configfile"
+
+	"oras.land/oras-go/pkg/auth"
 )
 
 // Logout logs out from a docker registry identified by the hostname.

--- a/pkg/auth/docker/resolver.go
+++ b/pkg/auth/docker/resolver.go
@@ -24,7 +24,7 @@ import (
 	ctypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/registry"
 
-	iface "github.com/oras-project/oras-go/pkg/auth"
+	iface "oras.land/oras-go/pkg/auth"
 )
 
 // Resolver returns a new authenticated resolver.

--- a/pkg/content/decompressstore_test.go
+++ b/pkg/content/decompressstore_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 
 	ctrcontent "github.com/containerd/containerd/content"
-	"github.com/oras-project/oras-go/pkg/content"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"oras.land/oras-go/pkg/content"
 )
 
 func TestDecompressStore(t *testing.T) {

--- a/pkg/content/file_test.go
+++ b/pkg/content/file_test.go
@@ -22,9 +22,10 @@ import (
 	"testing"
 
 	ctrcontent "github.com/containerd/containerd/content"
-	"github.com/oras-project/oras-go/pkg/content"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"oras.land/oras-go/pkg/content"
 )
 
 func TestFileStoreNoName(t *testing.T) {

--- a/pkg/content/multireader_test.go
+++ b/pkg/content/multireader_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 
 	ctrcontent "github.com/containerd/containerd/content"
-	"github.com/oras-project/oras-go/pkg/content"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"oras.land/oras-go/pkg/content"
 )
 
 var (

--- a/pkg/content/passthrough_test.go
+++ b/pkg/content/passthrough_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 
 	ctrcontent "github.com/containerd/containerd/content"
-	"github.com/oras-project/oras-go/pkg/content"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"oras.land/oras-go/pkg/content"
 )
 
 var (

--- a/pkg/oras/oras_test.go
+++ b/pkg/oras/oras_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	orascontent "github.com/oras-project/oras-go/pkg/content"
+	orascontent "oras.land/oras-go/pkg/content"
 
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"

--- a/pkg/oras/pull.go
+++ b/pkg/oras/pull.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"sync"
 
-	orascontent "github.com/oras-project/oras-go/pkg/content"
-
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/log"
@@ -28,6 +26,8 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
+
+	orascontent "oras.land/oras-go/pkg/content"
 )
 
 // Pull pull files from the remote

--- a/pkg/oras/pull_opts.go
+++ b/pkg/oras/pull_opts.go
@@ -21,12 +21,12 @@ import (
 	"io"
 	"sync"
 
-	orascontent "github.com/oras-project/oras-go/pkg/content"
-
 	"github.com/containerd/containerd/images"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/semaphore"
+
+	orascontent "oras.land/oras-go/pkg/content"
 )
 
 type pullOpts struct {

--- a/pkg/oras/push.go
+++ b/pkg/oras/push.go
@@ -22,10 +22,11 @@ import (
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes"
-	artifact "github.com/oras-project/oras-go/pkg/artifact"
 	digest "github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	artifact "oras.land/oras-go/pkg/artifact"
 )
 
 // Push pushes files to the remote

--- a/pkg/oras/push_opts.go
+++ b/pkg/oras/push_opts.go
@@ -24,10 +24,10 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd/images"
-	orascontent "github.com/oras-project/oras-go/pkg/content"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+
+	orascontent "oras.land/oras-go/pkg/content"
 )
 
 type pushOpts struct {

--- a/pkg/oras/store.go
+++ b/pkg/oras/store.go
@@ -21,12 +21,12 @@ import (
 	"io"
 	"time"
 
-	orascontent "github.com/oras-project/oras-go/pkg/content"
-
 	"github.com/containerd/containerd/content"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
+
+	orascontent "oras.land/oras-go/pkg/content"
 )
 
 // ensure interface


### PR DESCRIPTION
Just for fun. I've enabled it on the website:
```
$ curl https://oras.land/oras-go
<!doctype html><html lang=en-us><head><meta charset=utf-8><meta name=go-import content="oras.land/oras-go git https://github.com/oras-project/oras-go"><meta name=go-source content="oras.land/oras-go git https://github.com/oras-project/oras-go https://github.com/oras-project/oras-go/tree/main{/dir} https://github.com/oras-project/oras-go/blob/main{/dir}/{file}#L{line}"><meta http-equiv=refresh content="0; url=https://github.com/oras-project/oras-go"></head><body>Nothing to see here; <a href=https://github.com/oras-project/oras-go>move along</a>.</body></html>
```

Let me know if any objection