### PR TITLE
fix: Revert "fix: remove `+json` encoding from the default config media type"

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -33,7 +33,7 @@ import (
 
 // MediaTypeUnknownConfig is the default mediaType used when no
 // config media type is specified.
-const MediaTypeUnknownConfig = "application/vnd.unknown.config.v1"
+const MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json"
 
 var (
 	// ErrMissingArtifactType is returned by PackArtifact() when no artifact


### PR DESCRIPTION
Reverts oras-project/oras-go#288
Related to #294 

Signed-off-by: Sylvia Lei <lixlei@microsoft.com>