### PR TITLE
fix: Scrutinize references for digests posing as tags

### DIFF
--- a/registry/reference_test.go
+++ b/registry/reference_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 )
 
+const ValidDigest = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+const InvalidDigest = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde"
+
 // For a definition of what a "valid form [ABCD]" means, see reference.go.
 func TestParseReferenceGoodies(t *testing.T) {
 	tests := []struct {
@@ -31,18 +34,26 @@ func TestParseReferenceGoodies(t *testing.T) {
 	}{
 		{
 			name:  "digest reference (valid form A)",
-			image: "hello-world@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+			image: fmt.Sprintf("hello-world@%s", ValidDigest),
 			wantTemplate: Reference{
 				Repository: "hello-world",
-				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+				Reference:  ValidDigest,
 			},
 		},
 		{
 			name:  "tag with digest (valid form B)",
-			image: "hello-world:v2@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+			image: fmt.Sprintf("hello-world:v2@%s", ValidDigest),
 			wantTemplate: Reference{
 				Repository: "hello-world",
-				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+				Reference:  ValidDigest,
+			},
+		},
+		{
+			name:  "empty tag with digest (valid form B)",
+			image: fmt.Sprintf("hello-world:@%s", ValidDigest),
+			wantTemplate: Reference{
+				Repository: "hello-world",
+				Reference:  ValidDigest,
 			},
 		},
 		{
@@ -109,6 +120,22 @@ func TestParseReferenceUglies(t *testing.T) {
 		{
 			name: "invalid port",
 			raw:  "localhost:v1/hello-world",
+		},
+		{
+			name: "invalid digest",
+			raw:  fmt.Sprintf("registry.example.com/foobar@%s", InvalidDigest),
+		},
+		{
+			name: "invalid digest prefix: colon instead of the at sign",
+			raw:  fmt.Sprintf("registry.example.com/hello-world:foobar:%s", ValidDigest),
+		},
+		{
+			name: "invalid digest prefix: double at sign",
+			raw:  fmt.Sprintf("registry.example.com/hello-world@@%s", ValidDigest),
+		},
+		{
+			name: "invalid digest prefix: space",
+			raw:  fmt.Sprintf("registry.example.com/hello-world @%s", ValidDigest),
 		},
 	}
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3590,18 +3590,6 @@ func TestRepository_ParseReference(t *testing.T) {
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
-			name: "missing reference after @",
-			repoRef: registry.Reference{
-				Registry:   "registry.example.com",
-				Repository: "hello-world",
-			},
-			args: args{
-				reference: "registry.example.com/hello-world@",
-			},
-			want:    registry.Reference{},
-			wantErr: errdef.ErrInvalidReference,
-		},
-		{
 			name: "registry mismatch",
 			repoRef: registry.Reference{
 				Registry:   "registry.example.com",
@@ -3621,6 +3609,68 @@ func TestRepository_ParseReference(t *testing.T) {
 			},
 			args: args{
 				reference: "registry.example.com/goodbye-world:foobar@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+			},
+			want:    registry.Reference{},
+			wantErr: errdef.ErrInvalidReference,
+		},
+		{
+			name: "digest posing as a tag",
+			repoRef: registry.Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+			},
+			args: args{
+				reference: "registry.example.com:5000/hello-world:sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			},
+			want:    registry.Reference{},
+			wantErr: errdef.ErrInvalidReference,
+		},
+		{
+			name: "missing reference after the at sign",
+			repoRef: registry.Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+			},
+			args: args{
+				reference: "registry.example.com/hello-world@",
+			},
+			want:    registry.Reference{},
+			wantErr: errdef.ErrInvalidReference,
+		},
+		{
+			name: "missing reference after the colon",
+			repoRef: registry.Reference{
+				Registry: "localhost",
+			},
+			args: args{
+				reference: "localhost:5000/hello:",
+			},
+			want:    registry.Reference{},
+			wantErr: errdef.ErrInvalidReference,
+		},
+		{
+			name:    "zero-size tag, zero-size digest",
+			repoRef: registry.Reference{},
+			args: args{
+				reference: "localhost:5000/hello:@",
+			},
+			want:    registry.Reference{},
+			wantErr: errdef.ErrInvalidReference,
+		},
+		{
+			name:    "zero-size tag with valid digest",
+			repoRef: registry.Reference{},
+			args: args{
+				reference: "localhost:5000/hello:@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			},
+			want:    registry.Reference{},
+			wantErr: errdef.ErrInvalidReference,
+		},
+		{
+			name:    "valid tag with zero-size digest",
+			repoRef: registry.Reference{},
+			args: args{
+				reference: "localhost:5000/hello:foobar@",
 			},
 			want:    registry.Reference{},
 			wantErr: errdef.ErrInvalidReference,


### PR DESCRIPTION
This change prevents a token sneaking in as a *tag*, then later getting validated as a *digest*.  In order to do that, a new struct member has been introduced to `registry.Reference`, namely, `ReferenceType`.  This can take one of the small finite set of values: `Undefined`, `None`, `Tag`, and `Digest`.  `None` is applicable only to *valid form D*, and `Undefined` is the `zero/null/empty` default value to force explicitness.

~~Also note that in *valid form B*, we're still allowing the redundant `tag`, is there a reason to allow for this (as opposed to considering it ambiguous, and deeming it invalid)?~~ just noticed this was already answered by @Wwwsylvia in #303.

Resolves #303.

Signed-off-by: Nima Talebi <github@nima.id.au>