### PR TITLE
feat: Support platform selection on Copy

### DIFF
--- a/content.go
+++ b/content.go
@@ -44,22 +44,29 @@ func Tag(ctx context.Context, target Target, src, dst string) error {
 	return target.Tag(ctx, desc, dst)
 }
 
+var (
+	// DefaultResolveOptions provides the default ResolveOptions.
+	DefaultResolveOptions = ResolveOptions{
+		TargetPlatform: nil,
+	}
+)
+
 // ResolveOptions contains parameters for oras.Resolve.
 type ResolveOptions struct {
-	// MatchPlaform is the target platform.
+	// TargetPlatform is the target platform.
 	// Will do the platform selection if specified.
-	MatchPlatform *ocispec.Platform
+	TargetPlatform *ocispec.Platform
 }
 
-// Resolve returns the resolved descriptor.
+// Resolve resolves a descriptor with provided reference from the target.
 func Resolve(ctx context.Context, target Target, ref string, opts ResolveOptions) (ocispec.Descriptor, error) {
 	desc, err := target.Resolve(ctx, ref)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
 
-	if opts.MatchPlatform != nil {
-		desc, err = selectPlatform(ctx, target, desc, opts.MatchPlatform)
+	if opts.TargetPlatform != nil {
+		desc, err = selectPlatform(ctx, target, desc, opts.TargetPlatform)
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}

--- a/content.go
+++ b/content.go
@@ -18,6 +18,7 @@ package oras
 import (
 	"context"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -41,4 +42,28 @@ func Tag(ctx context.Context, target Target, src, dst string) error {
 		return err
 	}
 	return target.Tag(ctx, desc, dst)
+}
+
+// ResolveOptions contains parameters for oras.Resolve.
+type ResolveOptions struct {
+	// MatchPlaform is the target platform.
+	// Will do the platform selection if specified.
+	MatchPlatform *ocispec.Platform
+}
+
+// Resolve returns the resolved descriptor.
+func Resolve(ctx context.Context, target Target, ref string, opts ResolveOptions) (ocispec.Descriptor, error) {
+	desc, err := target.Resolve(ctx, ref)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	if opts.MatchPlatform != nil {
+		desc, err = selectPlatform(ctx, target, desc, opts.MatchPlatform)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	return desc, nil
 }

--- a/content.go
+++ b/content.go
@@ -17,8 +17,12 @@ package oras
 
 import (
 	"context"
+	"fmt"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/docker"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -44,33 +48,53 @@ func Tag(ctx context.Context, target Target, src, dst string) error {
 	return target.Tag(ctx, desc, dst)
 }
 
-var (
-	// DefaultResolveOptions provides the default ResolveOptions.
-	DefaultResolveOptions = ResolveOptions{
-		TargetPlatform: nil,
-	}
-)
+// DefaultResolveOptions provides the default ResolveOptions.
+var DefaultResolveOptions ResolveOptions
 
 // ResolveOptions contains parameters for oras.Resolve.
 type ResolveOptions struct {
-	// TargetPlatform is the target platform.
-	// Will do the platform selection if specified.
+	// TargetPlatform ensures the resolved content matches the target platform
+	// if the node is a manifest, or selects the first resolved content that
+	// matches the target platform if the node is a manifest list.
 	TargetPlatform *ocispec.Platform
 }
 
 // Resolve resolves a descriptor with provided reference from the target.
 func Resolve(ctx context.Context, target Target, ref string, opts ResolveOptions) (ocispec.Descriptor, error) {
+	if opts.TargetPlatform == nil {
+		return target.Resolve(ctx, ref)
+	}
+
+	if refFetcher, ok := target.(registry.ReferenceFetcher); ok {
+		// optimize performance for ReferenceFetcher targets
+		desc, rc, err := refFetcher.FetchReference(ctx, ref)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		defer rc.Close()
+
+		switch desc.MediaType {
+		case docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex,
+			docker.MediaTypeManifest, ocispec.MediaTypeImageManifest:
+			// create a proxy to cache the fetched descriptor
+			store := cas.NewMemory()
+			err = store.Push(ctx, desc, rc)
+			if err != nil {
+				return ocispec.Descriptor{}, err
+			}
+
+			proxy := cas.NewProxy(target, store)
+			proxy.StopCaching = true
+			return selectPlatform(ctx, proxy, desc, opts.TargetPlatform)
+		default:
+			return ocispec.Descriptor{}, fmt.Errorf("%s: %s: %w", desc.Digest, desc.MediaType, errdef.ErrUnsupported)
+		}
+	}
+
 	desc, err := target.Resolve(ctx, ref)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
 
-	if opts.TargetPlatform != nil {
-		desc, err = selectPlatform(ctx, target, desc, opts.TargetPlatform)
-		if err != nil {
-			return ocispec.Descriptor{}, err
-		}
-	}
-
-	return desc, nil
+	return selectPlatform(ctx, target, desc, opts.TargetPlatform)
 }

--- a/content_test.go
+++ b/content_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,6 +31,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
@@ -184,5 +186,162 @@ func TestTag_Repository(t *testing.T) {
 	}
 	if !bytes.Equal(gotIndex, index) {
 		t.Errorf("Repository.TagReference() = %v, want %v", gotIndex, index)
+	}
+}
+
+func TestResolve_WithOptions(t *testing.T) {
+	target := memory.New()
+
+	// generate test content
+	var blobs [][]byte
+	var descs []ocispec.Descriptor
+	appendBlob := func(mediaType string, blob []byte) {
+		blobs = append(blobs, blob)
+		descs = append(descs, ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+		})
+	}
+	generateManifest := func(config ocispec.Descriptor, layers ...ocispec.Descriptor) {
+		manifest := ocispec.Manifest{
+			Config: config,
+			Layers: layers,
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
+	}
+
+	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))     // Blob 1
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("bar"))     // Blob 2
+	generateManifest(descs[0], descs[1:3]...)                  // Blob 3
+
+	ctx := context.Background()
+	for i := range blobs {
+		err := target.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
+		if err != nil {
+			t.Fatalf("failed to push test content to src: %d: %v", i, err)
+		}
+	}
+
+	manifestDesc := descs[3]
+	ref := "foobar"
+	err := target.Tag(ctx, manifestDesc, ref)
+	if err != nil {
+		t.Fatal("fail to tag manifestDesc node", err)
+	}
+
+	// test Resolve with TargetPlatform
+	resolveOptions := oras.DefaultResolveOptions
+	gotDesc, err := oras.Resolve(ctx, target, ref, resolveOptions)
+
+	if err != nil {
+		t.Fatal("oras.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, manifestDesc) {
+		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
+	}
+}
+
+func TestResolve_WithTargetPlatformOptions(t *testing.T) {
+	target := memory.New()
+	arc_1 := "test-arc-1"
+	os_1 := "test-os-1"
+	variant_1 := "v1"
+	variant_2 := "v2"
+
+	// generate test content
+	var blobs [][]byte
+	var descs []ocispec.Descriptor
+	appendBlob := func(mediaType string, blob []byte) {
+		blobs = append(blobs, blob)
+		descs = append(descs, ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+		})
+	}
+	appendManifest := func(arc, os, variant string, mediaType string, blob []byte) {
+		blobs = append(blobs, blob)
+		descs = append(descs, ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+			Platform: &ocispec.Platform{
+				Architecture: arc,
+				OS:           os,
+				Variant:      variant,
+			},
+		})
+	}
+	generateManifest := func(arc, os, variant string, config ocispec.Descriptor, layers ...ocispec.Descriptor) {
+		manifest := ocispec.Manifest{
+			Config: config,
+			Layers: layers,
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		appendManifest(arc, os, variant, ocispec.MediaTypeImageManifest, manifestJSON)
+	}
+
+	appendBlob(ocispec.MediaTypeImageConfig, []byte(`{"mediaType":"application/vnd.oci.image.config.v1+json",
+"created":"2022-07-29T08:13:55Z",
+"author":"test author",
+"architecture":"test-arc-1",
+"os":"test-os-1",
+"variant":"test-variant"}`)) // Blob 0
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))            // Blob 1
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("bar"))            // Blob 2
+	generateManifest(arc_1, os_1, variant_1, descs[0], descs[1:3]...) // Blob 3
+
+	ctx := context.Background()
+	for i := range blobs {
+		err := target.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
+		if err != nil {
+			t.Fatalf("failed to push test content to src: %d: %v", i, err)
+		}
+	}
+
+	manifestDesc := descs[3]
+	ref := "foobar"
+	err := target.Tag(ctx, manifestDesc, ref)
+	if err != nil {
+		t.Fatal("fail to tag manifestDesc node", err)
+	}
+
+	// test Resolve with TargetPlatform
+	resolveOptions := oras.ResolveOptions{
+		TargetPlatform: &ocispec.Platform{
+			Architecture: arc_1,
+			OS:           os_1,
+		},
+	}
+	gotDesc, err := oras.Resolve(ctx, target, ref, resolveOptions)
+
+	if err != nil {
+		t.Fatal("oras.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, manifestDesc) {
+		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
+	}
+
+	// test Resolve with TargetPlatform but there is no matching node
+	// Should return not found error
+	resolveOptions = oras.ResolveOptions{
+		TargetPlatform: &ocispec.Platform{
+			Architecture: arc_1,
+			OS:           os_1,
+			Variant:      variant_2,
+		},
+	}
+	_, err = oras.Resolve(ctx, target, ref, resolveOptions)
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Fatalf("oras.Resolve() error = %v, wantErr %v", err, errdef.ErrNotFound)
 	}
 }

--- a/copy.go
+++ b/copy.go
@@ -70,12 +70,12 @@ func getPlatformFromConfig(ctx context.Context, src content.Storage, desc ocispe
 	}
 	defer rc.Close()
 
-	var platform *ocispec.Platform
-	if err = json.NewDecoder(rc).Decode(&platform); err != nil {
+	var platform ocispec.Platform
+	if err = json.NewDecoder(rc).Decode(&platform); err != nil && err != io.EOF {
 		return nil, err
 	}
 
-	return platform, nil
+	return &platform, nil
 }
 
 // selectPlatform implements platform filter and returns the descriptor of the
@@ -110,9 +110,6 @@ func selectPlatform(ctx context.Context, src content.Storage, root ocispec.Descr
 		cfgPlatform, err := getPlatformFromConfig(ctx, src, descs[0], configMediaType)
 		if err != nil {
 			return ocispec.Descriptor{}, err
-		}
-		if cfgPlatform == nil {
-			return ocispec.Descriptor{}, fmt.Errorf("%s: missing platform info", descs[0].Digest)
 		}
 
 		if platform.Match(cfgPlatform, p) {

--- a/copy.go
+++ b/copy.go
@@ -88,12 +88,11 @@ func selectPlatform(ctx context.Context, src content.Storage, root ocispec.Descr
 				if err != nil {
 					return ocispec.Descriptor{}, err
 				}
+				defer rc.Close()
 				var currPlatform ocispec.Platform
-				err = json.NewDecoder(rc).Decode(&currPlatform)
-				if err != nil {
+				if err = json.NewDecoder(rc).Decode(&currPlatform); err != nil {
 					return ocispec.Descriptor{}, err
 				}
-				defer rc.Close()
 
 				if platform.Match(&currPlatform, p) {
 					return root, nil

--- a/copy.go
+++ b/copy.go
@@ -62,7 +62,7 @@ func (o *CopyOptions) selectPlatform(ctx context.Context, src content.Storage, r
 	if root.MediaType == docker.MediaTypeManifestList || root.MediaType == ocispec.MediaTypeImageIndex {
 		manifests, err := content.Successors(ctx, src, root)
 		if err != nil {
-			return ocispec.Descriptor{}, errdef.ErrNotFound
+			return ocispec.Descriptor{}, err
 		}
 
 		// platform filter

--- a/copy.go
+++ b/copy.go
@@ -121,10 +121,17 @@ func selectPlatform(ctx context.Context, src content.Storage, root ocispec.Descr
 	}
 }
 
-// WithTargetPlatform adds the check on the platform attributes.
-func (o *CopyOptions) WithTargetPlatform(p *ocispec.Platform) {
-	mapRoot := o.MapRoot
-	o.MapRoot = func(ctx context.Context, src content.Storage, root ocispec.Descriptor) (desc ocispec.Descriptor, err error) {
+// WithTargetPlatform configures opts.MapRoot to select the manifest whose
+// platform matches the given platform. When MapRoot is provided, the platform
+// selection will be applied on the mapped root node.
+// - If the root node is a manifest, it will remain the same if platform
+// matches, otherwise ErrNotFound will be returned.
+// - If the root node is a manifest list, it will be mapped to the first
+// matching manifest if exists, otherwise ErrNotFound will be returned.
+// - Otherwise ErrUnsupported will be returned.
+func (opts *CopyOptions) WithTargetPlatform(p *ocispec.Platform) {
+	mapRoot := opts.MapRoot
+	opts.MapRoot = func(ctx context.Context, src content.Storage, root ocispec.Descriptor) (desc ocispec.Descriptor, err error) {
 		if mapRoot != nil {
 			if root, err = mapRoot(ctx, src, root); err != nil {
 				return ocispec.Descriptor{}, err

--- a/copy_test.go
+++ b/copy_test.go
@@ -661,6 +661,12 @@ func TestCopy_WithOptions(t *testing.T) {
 
 func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 	src := memory.New()
+	arc_1 := "test-arc-1"
+	os_1 := "test-os-1"
+	variant_1 := "v1"
+	arc_2 := "test-arc-2"
+	os_2 := "test-os-2"
+	variant_2 := "v2"
 
 	// generate test content
 	var blobs [][]byte
@@ -714,14 +720,14 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 "architecture":"test-arc-1",
 "os":"test-os-1",
 "variant":"test-variant"}`)) // Blob 0
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))                     // Blob 1
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("bar"))                     // Blob 2
-	generateManifest("test-arc-1", "test-os-1", "v1", descs[0], descs[1:3]...) // Blob 3
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("hello1"))                  // Blob 4
-	generateManifest("test-arc-2", "test-os-2", "v1", descs[0], descs[4])      // Blob 5
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("hello2"))                  // Blob 6
-	generateManifest("test-arc-1", "test-os-1", "v2", descs[0], descs[6])      // Blob 7
-	generateIndex(descs[3], descs[5], descs[7])                                // Blob 8
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))            // Blob 1
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("bar"))            // Blob 2
+	generateManifest(arc_1, os_1, variant_1, descs[0], descs[1:3]...) // Blob 3
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("hello1"))         // Blob 4
+	generateManifest(arc_2, os_2, variant_1, descs[0], descs[4])      // Blob 5
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("hello2"))         // Blob 6
+	generateManifest(arc_1, os_1, variant_2, descs[0], descs[6])      // Blob 7
+	generateIndex(descs[3], descs[5], descs[7])                       // Blob 8
 
 	ctx := context.Background()
 	for i := range blobs {
@@ -742,8 +748,8 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 	dst := memory.New()
 	opts := oras.CopyOptions{}
 	targetPlatform := ocispec.Platform{
-		Architecture: "test-arc-2",
-		OS:           "test-os-2",
+		Architecture: arc_2,
+		OS:           os_2,
 	}
 	opts.WithPlatformFilter(&targetPlatform)
 	wantDesc := descs[5]
@@ -780,8 +786,8 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 	// matching entry.
 	dst = memory.New()
 	targetPlatform = ocispec.Platform{
-		Architecture: "test-arc-1",
-		OS:           "test-os-1",
+		Architecture: arc_1,
+		OS:           os_1,
 	}
 	opts = oras.CopyOptions{}
 	opts.WithPlatformFilter(&targetPlatform)
@@ -828,8 +834,8 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 		},
 	}
 	targetPlatform = ocispec.Platform{
-		Architecture: "test-arc-1",
-		OS:           "test-os-3",
+		Architecture: arc_1,
+		OS:           os_2,
 	}
 	opts.WithPlatformFilter(&targetPlatform)
 
@@ -842,8 +848,8 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 	dst = memory.New()
 	opts = oras.CopyOptions{}
 	targetPlatform = ocispec.Platform{
-		Architecture: "test-arc-1",
-		OS:           "test-os-1",
+		Architecture: arc_1,
+		OS:           os_1,
 	}
 	opts.WithPlatformFilter(&targetPlatform)
 
@@ -887,9 +893,9 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 	dst = memory.New()
 	opts = oras.CopyOptions{}
 	targetPlatform = ocispec.Platform{
-		Architecture: "test-arc-1",
-		OS:           "test-os-1",
-		Variant:      "wrong-variant",
+		Architecture: arc_1,
+		OS:           os_1,
+		Variant:      variant_2,
 	}
 	opts.WithPlatformFilter(&targetPlatform)
 
@@ -903,8 +909,8 @@ func TestCopy_WithPlatformFilterOptions(t *testing.T) {
 	dst = memory.New()
 	opts = oras.CopyOptions{}
 	targetPlatform = ocispec.Platform{
-		Architecture: "test-arc-1",
-		OS:           "test-os-1",
+		Architecture: arc_1,
+		OS:           os_1,
 	}
 	opts.WithPlatformFilter(&targetPlatform)
 

--- a/internal/docker/mediatype.go
+++ b/internal/docker/mediatype.go
@@ -17,6 +17,7 @@ package docker
 
 // docker media types
 const (
+	MediaTypeImage        = "application/vnd.docker.container.image.v1+json"
 	MediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	MediaTypeManifest     = "application/vnd.docker.distribution.manifest.v2+json"
 )

--- a/internal/docker/mediatype.go
+++ b/internal/docker/mediatype.go
@@ -17,7 +17,7 @@ package docker
 
 // docker media types
 const (
-	MediaTypeImage        = "application/vnd.docker.container.image.v1+json"
+	MediaTypeConfig       = "application/vnd.docker.container.image.v1+json"
 	MediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	MediaTypeManifest     = "application/vnd.docker.distribution.manifest.v2+json"
 )

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,67 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// MatchPlatform checks whether the current platform matches the target platform.
+// MatchPlatform will return true if:
+// - Architecture and OS exactly match.
+// - Variant and OSVersion exactly match if target platform provided.
+// - OSFeatures of the target platform are the subsets of the OSFeatures array
+//   of the current platform.
+// Note: Variant, OSVersion and OSFeatures are optional fields, will skip the
+// comparison if the target platform does not provide specfic value.
+func MatchPlatform(curr *ocispec.Platform, target *ocispec.Platform) bool {
+	if curr.Architecture != target.Architecture || curr.OS != target.OS {
+		return false
+	}
+
+	if target.OSVersion != "" && curr.OSVersion != target.OSVersion {
+		return false
+	}
+
+	if target.Variant != "" && curr.Variant != target.Variant {
+		return false
+	}
+
+	if len(target.OSFeatures) != 0 && !isSubset(curr.OSFeatures, target.OSFeatures) {
+		return false
+	}
+
+	return true
+}
+
+// isSubset returns true if all items in target slice are present in current slice
+func isSubset(curr, target []string) bool {
+	if len(curr) < len(target) {
+		return false
+	}
+
+	set := make(map[string]bool)
+	for _, v := range curr {
+		set[v] = true
+	}
+	for _, v := range target {
+		if _, ok := set[v]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -19,15 +19,15 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// MatchPlatform checks whether the current platform matches the target platform.
-// MatchPlatform will return true if all of the following conditions are met.
+// Match checks whether the current platform matches the target platform.
+// Match will return true if all of the following conditions are met.
 // - Architecture and OS exactly match.
 // - Variant and OSVersion exactly match if target platform provided.
-// - OSFeatures of the target platform are the subsets of the OSFeatures array
-//   of the current platform.
-// Note: Variant, OSVersion and OSFeatures are optional fields, will skip the
-// comparison if the target platform does not provide specfic value.
-func MatchPlatform(got *ocispec.Platform, want *ocispec.Platform) bool {
+// - OSFeatures of the target platform are the subsets of the OSFeatures
+//   array of the current platform.
+// Note: Variant, OSVersion and OSFeatures are optional fields, will skip
+// the comparison if the target platform does not provide specfic value.
+func Match(got *ocispec.Platform, want *ocispec.Platform) bool {
 	if got.Architecture != want.Architecture || got.OS != want.OS {
 		return false
 	}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -27,29 +27,29 @@ import (
 //   of the current platform.
 // Note: Variant, OSVersion and OSFeatures are optional fields, will skip the
 // comparison if the target platform does not provide specfic value.
-func MatchPlatform(curr *ocispec.Platform, target *ocispec.Platform) bool {
-	if curr.Architecture != target.Architecture || curr.OS != target.OS {
+func MatchPlatform(got *ocispec.Platform, want *ocispec.Platform) bool {
+	if got.Architecture != want.Architecture || got.OS != want.OS {
 		return false
 	}
 
-	if target.OSVersion != "" && curr.OSVersion != target.OSVersion {
+	if want.OSVersion != "" && got.OSVersion != want.OSVersion {
 		return false
 	}
 
-	if target.Variant != "" && curr.Variant != target.Variant {
+	if want.Variant != "" && got.Variant != want.Variant {
 		return false
 	}
 
-	if len(target.OSFeatures) != 0 && !isSubset(target.OSFeatures, curr.OSFeatures) {
+	if len(want.OSFeatures) != 0 && !isSubset(want.OSFeatures, got.OSFeatures) {
 		return false
 	}
 
 	return true
 }
 
-// isSubset returns true if all items in slice A are present in slice B
+// isSubset returns true if all items in slice A are present in slice B.
 func isSubset(a, b []string) bool {
-	set := make(map[string]bool)
+	set := make(map[string]bool, len(b))
 	for _, v := range b {
 		set[v] = true
 	}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -20,7 +20,7 @@ import (
 )
 
 // MatchPlatform checks whether the current platform matches the target platform.
-// MatchPlatform will return true if:
+// MatchPlatform will return true if all of the following conditions are met.
 // - Architecture and OS exactly match.
 // - Variant and OSVersion exactly match if target platform provided.
 // - OSFeatures of the target platform are the subsets of the OSFeatures array
@@ -40,24 +40,20 @@ func MatchPlatform(curr *ocispec.Platform, target *ocispec.Platform) bool {
 		return false
 	}
 
-	if len(target.OSFeatures) != 0 && !isSubset(curr.OSFeatures, target.OSFeatures) {
+	if len(target.OSFeatures) != 0 && !isSubset(target.OSFeatures, curr.OSFeatures) {
 		return false
 	}
 
 	return true
 }
 
-// isSubset returns true if all items in target slice are present in current slice
-func isSubset(curr, target []string) bool {
-	if len(curr) < len(target) {
-		return false
-	}
-
+// isSubset returns true if all items in slice A are present in slice B
+func isSubset(a, b []string) bool {
 	set := make(map[string]bool)
-	for _, v := range curr {
+	for _, v := range b {
 		set[v] = true
 	}
-	for _, v := range target {
+	for _, v := range a {
 		if _, ok := set[v]; !ok {
 			return false
 		}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestMatch(t *testing.T) {
 	tests := []struct {
-		curr   ocispec.Platform
-		target ocispec.Platform
-		want   bool
+		got       ocispec.Platform
+		want      ocispec.Platform
+		isMatched bool
 	}{{
 		ocispec.Platform{Architecture: "amd64", OS: "linux"},
 		ocispec.Platform{Architecture: "amd64", OS: "linux"},
@@ -90,12 +90,12 @@ func TestMatch(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		currPlatforJSON, _ := json.Marshal(tt.curr)
-		targetPlatforJSON, _ := json.Marshal(tt.target)
-		name := string(currPlatforJSON) + string(targetPlatforJSON)
+		gotPlatformJSON, _ := json.Marshal(tt.got)
+		wantPlatformJSON, _ := json.Marshal(tt.want)
+		name := string(gotPlatformJSON) + string(wantPlatformJSON)
 		t.Run(name, func(t *testing.T) {
-			if got := Match(&tt.curr, &tt.target); got != tt.want {
-				t.Errorf("MatchPlatform() = %v, want %v", got, tt.want)
+			if actual := Match(&tt.got, &tt.want); actual != tt.isMatched {
+				t.Errorf("Match() = %v, want %v", actual, tt.isMatched)
 			}
 		})
 	}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"encoding/json"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestMatchPlatform(t *testing.T) {
+	tests := []struct {
+		curr   ocispec.Platform
+		target ocispec.Platform
+		want   bool
+	}{{
+		ocispec.Platform{Architecture: "amd64", OS: "linux"},
+		ocispec.Platform{Architecture: "amd64", OS: "linux"},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "amd64", OS: "linux"},
+		ocispec.Platform{Architecture: "amd64", OS: "LINUX"},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "amd64", OS: "linux"},
+		ocispec.Platform{Architecture: "arm64", OS: "linux"},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux"},
+		ocispec.Platform{Architecture: "arm", OS: "linux", Variant: "v7"},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux", Variant: "v7"},
+		ocispec.Platform{Architecture: "arm", OS: "linux"},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux", Variant: "v7"},
+		ocispec.Platform{Architecture: "arm", OS: "linux", Variant: "v7"},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.20348.768"},
+		ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.20348.700"},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "amd64", OS: "windows"},
+		ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.20348.768"},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.20348.768"},
+		ocispec.Platform{Architecture: "amd64", OS: "windows"},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.20348.768"},
+		ocispec.Platform{Architecture: "amd64", OS: "windows", OSVersion: "10.0.20348.768"},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a", "d"}},
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a", "c"}},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux"},
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a"}},
+		false,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a"}},
+		ocispec.Platform{Architecture: "arm", OS: "linux"},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a", "b"}},
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a", "b"}},
+		true,
+	}, {
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"a", "d", "c", "b"}},
+		ocispec.Platform{Architecture: "arm", OS: "linux", OSFeatures: []string{"d", "c", "a", "b"}},
+		true,
+	}}
+
+	for _, tt := range tests {
+		currPlatforJSON, _ := json.Marshal(tt.curr)
+		targetPlatforJSON, _ := json.Marshal(tt.target)
+		name := string(currPlatforJSON) + string(targetPlatforJSON)
+		t.Run(name, func(t *testing.T) {
+			if got := MatchPlatform(&tt.curr, &tt.target); got != tt.want {
+				t.Errorf("MatchPlatform() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -22,7 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func TestMatchPlatform(t *testing.T) {
+func TestMatch(t *testing.T) {
 	tests := []struct {
 		curr   ocispec.Platform
 		target ocispec.Platform
@@ -94,7 +94,7 @@ func TestMatchPlatform(t *testing.T) {
 		targetPlatforJSON, _ := json.Marshal(tt.target)
 		name := string(currPlatforJSON) + string(targetPlatforJSON)
 		t.Run(name, func(t *testing.T) {
-			if got := MatchPlatform(&tt.curr, &tt.target); got != tt.want {
+			if got := Match(&tt.curr, &tt.target); got != tt.want {
 				t.Errorf("MatchPlatform() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Support platform selection on Copy by adding `AddPlatformFilter` func that configure the `MapRoot` option for clients.

Platform property ref: [OCI Image Index Specification](https://github.com/opencontainers/image-spec/blob/main/image-index.md#oci-image-index-specification)

The given platform matches the target platform if all of the below conditions are met:
- Architecture and OS exactly match.
- Variant and OSVersion exactly match if target platform provided.
- OSFeatures of the target platform are the subsets of the OSFeatures array of the given platform.
- Features property is reserved for future versions of the specification, will skip this for now. ref: [descriptor.go](https://github.com/opencontainers/image-spec/blob/main/specs-go/v1/descriptor.go#L50)

Note: Variant, OSVersion, OSFeatures and Features are optional fields, will skip the comparison if the target platform does not provide specfic value.

If multiple manifests match a client or runtime's requirements, the first matching entry will be returned.

Resolves #210 

Signed-off-by: REDMOND\zoeyli <zoeyli@microsoft.com>