### PR TITLE
Corrected auth scope repository

### DIFF
--- a/registry/remote/utils.go
+++ b/registry/remote/utils.go
@@ -67,6 +67,6 @@ func limitReader(r io.Reader, n int64) io.Reader {
 
 // withScopeHint adds a hinted scope to the context.
 func withScopeHint(ctx context.Context, ref registry.Reference, actions ...string) context.Context {
-	scope := auth.ScopeRepository(ref.Reference, actions...)
+	scope := auth.ScopeRepository(ref.Repository, actions...)
 	return auth.AppendScopes(ctx, scope)
 }


### PR DESCRIPTION
Auth scope currently makes use of a repository reference, but should make use of the repository field instead. 