### PR TITLE
build: update support window to Go 1.18, 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17, 1.18]
+        go-version: [1.18, 1.19]
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: [1.17, 1.18]
+        go-version: [1.18, 1.19]
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module oras.land/oras-go/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86


### PR DESCRIPTION
Update support window to Go 1.18, 1.19.
Resolves #261 

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>