### PR TITLE
use io.ReadFull for ProviderWrapper in case of partial read

### DIFF
--- a/pkg/oras/provider.go
+++ b/pkg/oras/provider.go
@@ -70,7 +70,7 @@ func (f *fetcherReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		f.rc = rc
 	}
 
-	n, err = f.rc.Read(p)
+	n, err = io.ReadFull(f.rc, p)
 	if err != nil {
 		return n, err
 	}


### PR DESCRIPTION
fixes https://github.com/oras-project/oras-go/issues/141