### PR TITLE
fix: Scrutinize references for digests posing as tags

### DIFF
--- a/registry/reference_test.go
+++ b/registry/reference_test.go
@@ -110,6 +110,10 @@ func TestParseReferenceUglies(t *testing.T) {
 			name: "invalid port",
 			raw:  "localhost:v1/hello-world",
 		},
+		{
+			name: "digest posing as tag",
+			raw:  "localhost:5000/hello:sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This change prevents a token sneaking in as though it was a *tag*, then later getting validated as a *digest*.  I have not added more tests to this but that part should be easy.

Also want to find out if we can invalidate `Valid Form B`, since it's ambiguous and seems unnecessary.  That may break clients that are today using that ambiguous form (ambiguous because it has both a tag and a digest, in which case the tag is ignored).

Resolves #271.