### PR TITLE
Add PackArtifact

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -21,32 +21,61 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/opencontainers/go-digest"
+	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
+
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 )
 
-// MediaTypeUnknownConfig is the default mediaType used when no
-// config media type is specified.
-const MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json"
+const (
+	// MediaTypeUnknownConfig is the default mediaType used when no
+	// config media type is specified.
+	MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json"
+
+	// AnnotationArtifactCreated is the annotation key representing the UTC date
+	// and time on which the artifact was created, in RFC3339 format.
+	// References:
+	// - https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+	// - https://github.com/oras-project/artifacts-spec/blob/main/artifact-manifest.md#oras-artifact-manifest-properties
+	AnnotationArtifactCreated = "io.cncf.oras.artifact.created"
+)
+
+// ErrMissingArtifactType is returned by PackArtifact() when no artifact type is
+// specified.
+var ErrMissingArtifactType = errors.New("missing artifact type")
 
 // PackOptions contains parameters for oras.Pack.
 type PackOptions struct {
-	ConfigDescriptor    *ocispec.Descriptor
-	ConfigMediaType     string
-	ConfigAnnotations   map[string]string
+	// ConfigDescriptor is a pointer to the descriptor of the config blob.
+	ConfigDescriptor *ocispec.Descriptor
+	// ConfigMediaType is the media type of the config blob.
+	// If not specified, MediaTypeUnknownConfig will be used.
+	ConfigMediaType string
+	// ConfigAnnotations is the annotation map of the config descriptor.
+	ConfigAnnotations map[string]string
+	// ManifestAnnotations is the annotation map of the manifest.
+	ManifestAnnotations map[string]string
+}
+
+// PackArtifactOptions contains parameters for oras.PackArtifact.
+type PackArtifactOptions struct {
+	// Subject is the subject of the ORAS Artifact Manifest.
+	Subject *artifactspec.Descriptor
+	// ManifestAnnotations is the annotation map of the manifest.
 	ManifestAnnotations map[string]string
 }
 
 // Pack packs the given layers, generates a manifest for the pack,
-// and pushes it to a content storage. If succeeded, returns a descriptor of the manifest.
+// and pushes it to a content storage.
+// If succeeded, returns a descriptor of the manifest.
 func Pack(ctx context.Context, pusher content.Pusher, layers []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
-	configMediaType := MediaTypeUnknownConfig
-	if opts.ConfigMediaType != "" {
-		configMediaType = opts.ConfigMediaType
+	if opts.ConfigMediaType == "" {
+		opts.ConfigMediaType = MediaTypeUnknownConfig
 	}
 
 	var configDesc ocispec.Descriptor
@@ -55,13 +84,13 @@ func Pack(ctx context.Context, pusher content.Pusher, layers []ocispec.Descripto
 	} else {
 		configBytes := []byte("{}")
 		configDesc = ocispec.Descriptor{
-			MediaType:   configMediaType,
+			MediaType:   opts.ConfigMediaType,
 			Digest:      digest.FromBytes(configBytes),
 			Size:        int64(len(configBytes)),
 			Annotations: opts.ConfigAnnotations,
 		}
 
-		// push config.
+		// push config
 		if err := pusher.Push(ctx, configDesc, bytes.NewReader(configBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 			return ocispec.Descriptor{}, fmt.Errorf("failed to push config: %w", err)
 		}
@@ -90,7 +119,60 @@ func Pack(ctx context.Context, pusher content.Pusher, layers []ocispec.Descripto
 		Size:      int64(len(manifestBytes)),
 	}
 
-	// push manifest.
+	// push manifest
+	if err := pusher.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push manifest: %w", err)
+	}
+
+	return manifestDesc, nil
+}
+
+// PackArtifact packs the given blobs, generates an ORAS Artifact Manifest for
+// the pack, and pushes it to a content storage.
+// If succeeded, returns a descriptor of the manifest.
+// Returns ErrMissingArtifactType if artifactType is empty.
+// Reference: https://github.com/oras-project/artifacts-spec/blob/main/artifact-manifest.md
+func PackArtifact(ctx context.Context, pusher content.Pusher, blobs []artifactspec.Descriptor, artifactType string, opts PackArtifactOptions) (ocispec.Descriptor, error) {
+	if artifactType == "" {
+		// artifactType is required for ORAS Artifact Manifest
+		return ocispec.Descriptor{}, ErrMissingArtifactType
+	}
+
+	if opts.ManifestAnnotations == nil {
+		opts.ManifestAnnotations = make(map[string]string)
+	}
+
+	_, ok := opts.ManifestAnnotations[AnnotationArtifactCreated]
+	if !ok {
+		// set creation time in RFC3339 format, if not provided
+		// reference: https://github.com/oras-project/artifacts-spec/blob/main/artifact-manifest.md#oras-artifact-manifest-properties
+		now := time.Now().UTC()
+		opts.ManifestAnnotations[AnnotationArtifactCreated] = now.Format(time.RFC3339)
+	}
+
+	if blobs == nil {
+		blobs = []artifactspec.Descriptor{} // make it an empty array to prevent potential server-side bugs
+	}
+
+	manifest := artifactspec.Manifest{
+		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		ArtifactType: artifactType,
+		Blobs:        blobs,
+		Subject:      opts.Subject,
+		Annotations:  opts.ManifestAnnotations,
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+
+	manifestDesc := ocispec.Descriptor{
+		MediaType: artifactspec.MediaTypeArtifactManifest,
+		Digest:    digest.FromBytes(manifestBytes),
+		Size:      int64(len(manifestBytes)),
+	}
+
+	// push manifest
 	if err := pusher.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to push manifest: %w", err)
 	}

--- a/pack_test.go
+++ b/pack_test.go
@@ -316,9 +316,8 @@ func Test_PackArtifact_WithOptions(t *testing.T) {
 		Digest:    digest.FromBytes(subjectManifest),
 		Size:      int64(len(subjectManifest)),
 	}
-	now := time.Now().UTC()
 	annotations := map[string]string{
-		AnnotationArtifactCreated: now.Format(time.RFC3339),
+		AnnotationArtifactCreated: "2000-01-01T00:00:00Z",
 	}
 
 	// test PackArtifact
@@ -415,5 +414,21 @@ func Test_PackArtifact_MissingArtifactType(t *testing.T) {
 	_, err := PackArtifact(ctx, s, "", nil, PackArtifactOptions{})
 	if err == nil || !errors.Is(err, ErrMissingArtifactType) {
 		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, ErrMissingArtifactType)
+	}
+}
+
+func Test_PackArtifact_InvalidDateTimeFormat(t *testing.T) {
+	s := memory.New()
+
+	ctx := context.Background()
+	opts := PackArtifactOptions{
+		ManifestAnnotations: map[string]string{
+			AnnotationArtifactCreated: "2000/01/01 00:00:00",
+		},
+	}
+	artifactType := "application/vnd.test"
+	_, err := PackArtifact(ctx, s, artifactType, nil, opts)
+	if err == nil || !errors.Is(err, ErrInvalidDateTimeFormat) {
+		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, ErrInvalidDateTimeFormat)
 	}
 }

--- a/pack_test.go
+++ b/pack_test.go
@@ -243,7 +243,7 @@ func Test_PackArtifact_Default(t *testing.T) {
 
 	// test PackArtifact
 	ctx := context.Background()
-	manifestDesc, err := PackArtifact(ctx, s, blobs, artifactType, PackArtifactOptions{})
+	manifestDesc, err := PackArtifact(ctx, s, artifactType, blobs, PackArtifactOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackArtifact() error =", err)
 	}
@@ -327,7 +327,7 @@ func Test_PackArtifact_WithOptions(t *testing.T) {
 		Subject:             &subjectDesc,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackArtifact(ctx, s, blobs, artifactType, opts)
+	manifestDesc, err := PackArtifact(ctx, s, artifactType, blobs, opts)
 	if err != nil {
 		t.Fatal("Oras.PackArtifact() error =", err)
 	}
@@ -368,7 +368,7 @@ func Test_PackArtifact_NoBlob(t *testing.T) {
 	// test Pack
 	ctx := context.Background()
 	artifactType := "application/vnd.test"
-	manifestDesc, err := PackArtifact(ctx, s, nil, artifactType, PackArtifactOptions{})
+	manifestDesc, err := PackArtifact(ctx, s, artifactType, nil, PackArtifactOptions{})
 	if err != nil {
 		t.Fatal("Oras.Pack() error =", err)
 	}
@@ -412,7 +412,7 @@ func Test_PackArtifact_MissingArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	_, err := PackArtifact(ctx, s, nil, "", PackArtifactOptions{})
+	_, err := PackArtifact(ctx, s, "", nil, PackArtifactOptions{})
 	if err == nil || !errors.Is(err, ErrMissingArtifactType) {
 		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, ErrMissingArtifactType)
 	}


### PR DESCRIPTION
Add `PackArtifact` to support packing ORAS Artifact Manifest, and set a default `io.cncf.oras.artifact.created` annotation.

Signed-off-by: Sylvia Lei <lixlei@microsoft.com>

Resolves #175
Resolves #202
Related: #205, #206