### PR TITLE
feat!: Support specifying `MaxMetadataBytes` option for `oras.Resolve` and `oras.Copy`

### DIFF
--- a/content.go
+++ b/content.go
@@ -56,9 +56,7 @@ func Tag(ctx context.Context, target Target, src, dst string) error {
 }
 
 // DefaultResolveOptions provides the default ResolveOptions.
-var DefaultResolveOptions = ResolveOptions{
-	MaxMetadataBytes: defaultResolveMaxMetadataBytes,
-}
+var DefaultResolveOptions ResolveOptions
 
 // defaultResolveMaxMetadataBytes is the default value of
 // ResolveOptions.MaxMetadataBytes.
@@ -73,7 +71,7 @@ type ResolveOptions struct {
 
 	// MaxMetadataBytes limits the maximum size of metadata that can be cached
 	// in the memory.
-	// If less than or equal to 0, a default (currently 4MiB) is used.
+	// If less than or equal to 0, a default (currently 4 MiB) is used.
 	MaxMetadataBytes int64
 }
 
@@ -231,30 +229,23 @@ func PushBytes(ctx context.Context, pusher content.Pusher, mediaType string, con
 	return desc, nil
 }
 
-// defaultTagConcurrency is the default value of TagBytesOptions.Concurrency.
+// defaultTagConcurrency is the default value of TagBytesNOptions.Concurrency.
 const defaultTagConcurrency = 5 // This value is consistent with dockerd
 
-// DefaultTagBytesOptions provides the default TagBytesOptions.
-var DefaultTagBytesOptions TagBytesOptions
+// DefaultTagBytesNOptions provides the default TagBytesNOptions.
+var DefaultTagBytesNOptions TagBytesNOptions
 
-// TagBytesOptions contains parameters for oras.TagBytes.
-type TagBytesOptions struct {
+// TagBytesNOptions contains parameters for oras.TagBytesN.
+type TagBytesNOptions struct {
 	// Concurrency limits the maximum number of concurrent tag tasks.
 	// If less than or equal to 0, a default (currently 5) is used.
 	Concurrency int64
 }
 
-// TagBytes describes the contentBytes using the given mediaType, pushes it,
-// and tag it with the given reference.
-// If mediaType is not specified, "application/octet-stream" is used.
-func TagBytes(ctx context.Context, target Target, mediaType string, contentBytes []byte, reference string) (ocispec.Descriptor, error) {
-	return TagBytesN(ctx, target, mediaType, contentBytes, []string{reference}, DefaultTagBytesOptions)
-}
-
 // TagBytesN describes the contentBytes using the given mediaType, pushes it,
 // and tag it with the given references.
 // If mediaType is not specified, "application/octet-stream" is used.
-func TagBytesN(ctx context.Context, target Target, mediaType string, contentBytes []byte, references []string, opts TagBytesOptions) (ocispec.Descriptor, error) {
+func TagBytesN(ctx context.Context, target Target, mediaType string, contentBytes []byte, references []string, opts TagBytesNOptions) (ocispec.Descriptor, error) {
 	if len(references) == 0 {
 		return PushBytes(ctx, target, mediaType, contentBytes)
 	}
@@ -300,4 +291,11 @@ func TagBytesN(ctx context.Context, target Target, mediaType string, contentByte
 		return ocispec.Descriptor{}, err
 	}
 	return desc, nil
+}
+
+// TagBytes describes the contentBytes using the given mediaType, pushes it,
+// and tag it with the given reference.
+// If mediaType is not specified, "application/octet-stream" is used.
+func TagBytes(ctx context.Context, target Target, mediaType string, contentBytes []byte, reference string) (ocispec.Descriptor, error) {
+	return TagBytesN(ctx, target, mediaType, contentBytes, []string{reference}, DefaultTagBytesNOptions)
 }

--- a/content_test.go
+++ b/content_test.go
@@ -282,9 +282,15 @@ func TestResolve_Memory(t *testing.T) {
 	}
 
 	// test Resolve with MaxMetadataBytes = 1
-	_, err = oras.Resolve(ctx, target, ref, oras.ResolveOptions{MaxMetadataBytes: 1})
-	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
-		t.Fatalf("oras.Resolve() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
+	resolveOptions = oras.ResolveOptions{
+		MaxMetadataBytes: 1,
+	}
+	gotDesc, err = oras.Resolve(ctx, target, ref, resolveOptions)
+	if err != nil {
+		t.Fatal("oras.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, manifestDesc) {
+		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
 	}
 
 	// test Resolve with TargetPlatform
@@ -310,9 +316,12 @@ func TestResolve_Memory(t *testing.T) {
 		},
 		MaxMetadataBytes: 1,
 	}
-	_, err = oras.Resolve(ctx, target, ref, resolveOptions)
-	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
-		t.Fatalf("oras.Resolve() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
+	gotDesc, err = oras.Resolve(ctx, target, ref, resolveOptions)
+	if err != nil {
+		t.Fatal("oras.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, manifestDesc) {
+		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
 	}
 
 	// test Resolve with TargetPlatform but there is no matching node
@@ -407,6 +416,19 @@ func TestResolve_Repository(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotDesc, manifestDesc) {
 		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
+	}
+
+	// test Resolve with TargetPlatform and MaxMetadataBytes = 1
+	resolveOptions = oras.ResolveOptions{
+		TargetPlatform: &ocispec.Platform{
+			Architecture: arc_1,
+			OS:           os_1,
+		},
+		MaxMetadataBytes: 1,
+	}
+	_, err = oras.Resolve(ctx, repo, src, resolveOptions)
+	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
+		t.Fatalf("oras.Resolve() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
 	}
 
 	// test Resolve with TargetPlatform but there is no matching node

--- a/content_test.go
+++ b/content_test.go
@@ -1515,7 +1515,7 @@ func TestTagBytesN_Memory(t *testing.T) {
 
 	ctx := context.Background()
 	// test TagBytes with no reference
-	gotDesc, err := oras.TagBytesN(ctx, s, mediaType, content, nil, oras.DefaultTagBytesOptions)
+	gotDesc, err := oras.TagBytesN(ctx, s, mediaType, content, nil, oras.DefaultTagBytesNOptions)
 	if err != nil {
 		t.Fatal("oras.TagBytes() error =", err)
 	}
@@ -1540,7 +1540,7 @@ func TestTagBytesN_Memory(t *testing.T) {
 
 	// test TagBytes with multiple references
 	refs := []string{"foo", "bar", "baz"}
-	gotDesc, err = oras.TagBytesN(ctx, s, mediaType, content, refs, oras.DefaultTagBytesOptions)
+	gotDesc, err = oras.TagBytesN(ctx, s, mediaType, content, refs, oras.DefaultTagBytesNOptions)
 	if err != nil {
 		t.Fatal("oras.TagBytes() error =", err)
 	}
@@ -1573,7 +1573,7 @@ func TestTagBytesN_Memory(t *testing.T) {
 	}
 
 	// test TagBytes with empty media type and multiple references
-	gotDesc, err = oras.TagBytesN(ctx, s, "", content, refs, oras.DefaultTagBytesOptions)
+	gotDesc, err = oras.TagBytesN(ctx, s, "", content, refs, oras.DefaultTagBytesNOptions)
 	if err != nil {
 		t.Fatal("oras.TagBytes() error =", err)
 	}
@@ -1606,7 +1606,7 @@ func TestTagBytesN_Memory(t *testing.T) {
 	}
 
 	// test TagBytes with empty content and multiple references
-	gotDesc, err = oras.TagBytesN(ctx, s, mediaType, nil, refs, oras.DefaultTagBytesOptions)
+	gotDesc, err = oras.TagBytesN(ctx, s, mediaType, nil, refs, oras.DefaultTagBytesNOptions)
 	if err != nil {
 		t.Fatal("oras.TagBytes() error =", err)
 	}
@@ -1700,7 +1700,7 @@ func TestTagBytesN_Repository(t *testing.T) {
 	ctx := context.Background()
 
 	// test TagBytes with no reference
-	gotDesc, err := oras.TagBytesN(ctx, repo, indexMediaType, index, nil, oras.DefaultTagBytesOptions)
+	gotDesc, err := oras.TagBytesN(ctx, repo, indexMediaType, index, nil, oras.DefaultTagBytesNOptions)
 	if err != nil {
 		t.Fatal("oras.TagBytes() error =", err)
 	}
@@ -1713,7 +1713,7 @@ func TestTagBytesN_Repository(t *testing.T) {
 
 	// test TagBytes with multiple references
 	gotIndex = nil
-	gotDesc, err = oras.TagBytesN(ctx, repo, indexMediaType, index, refs, oras.DefaultTagBytesOptions)
+	gotDesc, err = oras.TagBytesN(ctx, repo, indexMediaType, index, refs, oras.DefaultTagBytesNOptions)
 	if err != nil {
 		t.Fatal("oras.TagBytes() error =", err)
 	}

--- a/content_test.go
+++ b/content_test.go
@@ -193,65 +193,7 @@ func TestTag_Repository(t *testing.T) {
 	}
 }
 
-func TestResolve_WithOptions(t *testing.T) {
-	target := memory.New()
-
-	// generate test content
-	var blobs [][]byte
-	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, blob []byte) {
-		blobs = append(blobs, blob)
-		descs = append(descs, ocispec.Descriptor{
-			MediaType: mediaType,
-			Digest:    digest.FromBytes(blob),
-			Size:      int64(len(blob)),
-		})
-	}
-	generateManifest := func(config ocispec.Descriptor, layers ...ocispec.Descriptor) {
-		manifest := ocispec.Manifest{
-			Config: config,
-			Layers: layers,
-		}
-		manifestJSON, err := json.Marshal(manifest)
-		if err != nil {
-			t.Fatal(err)
-		}
-		appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
-	}
-
-	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))     // Blob 1
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("bar"))     // Blob 2
-	generateManifest(descs[0], descs[1:3]...)                  // Blob 3
-
-	ctx := context.Background()
-	for i := range blobs {
-		err := target.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
-		if err != nil {
-			t.Fatalf("failed to push test content to src: %d: %v", i, err)
-		}
-	}
-
-	manifestDesc := descs[3]
-	ref := "foobar"
-	err := target.Tag(ctx, manifestDesc, ref)
-	if err != nil {
-		t.Fatal("fail to tag manifestDesc node", err)
-	}
-
-	// test Resolve with default resolve options
-	resolveOptions := oras.DefaultResolveOptions
-	gotDesc, err := oras.Resolve(ctx, target, ref, resolveOptions)
-
-	if err != nil {
-		t.Fatal("oras.Resolve() error =", err)
-	}
-	if !reflect.DeepEqual(gotDesc, manifestDesc) {
-		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
-	}
-}
-
-func TestResolve_Memory_WithTargetPlatformOptions(t *testing.T) {
+func TestResolve_Memory(t *testing.T) {
 	target := memory.New()
 	arc_1 := "test-arc-1"
 	os_1 := "test-os-1"
@@ -319,13 +261,8 @@ func TestResolve_Memory_WithTargetPlatformOptions(t *testing.T) {
 		t.Fatal("fail to tag manifestDesc node", err)
 	}
 
-	// test Resolve with TargetPlatform
-	resolveOptions := oras.ResolveOptions{
-		TargetPlatform: &ocispec.Platform{
-			Architecture: arc_1,
-			OS:           os_1,
-		},
-	}
+	// test Resolve with default resolve options
+	resolveOptions := oras.DefaultResolveOptions
 	gotDesc, err := oras.Resolve(ctx, target, ref, resolveOptions)
 
 	if err != nil {
@@ -333,6 +270,49 @@ func TestResolve_Memory_WithTargetPlatformOptions(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotDesc, manifestDesc) {
 		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
+	}
+
+	// test Resolve with empty resolve options
+	gotDesc, err = oras.Resolve(ctx, target, ref, oras.ResolveOptions{})
+	if err != nil {
+		t.Fatal("oras.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, manifestDesc) {
+		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
+	}
+
+	// test Resolve with MaxMetadataBytes = 1
+	_, err = oras.Resolve(ctx, target, ref, oras.ResolveOptions{MaxMetadataBytes: 1})
+	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
+		t.Fatalf("oras.Resolve() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
+	}
+
+	// test Resolve with TargetPlatform
+	resolveOptions = oras.ResolveOptions{
+		TargetPlatform: &ocispec.Platform{
+			Architecture: arc_1,
+			OS:           os_1,
+		},
+	}
+	gotDesc, err = oras.Resolve(ctx, target, ref, resolveOptions)
+	if err != nil {
+		t.Fatal("oras.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, manifestDesc) {
+		t.Errorf("oras.Resolve() = %v, want %v", gotDesc, manifestDesc)
+	}
+
+	// test Resolve with TargetPlatform and MaxMetadataBytes = 1
+	resolveOptions = oras.ResolveOptions{
+		TargetPlatform: &ocispec.Platform{
+			Architecture: arc_1,
+			OS:           os_1,
+		},
+		MaxMetadataBytes: 1,
+	}
+	_, err = oras.Resolve(ctx, target, ref, resolveOptions)
+	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
+		t.Fatalf("oras.Resolve() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
 	}
 
 	// test Resolve with TargetPlatform but there is no matching node
@@ -351,7 +331,7 @@ func TestResolve_Memory_WithTargetPlatformOptions(t *testing.T) {
 	}
 }
 
-func TestResolve_Repository_WithTargetPlatformOptions(t *testing.T) {
+func TestResolve_Repository(t *testing.T) {
 	arc_1 := "test-arc-1"
 	arc_2 := "test-arc-2"
 	os_1 := "test-os-1"
@@ -1490,7 +1470,7 @@ func TestPushBytes_Repository(t *testing.T) {
 	}
 }
 
-func TestTagBytes_Memory(t *testing.T) {
+func TestTagBytesN_Memory(t *testing.T) {
 	s := memory.New()
 
 	content := []byte("hello world")
@@ -1637,7 +1617,7 @@ func TestTagBytes_Memory(t *testing.T) {
 	}
 }
 
-func TestTagBytes_Repository(t *testing.T) {
+func TestTagBytesN_Repository(t *testing.T) {
 	index := []byte(`{"manifests":[]}`)
 	indexMediaType := ocispec.MediaTypeImageIndex
 	indexDesc := ocispec.Descriptor{

--- a/copy.go
+++ b/copy.go
@@ -75,13 +75,17 @@ func (opts *CopyOptions) WithTargetPlatform(p *ocispec.Platform) {
 	}
 }
 
+// defaultCopyMaxMetadataBytes is the default value of
+// CopyGraphOptions.MaxMetadataBytes.
+const defaultCopyMaxMetadataBytes int64 = 4 * 1024 * 1024 // 4 MiB
+
 // CopyGraphOptions contains parameters for oras.CopyGraph.
 type CopyGraphOptions struct {
 	// Concurrency limits the maximum number of concurrent copy tasks.
 	// If less than or equal to 0, a default (currently 3) is used.
 	Concurrency int64
 	// MaxMetadataBytes limits the maximum size of the metadata that can be
-	// loaded into memory.
+	// cached in the memory.
 	// If less than or equal to 0, a default (currently 4 MiB) is used.
 	MaxMetadataBytes int64
 	// PreCopy handles the current descriptor before copying it.
@@ -117,7 +121,10 @@ func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, ds
 	}
 
 	// use caching proxy on non-leaf nodes
-	proxy := cas.NewProxy(src, cas.NewMemory())
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultCopyMaxMetadataBytes
+	}
+	proxy := cas.NewProxyWithLimit(src, cas.NewMemory(), opts.MaxMetadataBytes)
 	root, err := resolveRoot(ctx, src, srcRef, proxy)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -147,7 +154,10 @@ func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, ds
 // the destination CAS.
 func CopyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, root ocispec.Descriptor, opts CopyGraphOptions) error {
 	// use caching proxy on non-leaf nodes
-	proxy := cas.NewProxy(src, cas.NewMemory())
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultCopyMaxMetadataBytes
+	}
+	proxy := cas.NewProxyWithLimit(src, cas.NewMemory(), opts.MaxMetadataBytes)
 	return copyGraph(ctx, src, dst, proxy, root, opts)
 }
 

--- a/copy.go
+++ b/copy.go
@@ -80,6 +80,10 @@ type CopyGraphOptions struct {
 	// Concurrency limits the maximum number of concurrent copy tasks.
 	// If less than or equal to 0, a default (currently 3) is used.
 	Concurrency int64
+	// MaxMetadataBytes limits the maximum size of the metadata that can be
+	// loaded into memory.
+	// If less than or equal to 0, a default (currently 4 MiB) is used.
+	MaxMetadataBytes int64
 	// PreCopy handles the current descriptor before copying it.
 	PreCopy func(ctx context.Context, desc ocispec.Descriptor) error
 	// PostCopy handles the current descriptor after copying it.

--- a/copy_test.go
+++ b/copy_test.go
@@ -659,6 +659,17 @@ func TestCopy_WithOptions(t *testing.T) {
 	if !errors.Is(err, errdef.ErrNotFound) {
 		t.Fatalf("Copy() error = %v, wantErr %v", err, errdef.ErrNotFound)
 	}
+
+	// test copy with MaxMetadataBytes = 1
+	dst = memory.New()
+	opts = oras.CopyOptions{
+		CopyGraphOptions: oras.CopyGraphOptions{
+			MaxMetadataBytes: 1,
+		},
+	}
+	if _, err := oras.Copy(ctx, src, ref, dst, "", opts); !errors.Is(err, errdef.ErrSizeExceedsLimit) {
+		t.Fatalf("CopyGraph() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
+	}
 }
 
 func TestCopy_WithTargetPlatformOptions(t *testing.T) {
@@ -1363,5 +1374,15 @@ func TestCopyGraph_WithOptions(t *testing.T) {
 	}
 	if got, want := skippedCount, int64(1); got != want {
 		t.Errorf("count(OnCopySkipped()) = %v, want %v", got, want)
+	}
+
+	// test CopyGraph with MaxMetadataBytes = 1
+	root = descs[6]
+	dst = cas.NewMemory()
+	opts = oras.CopyGraphOptions{
+		MaxMetadataBytes: 1,
+	}
+	if err := oras.CopyGraph(ctx, src, dst, root, opts); !errors.Is(err, errdef.ErrSizeExceedsLimit) {
+		t.Fatalf("CopyGraph() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
 	}
 }

--- a/internal/cas/proxy.go
+++ b/internal/cas/proxy.go
@@ -76,6 +76,9 @@ func (p *Proxy) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCl
 	go func() {
 		defer wg.Done()
 		pushErr = p.Cache.Push(ctx, target, pr)
+		if pushErr != nil {
+			pr.CloseWithError(pushErr)
+		}
 	}()
 	closer := ioutil.CloserFunc(func() error {
 		rcErr := rc.Close()

--- a/internal/cas/proxy.go
+++ b/internal/cas/proxy.go
@@ -44,6 +44,16 @@ func NewProxy(base content.ReadOnlyStorage, cache content.Storage) *Proxy {
 	}
 }
 
+// NewProxyWithLimit creates a proxy for the `base` storage, using the `cache`
+// storage with a push size limit as the cache.
+func NewProxyWithLimit(base content.ReadOnlyStorage, cache content.Storage, pushLimit int64) *Proxy {
+	limitedCache := content.LimitStorage(cache, pushLimit)
+	return &Proxy{
+		ReadOnlyStorage: base,
+		Cache:           limitedCache,
+	}
+}
+
 // Fetch fetches the content identified by the descriptor.
 func (p *Proxy) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
 	if p.StopCaching {

--- a/internal/cas/proxy_test.go
+++ b/internal/cas/proxy_test.go
@@ -19,11 +19,13 @@ import (
 	"bytes"
 	"context"
 	_ "crypto/sha256"
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
 )
 
 func TestProxyCache(t *testing.T) {
@@ -264,5 +266,107 @@ func TestProxy_StopCaching(t *testing.T) {
 
 	if exists {
 		t.Errorf("Proxy.Cache.Exists()() = %v, want %v", exists, false)
+	}
+}
+
+func TestProxyWithLimit_WithinLimit(t *testing.T) {
+	content := []byte("hello world")
+	desc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+	}
+
+	ctx := context.Background()
+	base := NewMemory()
+	err := base.Push(ctx, desc, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal("Memory.Push() error =", err)
+	}
+	s := NewProxyWithLimit(base, NewMemory(), 4*1024*1024)
+
+	// first fetch
+	exists, err := s.Exists(ctx, desc)
+	if err != nil {
+		t.Fatal("Proxy.Exists() error =", err)
+	}
+	if !exists {
+		t.Errorf("Proxy.Exists() = %v, want %v", exists, true)
+	}
+	rc, err := s.Fetch(ctx, desc)
+	if err != nil {
+		t.Fatal("Proxy.Fetch() error =", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Proxy.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Proxy.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Proxy.Fetch() = %v, want %v", got, content)
+	}
+
+	// repeated fetch should not touch base CAS
+	// nil base will generate panic if the base CAS is touched
+	s.ReadOnlyStorage = nil
+
+	exists, err = s.Exists(ctx, desc)
+	if err != nil {
+		t.Fatal("Proxy.Exists() error =", err)
+	}
+	if !exists {
+		t.Errorf("Proxy.Exists() = %v, want %v", exists, true)
+	}
+	rc, err = s.Fetch(ctx, desc)
+	if err != nil {
+		t.Fatal("Proxy.Fetch() error =", err)
+	}
+	got, err = io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Proxy.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Proxy.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("Proxy.Fetch() = %v, want %v", got, content)
+	}
+}
+
+func TestProxyWithLimit_ExceedsLimit(t *testing.T) {
+	content := []byte("hello world")
+	desc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(content),
+		Size:      int64(len(content)),
+	}
+
+	ctx := context.Background()
+	base := NewMemory()
+	err := base.Push(ctx, desc, bytes.NewReader(content))
+	if err != nil {
+		t.Fatal("Memory.Push() error =", err)
+	}
+	s := NewProxyWithLimit(base, NewMemory(), 1)
+
+	// test fetch
+	exists, err := s.Exists(ctx, desc)
+	if err != nil {
+		t.Fatal("Proxy.Exists() error =", err)
+	}
+	if !exists {
+		t.Errorf("Proxy.Exists() = %v, want %v", exists, true)
+	}
+	rc, err := s.Fetch(ctx, desc)
+	if err != nil {
+		t.Fatal("Proxy.Fetch() error =", err)
+	}
+	_, err = io.ReadAll(rc)
+	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
+		t.Fatalf("Proxy.Fetch().Read() error = %v, wantErr %v", err, errdef.ErrSizeExceedsLimit)
 	}
 }


### PR DESCRIPTION
Resolves #291 
Fixes #298
BREAKING CHANGE: Rename `oras.TagBytesOptions` to `oras.TagBytesNOptions`

Signed-off-by: Sylvia Lei <lixlei@microsoft.com>