### PR TITLE
refactor!: Migrate `artifactspec.Descriptor` to `ocispec.Descriptor`

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -60,7 +60,7 @@ var (
 		MediaType: artifactspec.MediaTypeArtifactManifest,
 		Digest:    digest.FromBytes(exampleSignatureManifest),
 		Size:      int64(len(exampleSignatureManifest))}
-	exampleSignatureManifestDescriptorArtifactspec = artifactspec.Descriptor{
+	exampleSignatureManifestDescriptorArtifactspec = ocispec.Descriptor{
 		MediaType: exampleSignatureManifestDescriptor.MediaType,
 		Digest:    exampleSignatureManifestDescriptor.Digest,
 		Size:      exampleSignatureManifestDescriptor.Size}
@@ -143,14 +143,14 @@ func TestMain(m *testing.M) {
 		case strings.Contains(p, "/artifacts/referrers"):
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
 			q := r.URL.Query()
-			var referrers []artifactspec.Descriptor
+			var referrers []ocispec.Descriptor
 			if q.Get("digest") == exampleManifestDescriptor.Digest.String() {
-				referrers = []artifactspec.Descriptor{exampleSignatureManifestDescriptorArtifactspec}
+				referrers = []ocispec.Descriptor{exampleSignatureManifestDescriptorArtifactspec}
 			} else if q.Get("digest") == exampleSignatureManifestDescriptor.Digest.String() {
-				referrers = []artifactspec.Descriptor{}
+				referrers = []ocispec.Descriptor{}
 			}
 			result := struct {
-				Referrers []artifactspec.Descriptor `json:"referrers"`
+				Referrers []ocispec.Descriptor `json:"referrers"`
 			}{
 				Referrers: referrers,
 			}

--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -282,11 +282,11 @@ func (opts *ExtendedCopyGraphOptions) FilterArtifactType(regex *regexp.Regexp) {
 // findReferrersAndFilter filters the predecessors with Referrers.
 func findReferrersAndFilter(rf registry.ReferrerFinder, ctx context.Context, desc ocispec.Descriptor, regex *regexp.Regexp) ([]ocispec.Descriptor, error) {
 	var predecessors []ocispec.Descriptor
-	if err := rf.Referrers(ctx, desc, "", func(referrers []artifactspec.Descriptor) error {
+	if err := rf.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
 		// for each page of the results, do the following:
 		for _, referrer := range referrers {
 			if regex.MatchString(referrer.ArtifactType) {
-				predecessors = append(predecessors, descriptor.ArtifactToOCI(referrer))
+				predecessors = append(predecessors, referrer)
 			}
 		}
 		return nil

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -968,7 +968,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	var referrerSet []artifactspec.Descriptor
+	var referrerSet []ocispec.Descriptor
 	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
@@ -989,7 +989,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
 	}
 	pushReferrers := func(desc ocispec.Descriptor, artifactType string) {
-		referrerSet = append(referrerSet, artifactspec.Descriptor{
+		referrerSet = append(referrerSet, ocispec.Descriptor{
 			MediaType:    desc.MediaType,
 			ArtifactType: artifactType,
 			Digest:       desc.Digest,
@@ -1046,12 +1046,12 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 			w.Write(blobs[5])
 		case strings.Contains(p, "referrers"):
 			q := r.URL.Query()
-			var referrers []artifactspec.Descriptor
+			var referrers []ocispec.Descriptor
 			if q.Get("digest") == descs[0].Digest.String() {
 				referrers = referrerSet
 			}
 			result := struct {
-				Referrers []artifactspec.Descriptor `json:"referrers"`
+				Referrers []ocispec.Descriptor `json:"referrers"`
 			}{
 				Referrers: referrers,
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.2
+	github.com/opencontainers/image-spec v1.0.3-0.20220915173658-a7ac485f4c80
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab47
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
-github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.3-0.20220915173658-a7ac485f4c80 h1:4r7VhO7fgr2+uiuYjVip7TqKsJPVDTLmxxSNS9APJfU=
+github.com/opencontainers/image-spec v1.0.3-0.20220915173658-a7ac485f4c80/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2 h1:9SMCNSxkJEHqWGDiMCuy6TXHgvjgwXGdXZZGXLKQvVE=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -47,15 +47,6 @@ func FromOCI(desc ocispec.Descriptor) Descriptor {
 	}
 }
 
-// FromArtifact shrinks the artifact descriptor to the minimum.
-func FromArtifact(desc artifactspec.Descriptor) Descriptor {
-	return Descriptor{
-		MediaType: desc.MediaType,
-		Digest:    desc.Digest,
-		Size:      desc.Size,
-	}
-}
-
 // ArtifactToOCI converts artifact descriptor to OCI descriptor.
 func ArtifactToOCI(desc artifactspec.Descriptor) ocispec.Descriptor {
 	return ocispec.Descriptor{

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -60,7 +60,7 @@ var (
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Subject:      &exampleManifestDescriptor})
-	exampleSignatureManifestDescriptor = artifactspec.Descriptor{
+	exampleSignatureManifestDescriptor = ocispec.Descriptor{
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Digest:       digest.FromBytes(exampleSignatureManifest),
@@ -69,12 +69,12 @@ var (
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Subject:      &exampleManifestDescriptor})
-	exampleSBoMManifestDescriptor = artifactspec.Descriptor{
+	exampleSBoMManifestDescriptor = ocispec.Descriptor{
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Digest:       digest.FromBytes(exampleSBoMManifest),
 		Size:         int64(len(exampleSBoMManifest))}
-	exampleReferrerDescriptors = [][]artifactspec.Descriptor{
+	exampleReferrerDescriptors = [][]ocispec.Descriptor{
 		{exampleSBoMManifestDescriptor},      // page 0
 		{exampleSignatureManifestDescriptor}, // page 1
 	}
@@ -88,7 +88,7 @@ var (
 		ArtifactType: "example/manifest",
 		Blobs:        []artifactspec.Descriptor{blobDescriptor},
 		Subject:      &exampleManifestDescriptor})
-	exampleManifestWithBlobsDescriptor = artifactspec.Descriptor{
+	exampleManifestWithBlobsDescriptor = ocispec.Descriptor{
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
 		Digest:       digest.FromBytes(exampleManifestWithBlobs),
@@ -157,7 +157,7 @@ func TestMain(m *testing.M) {
 			w.Write([]byte(blobContent))
 		case p == fmt.Sprintf("/v2/%s/_oras/artifacts/referrers", exampleRepositoryName):
 			q := r.URL.Query()
-			var referrers []artifactspec.Descriptor
+			var referrers []ocispec.Descriptor
 			switch q.Get("test") {
 			case "page1":
 				referrers = exampleReferrerDescriptors[1]
@@ -168,7 +168,7 @@ func TestMain(m *testing.M) {
 				w.Header().Set("Link", fmt.Sprintf(`<%s?n=1&test=page1>; rel="next"`, p))
 			}
 			result := struct {
-				Referrers []artifactspec.Descriptor `json:"referrers"`
+				Referrers []ocispec.Descriptor `json:"referrers"`
 			}{
 				Referrers: referrers,
 			}

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -441,7 +441,7 @@ func ExampleRepository_Fetch_artifactReferenceManifest() {
 		panic(err)
 	}
 	// find its referrers by calling Referrers
-	if err := repo.Referrers(ctx, descriptor, "", func(referrers []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, descriptor, "", func(referrers []ocispec.Descriptor) error {
 		// for each page of the results, do the following:
 		for _, referrer := range referrers {
 			// for each item in this page, pull the manifest and verify its content

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -37,7 +37,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
-	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/interfaces"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -867,7 +866,7 @@ func TestRepository_Predecessors(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -921,7 +920,7 @@ func TestRepository_Predecessors(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -938,7 +937,7 @@ func TestRepository_Predecessors(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -967,7 +966,7 @@ func TestRepository_Predecessors(t *testing.T) {
 	var want []ocispec.Descriptor
 	for _, referrers := range referrerSet {
 		for _, referrer := range referrers {
-			want = append(want, descriptor.ArtifactToOCI(referrer))
+			want = append(want, referrer)
 		}
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -982,7 +981,7 @@ func TestRepository_Referrers(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1036,7 +1035,7 @@ func TestRepository_Referrers(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1053,7 +1052,7 @@ func TestRepository_Referrers(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -1076,7 +1075,7 @@ func TestRepository_Referrers(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		if index >= len(referrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1121,7 +1120,7 @@ func TestRepository_Referrers_Incompatible(t *testing.T) {
 	repo.PlainHTTP = true
 
 	ctx := context.Background()
-	if err := repo.Referrers(ctx, manifestDesc, "", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Error("Repository.Referrers() incompatible version not rejected")
@@ -1192,7 +1191,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1244,7 +1243,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1256,7 +1255,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			References []artifactspec.Descriptor `json:"references"`
+			References []ocispec.Descriptor `json:"references"`
 		}{
 			References: referrers,
 		}
@@ -1279,7 +1278,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		if index >= len(referrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1301,7 +1300,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1355,7 +1354,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1372,7 +1371,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -1395,7 +1394,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []ocispec.Descriptor) error {
 		if index >= len(referrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1420,7 +1419,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1458,7 +1457,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 			},
 		},
 	}
-	filteredReferrerSet := [][]artifactspec.Descriptor{
+	filteredReferrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1492,7 +1491,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1509,7 +1508,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -1532,7 +1531,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []ocispec.Descriptor) error {
 		if index >= len(filteredReferrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1551,7 +1550,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 }
 
 func Test_filterReferrers(t *testing.T) {
-	refs := []artifactspec.Descriptor{
+	refs := []ocispec.Descriptor{
 		{
 			MediaType:    artifactspec.MediaTypeArtifactManifest,
 			Size:         1,
@@ -1584,7 +1583,7 @@ func Test_filterReferrers(t *testing.T) {
 		},
 	}
 	got := filterReferrers(refs, "application/vnd.test")
-	want := []artifactspec.Descriptor{
+	want := []ocispec.Descriptor{
 		{
 			MediaType:    artifactspec.MediaTypeArtifactManifest,
 			Size:         1,
@@ -1604,7 +1603,7 @@ func Test_filterReferrers(t *testing.T) {
 }
 
 func Test_filterReferrers_allMatch(t *testing.T) {
-	refs := []artifactspec.Descriptor{
+	refs := []ocispec.Descriptor{
 		{
 			MediaType:    artifactspec.MediaTypeArtifactManifest,
 			Size:         1,

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -20,7 +20,6 @@ import (
 	"io"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 )
 
@@ -97,7 +96,7 @@ type ReferenceFetcher interface {
 // ReferrerFinder provides the Referrers API.
 // Reference: https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md
 type ReferrerFinder interface {
-	Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []artifactspec.Descriptor) error) error
+	Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error
 }
 
 // Tags lists the tags available in the repository.


### PR DESCRIPTION
1. Reference the latest version of `github.com/opencontainers/image-spec`
2. Migrate `artifactspec.Descriptor` to `ocispec.Descriptor`
3. Some `artifactspec.Descriptor` are not migrated because they are used by ORAS Artifact Manifest. More refactors will come in later PRs.

Related to https://github.com/oras-project/oras-go/issues/307.
BREAKING CHANGE: change the parameter type of `Referrers` 
Signed-off-by: Sylvia Lei <lixlei@microsoft.com>