### PR TITLE
Update Makefile and scripts

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.4'
+          go-version: '1.17.6'
       - name: run unit tests
         run: make test
       - name: run acceptance tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16.4'
+          go-version: '1.17.6'
       - name: run unit tests
         run: make test
       - name: run acceptance tests

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ clean:
 
 .PHONY: check-encoding
 check-encoding:
-	! find . -name "*.go" -type f -exec file "{}" ";" | grep CRLF
+	! find . -not -path "./vendor/*" -name "*.go" -type f -exec file "{}" ";" | grep CRLF
 	! find scripts -name "*.sh" -type f -exec file "{}" ";" | grep CRLF
 
 .PHONY: fix-encoding
 fix-encoding:
-	find . -type f -name "*.go" -exec sed -i -e "s/\r//g" {} +
-	find scripts -type f -name "*.sh" -exec sed -i -e "s/\r//g" {} +
+	find . -not -path "./vendor/*" -name "*.go" -type f -exec sed -i -e "s/\r//g" {} +
+	find scripts -name "*.sh" -type f -exec sed -i -e "s/\r//g" {} +
 
 .PHONY: vendor
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# TODO: use this for fetch-dist
-TARGET_OBJS ?= todo1.txt todo2.txt
-
 .PHONY: test
 test: vendor check-encoding
 	./scripts/test.sh
@@ -19,41 +16,14 @@ clean:
 
 .PHONY: check-encoding
 check-encoding:
-	! find pkg examples -name "*.go" -type f -exec file "{}" ";" | grep CRLF
+	! find . -name "*.go" -type f -exec file "{}" ";" | grep CRLF
 	! find scripts -name "*.sh" -type f -exec file "{}" ";" | grep CRLF
 
 .PHONY: fix-encoding
 fix-encoding:
-	find pkg examples -type f -name "*.go" -exec sed -i -e "s/\r//g" {} +
+	find . -type f -name "*.go" -exec sed -i -e "s/\r//g" {} +
 	find scripts -type f -name "*.sh" -exec sed -i -e "s/\r//g" {} +
 
 .PHONY: vendor
 vendor:
-	GO111MODULE=on go mod vendor
-
-# TODO: use this
-.PHONY: fetch-dist
-fetch-dist:
-	mkdir -p _dist
-	cd _dist && \
-	for obj in ${TARGET_OBJS} ; do \
-		curl -sSL -o oras_${VERSION}_$${obj} https://github.com/oras-project/oras-go/releases/download/v${VERSION}/oras_${VERSION}_$${obj} ; \
-	done
-
-# 1. mkdir _dist/
-# 2. manually download .zip / .tar.gz from release page
-# 3. move files into _dist/
-# 4. make sign
-# 5. upload .asc files back to release page
-.PHONY: sign
-sign:
-	for f in $$(ls _dist/*.{zip,tar.gz} 2>/dev/null) ; do \
-		gpg --armor --detach-sign $${f} ; \
-	done
-
-.PHONY: checksums
-checksums:
-	cd _dist/ && \
-	for f in $$(ls *.{zip,tar.gz} 2>/dev/null) ; do \
-		shasum -a 256 $${f} ; \
-	done
+	go mod vendor

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -29,7 +29,7 @@ docker rm -f oras-acceptance-registry || true
   cd examples
   for example in */; do
     example=${example%/}
-    CGO_ENABLED=0 go build -v -o ../bin/oras-acceptance-$example ./$example
+    CGO_ENABLED=0 go build -v -o ../bin/oras-acceptance-${example} ./${example}
   done
 )
 

--- a/scripts/acceptance.sh
+++ b/scripts/acceptance.sh
@@ -27,8 +27,10 @@ docker rm -f oras-acceptance-registry || true
 # Build the examples into binaries
 (
   cd examples
-  CGO_ENABLED=0 go build -v -o ../bin/oras-acceptance-simple ./simple
-  CGO_ENABLED=0 go build -v -o ../bin/oras-acceptance-advanced ./advanced
+  for example in */; do
+    example=${example%/}
+    CGO_ENABLED=0 go build -v -o ../bin/oras-acceptance-$example ./$example
+  done
 )
 
 # Run a test registry and expose at localhost:5000

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,7 +22,7 @@ mkdir .cover/ .test/
 trap "rm -rf .test/" EXIT
 
 export CGO_ENABLED=0
-for pkg in `go list ./pkg/... | grep -v /vendor/`; do
+for pkg in `go list ./...`; do
     go test -v -covermode=atomic \
         -coverprofile=".cover/$(echo $pkg | sed 's/\//_/g').cover.out" $pkg
 done


### PR DESCRIPTION
Resolves #61.

- Update and clean up Makefile.
- Fix test script.
- Detect examples instead of hard coding.
- Update go version to `1.17.6` for testing.