### PR TITLE
fix: oras pull error `empty response Docker-Content-Digest`

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1024,7 +1024,12 @@ func (s *manifestStore) generateDescriptor(resp *http.Response, ref registry.Ref
 	}
 
 	if len(refDigest) > 0 && refDigest != contentDigest {
-		return ocispec.Descriptor{}, fmt.Errorf("%s: mismatch digest: %s", refDigest, contentDigest)
+		return ocispec.Descriptor{}, fmt.Errorf(
+			"%s %q: invalid response; digest mismatch: `%s: %s` vs expected `%s`",
+			resp.Request.Method, resp.Request.URL,
+			dockerContentDigestHeader, contentDigest,
+			refDigest,
+		)
 	}
 
 	// 6. Finally, if we made it this far, then all is good; return.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -952,38 +952,7 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 }
 
 // generateDescriptor returns a descriptor generated from the response.
-//
-// The following truth table aims to cover the expected GET/HEAD request outcome
-// for all possible permutations of the client/server "containing a digest".
-//
-// The client is said to "contain a digest" if the user-supplied reference string
-// is of the form that contains a digest rather than a tag.  The server, on the
-// other hand, is said to "contain a digest" if the server responded with the
-// special header `Docker-Content-Digest`.
-//
-// In this table, anything denoted with an asterisk indicates that the true
-// response should actually be the opposite of what's expected; for example,
-// `*PASS` means we will get a `PASS`, even though the true answer would be its
-// diametric opposite--a `FAIL`. This may seem odd, and deserves an explanation.
-// This function has blind-spots, and while it can expend power to gain sight,
-// i.e., perform the expensive validation, we chose not to.  The reason is two-
-// fold: a) we "know" that even if we say "!PASS", it will eventually fail later
-// when checks are performed, and with that assumption, we have the luxury for
-// the second point, which is b) performance.
-//
-//	 ___________________________________________________________________________________
-//	| ID | CLIENT        | SERVER         | GET                   | HEAD                |
-//	|----+---------------+----------------+-----------------------+---------------------+
-//	| 1  | tag           | missing        | CALCULATE,PASS        | FAIL                |
-//	| 2  | tag           | presentValid   | TRUST,PASS            | TRUST,PASS          |
-//	| 3  | tag           | presentInvalid | TRUST,*PASS           | TRUST,*PASS         |
-//	| 4  | validDigest   | missing        | TRUST,PASS            | TRUST,PASS          |
-//	| 5  | validDigest   | presentValid   | TRUST,COMPARE,PASS    | TRUST,COMPARE,PASS  |
-//	| 6  | validDigest   | presentInvalid | TRUST,COMPARE,FAIL    | TRUST,COMPARE,FAIL  |
-//	| 7  | invalidDigest | missing        | TRUST,FAIL            | TRUST,*PASS         | <TBA>
-//	| 8  | invalidDigest | presentValid   | TRUST,COMPARE,FAIL    | TRUST,COMPARE,FAIL  | <TBA>
-//	| 9  | invalidDigest | presentInvalid | TRUST,COMPARE,*PASS   | TRUST,COMPARE,*PASS | <TBA>
-//	 -----------------------------------------------------------------------------------
+// See the truth table at the top of `repository_test.go`
 func (s *manifestStore) generateDescriptor(resp *http.Response, ref registry.Reference, httpMethod string) (ocispec.Descriptor, error) {
 	// 1. Validate Content-Type
 	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -2210,7 +2210,7 @@ func Test_BlobStore_Resolve(t *testing.T) {
 	}
 }
 
-func Test_Manifest_generateDescriptorWithVariousDockerContentDigestHeaders(t *testing.T) {
+func Test_Manifest_generateManifestDescriptorWithVariousDockerContentDigestHeaders(t *testing.T) {
 	type testIOStruct struct {
 		name                    string
 		clientSuppliedReference string
@@ -2286,7 +2286,7 @@ func Test_Manifest_generateDescriptorWithVariousDockerContentDigestHeaders(t *te
 			resp.Request = &http.Request{
 				Method: method,
 			}
-			_, err := generateDescriptor(&resp, reference, method)
+			_, err := generateManifestDescriptor(&resp, reference, method)
 			if !errExpected && err != nil {
 				t.Errorf(
 					"%v; expected no error for %v request, but got err: %v",

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -2268,10 +2268,10 @@ func Test_Manifest_generateManifestDescriptorWithVariousDockerContentDigestHeade
 	reference := registry.Reference{
 		Registry:   "eastern.haan.com",
 		Reference:  "<calculate>",
-		Repository: "25To220CE",
+		Repository: "from25to220ce",
 	}
 	for testName, dcdIOStruct := range tests {
-		for i, method := range []string{"GET", "HEAD"} {
+		for i, method := range []string{http.MethodGet, http.MethodHead} {
 			reference.Reference = dcdIOStruct.clientSuppliedReference
 			errExpected := []bool{dcdIOStruct.errExpectedOnGET, dcdIOStruct.errExpectedOnHEAD}[i]
 			resp := http.Response{
@@ -2280,13 +2280,13 @@ func Test_Manifest_generateManifestDescriptorWithVariousDockerContentDigestHeade
 					dockerContentDigestHeader: []string{dcdIOStruct.serverCalculatedDigest.String()},
 				},
 			}
-			if method == "GET" {
+			if method == http.MethodGet {
 				resp.Body = io.NopCloser(bytes.NewBufferString(theAmazingBanClan))
 			}
 			resp.Request = &http.Request{
 				Method: method,
 			}
-			_, err := generateManifestDescriptor(&resp, reference, method)
+			_, err := generateManifestDescriptor(&resp, reference, method, 0)
 			if !errExpected && err != nil {
 				t.Errorf(
 					"%v; expected no error for %v request, but got err: %v",

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -2210,98 +2210,6 @@ func Test_BlobStore_Resolve(t *testing.T) {
 	}
 }
 
-func Test_Manifest_generateManifestDescriptorWithVariousDockerContentDigestHeaders(t *testing.T) {
-	type testIOStruct struct {
-		name                    string
-		clientSuppliedReference string
-		serverCalculatedDigest  digest.Digest // for non-HEAD (body-containing) requests only
-		errExpectedOnHEAD       bool
-		errExpectedOnGET        bool
-	}
-	const theAmazingBanClan = "Ban Gu, Ban Chao, Ban Zhao"
-	const theAmazingBanDigest = "b526a4f2be963a2f9b0990c001255669eab8a254ab1a6e3f84f1820212ac7078"
-	correctDigest := fmt.Sprintf("sha256:%v", theAmazingBanDigest)
-	incorrectDigest := fmt.Sprintf("sha256:%v", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
-
-	// For the Truth Table that these tests are modeled on, see the following:
-	// https://github.com/nima/oras-go/blob/issues/225/registry/remote/repository.go#L1009-L1030
-	tests := map[string]testIOStruct{
-		"1. NoClient & NoServer": {
-			errExpectedOnHEAD: true,
-		},
-		"2. NoClient & ValidServer": {
-			serverCalculatedDigest: digest.Digest(correctDigest),
-		},
-		"3. NoClient & InvalidServer": {
-			serverCalculatedDigest: digest.Digest(incorrectDigest),
-		},
-		"4. ValidClient & NoServer": {
-			clientSuppliedReference: correctDigest,
-			errExpectedOnHEAD:       true,
-		},
-		"5. ValidClient & ValidServer": {
-			clientSuppliedReference: correctDigest,
-			serverCalculatedDigest:  digest.Digest(correctDigest),
-		},
-		"6. ValidClient & InvalidServer": {
-			clientSuppliedReference: correctDigest,
-			serverCalculatedDigest:  digest.Digest(incorrectDigest),
-			errExpectedOnHEAD:       true,
-			errExpectedOnGET:        true,
-		},
-		"7. InvalidClient & NoServer": {
-			clientSuppliedReference: incorrectDigest,
-			errExpectedOnHEAD:       true,
-			errExpectedOnGET:        true,
-		},
-		"8. InvalidClient & ValidServer": {
-			clientSuppliedReference: incorrectDigest,
-			serverCalculatedDigest:  digest.Digest(correctDigest),
-			errExpectedOnHEAD:       true,
-			errExpectedOnGET:        true,
-		},
-		"9. InvalidClient & InvalidServer": {
-			clientSuppliedReference: incorrectDigest,
-			serverCalculatedDigest:  digest.Digest(incorrectDigest),
-		},
-	}
-	reference := registry.Reference{
-		Registry:   "eastern.haan.com",
-		Reference:  "<calculate>",
-		Repository: "from25to220ce",
-	}
-	for testName, dcdIOStruct := range tests {
-		for i, method := range []string{http.MethodGet, http.MethodHead} {
-			reference.Reference = dcdIOStruct.clientSuppliedReference
-			errExpected := []bool{dcdIOStruct.errExpectedOnGET, dcdIOStruct.errExpectedOnHEAD}[i]
-			resp := http.Response{
-				Header: http.Header{
-					"Content-Type":            []string{"application/vnd.docker.distribution.manifest.v2+json"},
-					dockerContentDigestHeader: []string{dcdIOStruct.serverCalculatedDigest.String()},
-				},
-			}
-			if method == http.MethodGet {
-				resp.Body = io.NopCloser(bytes.NewBufferString(theAmazingBanClan))
-			}
-			resp.Request = &http.Request{
-				Method: method,
-			}
-			_, err := generateManifestDescriptor(&resp, reference, method, 0)
-			if !errExpected && err != nil {
-				t.Errorf(
-					"%v; expected no error for %v request, but got err: %v",
-					testName, method, err,
-				)
-			} else if errExpected && err == nil {
-				t.Errorf(
-					"%v; expected an error for %v request, but got none",
-					testName, method,
-				)
-			}
-		}
-	}
-}
-
 func Test_BlobStore_FetchReference(t *testing.T) {
 	blob := []byte("hello world")
 	blobDesc := ocispec.Descriptor{
@@ -2589,6 +2497,103 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 	_, err = store.Fetch(ctx, contentDesc)
 	if !errors.Is(err, errdef.ErrNotFound) {
 		t.Errorf("Manifests.Fetch() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}
+}
+
+func Test_ManifestStore_generateDescriptorWithVariousDockerContentDigestHeaders(t *testing.T) {
+	type testIOStruct struct {
+		name                    string
+		clientSuppliedReference string
+		serverCalculatedDigest  digest.Digest // for non-HEAD (body-containing) requests only
+		errExpectedOnHEAD       bool
+		errExpectedOnGET        bool
+	}
+	const theAmazingBanClan = "Ban Gu, Ban Chao, Ban Zhao"
+	const theAmazingBanDigest = "b526a4f2be963a2f9b0990c001255669eab8a254ab1a6e3f84f1820212ac7078"
+	correctDigest := fmt.Sprintf("sha256:%v", theAmazingBanDigest)
+	incorrectDigest := fmt.Sprintf("sha256:%v", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+
+	// For the Truth Table that these tests are modeled on, see the following:
+	// https://github.com/nima/oras-go/blob/issues/225/registry/remote/repository.go#L1009-L1030
+	tests := map[string]testIOStruct{
+		"1. NoClient & NoServer": {
+			errExpectedOnHEAD: true,
+		},
+		"2. NoClient & ValidServer": {
+			serverCalculatedDigest: digest.Digest(correctDigest),
+		},
+		"3. NoClient & InvalidServer": {
+			serverCalculatedDigest: digest.Digest(incorrectDigest),
+		},
+		"4. ValidClient & NoServer": {
+			clientSuppliedReference: correctDigest,
+		},
+		"5. ValidClient & ValidServer": {
+			clientSuppliedReference: correctDigest,
+			serverCalculatedDigest:  digest.Digest(correctDigest),
+		},
+		"6. ValidClient & InvalidServer": {
+			clientSuppliedReference: correctDigest,
+			serverCalculatedDigest:  digest.Digest(incorrectDigest),
+			errExpectedOnHEAD:       true,
+			errExpectedOnGET:        true,
+		},
+		"7. InvalidClient & NoServer": {
+			clientSuppliedReference: incorrectDigest,
+			errExpectedOnGET:        true,
+		},
+		"8. InvalidClient & ValidServer": {
+			clientSuppliedReference: incorrectDigest,
+			serverCalculatedDigest:  digest.Digest(correctDigest),
+			errExpectedOnHEAD:       true,
+			errExpectedOnGET:        true,
+		},
+		"9. InvalidClient & InvalidServer": {
+			clientSuppliedReference: incorrectDigest,
+			serverCalculatedDigest:  digest.Digest(incorrectDigest),
+		},
+	}
+	reference := registry.Reference{
+		Registry:   "eastern.haan.com",
+		Reference:  "<calculate>",
+		Repository: "from25to220ce",
+	}
+	for testName, dcdIOStruct := range tests {
+		repo, err := NewRepository(fmt.Sprintf("%s/%s", reference.Repository, reference.Repository))
+		if err != nil {
+			t.Fatalf("failed to initialize repository")
+		}
+
+		s := manifestStore{repo: repo}
+
+		for i, method := range []string{http.MethodGet, http.MethodHead} {
+			reference.Reference = dcdIOStruct.clientSuppliedReference
+			errExpected := []bool{dcdIOStruct.errExpectedOnGET, dcdIOStruct.errExpectedOnHEAD}[i]
+			resp := http.Response{
+				Header: http.Header{
+					"Content-Type":            []string{"application/vnd.docker.distribution.manifest.v2+json"},
+					dockerContentDigestHeader: []string{dcdIOStruct.serverCalculatedDigest.String()},
+				},
+			}
+			if method == http.MethodGet {
+				resp.Body = io.NopCloser(bytes.NewBufferString(theAmazingBanClan))
+			}
+			resp.Request = &http.Request{
+				Method: method,
+			}
+			_, err := s.generateDescriptor(&resp, reference, method)
+			if !errExpected && err != nil {
+				t.Errorf(
+					"%v; expected no error for %v request, but got err: %v",
+					testName, method, err,
+				)
+			} else if errExpected && err == nil {
+				t.Errorf(
+					"%v; expected an error for %v request, but got none",
+					testName, method,
+				)
+			}
+		}
 	}
 }
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -43,8 +43,6 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
 
-// For the Truth Table that these tests are modeled on, see the following:
-// https://github.com/nima/oras-go/blob/issues/225/registry/remote/repository.go#L1009-L1030
 type testIOStruct struct {
 	name                      string
 	isTag                     bool
@@ -2571,6 +2569,11 @@ func Test_generateBlobDescriptorWithVariousDockerContentDigestHeaders(t *testing
 			}
 
 			errExpected := []bool{dcdIOStruct.errExpectedOnBlobGET, dcdIOStruct.errExpectedOnBlobHEAD}[i]
+			if len(d) == 0 {
+				// To avoid an otherwise impossible scenario in the tested code
+				// path, we set d so that verifyContentDigest does not break.
+				d = dcdIOStruct.serverCalculatedDigest
+			}
 			_, err = generateBlobDescriptor(&resp, d)
 			if !errExpected && err != nil {
 				t.Errorf(


### PR DESCRIPTION
See https://github.com/oras-project/oras-go/issues/225 for details, but here's the **tldr**:

```
% oras pull 080565210187.dkr.ecr.us-west-2.amazonaws.com/my.repo:my.tag
Error: GET "https://080565210187.dkr.ecr.us-west-2.amazonaws.com/v2/my.repo/manifests/my.tag": empty response Docker-Content-Digest
```

The expected outcome (what this PR claims to fix):
```
% oras pull 080565210187.dkr.ecr.us-west-2.amazonaws.com/my.repo:my.tag
Downloading 3cd22ae067a3
Downloaded empty artifact
Pulled 080565210187.dkr.ecr.us-west-2.amazonaws.com/my.repo:my.tag
Digest: sha256:32aef68c20b6f25d69ecbc2f3f98e28f6f6fdacade75ee879459b61f610583f0
```

Resolves #225