### PR TITLE
feat!: support OCI artifact manifest with descriptor migration

### DIFF
--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
@@ -2126,17 +2125,14 @@ func TestStore_Predecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/graph.go
+++ b/content/graph.go
@@ -74,7 +74,7 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 			return nil, err
 		}
 		return index.Manifests, nil
-	case artifactspec.MediaTypeArtifactManifest:
+	case artifactspec.MediaTypeArtifactManifest: // TODO: deprecate
 		content, err := FetchAll(ctx, fetcher, node)
 		if err != nil {
 			return nil, err
@@ -92,6 +92,21 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 			nodes = append(nodes, descriptor.ArtifactToOCI(blob))
 		}
 		return nodes, nil
+	case ocispec.MediaTypeArtifactManifest:
+		content, err := FetchAll(ctx, fetcher, node)
+		if err != nil {
+			return nil, err
+		}
+
+		var manifest ocispec.Artifact
+		if err := json.Unmarshal(content, &manifest); err != nil {
+			return nil, err
+		}
+		var nodes []ocispec.Descriptor
+		if manifest.Subject != nil {
+			nodes = append(nodes, *manifest.Subject)
+		}
+		return append(nodes, manifest.Blobs...), nil
 	}
 	return nil, nil
 }

--- a/content/memory/memory_test.go
+++ b/content/memory/memory_test.go
@@ -29,13 +29,11 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
-	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/resolver"
 )
 
@@ -332,17 +330,14 @@ func TestStorePredecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -33,14 +33,12 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
-	"oras.land/oras-go/v2/internal/descriptor"
 )
 
 // storageTracker tracks storage API counts.
@@ -671,17 +669,14 @@ func TestStore_Predecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -786,17 +781,14 @@ func TestStore_ExistingStore(t *testing.T) {
 	}
 
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/example_test.go
+++ b/example_test.go
@@ -60,10 +60,6 @@ var (
 		MediaType: artifactspec.MediaTypeArtifactManifest,
 		Digest:    digest.FromBytes(exampleSignatureManifest),
 		Size:      int64(len(exampleSignatureManifest))}
-	exampleSignatureManifestDescriptorArtifactspec = artifactspec.Descriptor{
-		MediaType: exampleSignatureManifestDescriptor.MediaType,
-		Digest:    exampleSignatureManifestDescriptor.Digest,
-		Size:      exampleSignatureManifestDescriptor.Size}
 )
 
 func pushBlob(ctx context.Context, mediaType string, blob []byte, target oras.Target) (desc ocispec.Descriptor, err error) {
@@ -143,14 +139,14 @@ func TestMain(m *testing.M) {
 		case strings.Contains(p, "/artifacts/referrers"):
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
 			q := r.URL.Query()
-			var referrers []artifactspec.Descriptor
+			var referrers []ocispec.Descriptor
 			if q.Get("digest") == exampleManifestDescriptor.Digest.String() {
-				referrers = []artifactspec.Descriptor{exampleSignatureManifestDescriptorArtifactspec}
+				referrers = []ocispec.Descriptor{exampleSignatureManifestDescriptor}
 			} else if q.Get("digest") == exampleSignatureManifestDescriptor.Digest.String() {
-				referrers = []artifactspec.Descriptor{}
+				referrers = []ocispec.Descriptor{}
 			}
 			result := struct {
-				Referrers []artifactspec.Descriptor `json:"referrers"`
+				Referrers []ocispec.Descriptor `json:"referrers"`
 			}{
 				Referrers: referrers,
 			}

--- a/example_test.go
+++ b/example_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/content/oci"
@@ -41,23 +40,19 @@ import (
 var exampleMemoryStore oras.Target
 var remoteHost string
 var (
-	exampleManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/content"})
 	exampleManifestDescriptor = ocispec.Descriptor{
-		MediaType: artifactspec.MediaTypeArtifactManifest,
+		MediaType: ocispec.MediaTypeArtifactManifest,
 		Digest:    digest.Digest(digest.FromBytes(exampleManifest)),
 		Size:      int64(len(exampleManifest))}
-	exampleManifestDescriptorArtifactspec = artifactspec.Descriptor{
-		MediaType: exampleManifestDescriptor.MediaType,
-		Digest:    exampleManifestDescriptor.Digest,
-		Size:      exampleManifestDescriptor.Size}
-	exampleSignatureManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleSignatureManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
-		Subject:      &exampleManifestDescriptorArtifactspec})
+		Subject:      &exampleManifestDescriptor})
 	exampleSignatureManifestDescriptor = ocispec.Descriptor{
-		MediaType: artifactspec.MediaTypeArtifactManifest,
+		MediaType: ocispec.MediaTypeArtifactManifest,
 		Digest:    digest.FromBytes(exampleSignatureManifest),
 		Size:      int64(len(exampleSignatureManifest))}
 )
@@ -122,7 +117,7 @@ func TestMain(m *testing.M) {
 		case strings.Contains(p, "/blobs/uploads/"+exampleUploadUUid) && m == "GET":
 			w.WriteHeader(http.StatusCreated)
 		case strings.Contains(p, "/manifests/"+string(exampleSignatureManifestDescriptor.Digest)):
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Docker-Content-Digest", string(exampleSignatureManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSignatureManifest)))
 			w.Write(exampleSignatureManifest)
@@ -130,7 +125,7 @@ func TestMain(m *testing.M) {
 			w.WriteHeader(http.StatusCreated)
 		case strings.Contains(p, "/manifests/"+string(exampleManifestDescriptor.Digest)),
 			strings.Contains(p, "/manifests/latest") && m == "HEAD":
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Docker-Content-Digest", string(exampleManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleManifest)))
 			if m == "GET" {
@@ -317,7 +312,7 @@ func Example_copyArtifactManifestRemoteToLocal() {
 	dst := memory.New()
 	ctx := context.Background()
 
-	exampleDigest := "sha256:f9308ac4616a808210c12d049b4eb684754a5acf2c3c8d353a9fa2b3c47c274a"
+	exampleDigest := "sha256:70c29a81e235dda5c2cebb8ec06eafd3cca346cbd91f15ac74cefd98681c5b3d"
 	descriptor, err := src.Resolve(ctx, exampleDigest)
 	if err != nil {
 		panic(err)
@@ -358,5 +353,5 @@ func Example_extendedCopyArtifactAndReferrersRemoteToLocal() {
 
 	fmt.Println(desc.Digest)
 	// Output:
-	// sha256:1f3e679d4fc05dca20a699ae5af5fb2b7d481d5694aff929165d1c8b0f4c8598
+	// sha256:f396bc4d300934a39ca28ab0d5ac8a3573336d7d63c654d783a68cd1e2057662
 }

--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -287,11 +287,11 @@ func (opts *ExtendedCopyGraphOptions) FilterArtifactType(regex *regexp.Regexp) {
 // findReferrersAndFilter filters the predecessors with Referrers.
 func findReferrersAndFilter(rf registry.ReferrerFinder, ctx context.Context, desc ocispec.Descriptor, regex *regexp.Regexp) ([]ocispec.Descriptor, error) {
 	var predecessors []ocispec.Descriptor
-	if err := rf.Referrers(ctx, desc, "", func(referrers []artifactspec.Descriptor) error {
+	if err := rf.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
 		// for each page of the results, do the following:
 		for _, referrer := range referrers {
 			if regex.MatchString(referrer.ArtifactType) {
-				predecessors = append(predecessors, descriptor.ArtifactToOCI(referrer))
+				predecessors = append(predecessors, referrer)
 			}
 		}
 		return nil

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -68,17 +68,14 @@ func TestExtendedCopy_FullCopy(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -169,17 +166,14 @@ func TestExtendedCopyGraph_FullCopy(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -377,17 +371,14 @@ func TestExtendedCopyGraph_WithDepthOption(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -512,17 +503,14 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -577,7 +565,7 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 			for _, p := range predecessors {
 				// filter media type
 				switch p.MediaType {
-				case artifactspec.MediaTypeArtifactManifest:
+				case ocispec.MediaTypeArtifactManifest:
 					filtered = append(filtered, p)
 				}
 			}

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -1054,7 +1054,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	var referrerSet []artifactspec.Descriptor
+	var referrerSet []ocispec.Descriptor
 	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
@@ -1075,7 +1075,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
 	}
 	pushReferrers := func(desc ocispec.Descriptor, artifactType string) {
-		referrerSet = append(referrerSet, artifactspec.Descriptor{
+		referrerSet = append(referrerSet, ocispec.Descriptor{
 			MediaType:    desc.MediaType,
 			ArtifactType: artifactType,
 			Digest:       desc.Digest,
@@ -1132,12 +1132,12 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 			w.Write(blobs[5])
 		case strings.Contains(p, "referrers"):
 			q := r.URL.Query()
-			var referrers []artifactspec.Descriptor
+			var referrers []ocispec.Descriptor
 			if q.Get("digest") == descs[0].Digest.String() {
 				referrers = referrerSet
 			}
 			result := struct {
-				Referrers []artifactspec.Descriptor `json:"referrers"`
+				Referrers []ocispec.Descriptor `json:"referrers"`
 			}{
 				Referrers: referrers,
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.0.2
+	github.com/opencontainers/image-spec v1.0.3-0.20220915173658-a7ac485f4c80
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab47
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
-github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.3-0.20220915173658-a7ac485f4c80 h1:4r7VhO7fgr2+uiuYjVip7TqKsJPVDTLmxxSNS9APJfU=
+github.com/opencontainers/image-spec v1.0.3-0.20220915173658-a7ac485f4c80/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2 h1:9SMCNSxkJEHqWGDiMCuy6TXHgvjgwXGdXZZGXLKQvVE=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -47,15 +47,6 @@ func FromOCI(desc ocispec.Descriptor) Descriptor {
 	}
 }
 
-// FromArtifact shrinks the artifact descriptor to the minimum.
-func FromArtifact(desc artifactspec.Descriptor) Descriptor {
-	return Descriptor{
-		MediaType: desc.MediaType,
-		Digest:    desc.Digest,
-		Size:      desc.Size,
-	}
-}
-
 // ArtifactToOCI converts artifact descriptor to OCI descriptor.
 func ArtifactToOCI(desc artifactspec.Descriptor) ocispec.Descriptor {
 	return ocispec.Descriptor{

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -60,7 +60,7 @@ var (
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Subject:      &exampleManifestDescriptor})
-	exampleSignatureManifestDescriptor = artifactspec.Descriptor{
+	exampleSignatureManifestDescriptor = ocispec.Descriptor{
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Digest:       digest.FromBytes(exampleSignatureManifest),
@@ -69,12 +69,12 @@ var (
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Subject:      &exampleManifestDescriptor})
-	exampleSBoMManifestDescriptor = artifactspec.Descriptor{
+	exampleSBoMManifestDescriptor = ocispec.Descriptor{
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Digest:       digest.FromBytes(exampleSBoMManifest),
 		Size:         int64(len(exampleSBoMManifest))}
-	exampleReferrerDescriptors = [][]artifactspec.Descriptor{
+	exampleReferrerDescriptors = [][]ocispec.Descriptor{
 		{exampleSBoMManifestDescriptor},      // page 0
 		{exampleSignatureManifestDescriptor}, // page 1
 	}
@@ -88,7 +88,7 @@ var (
 		ArtifactType: "example/manifest",
 		Blobs:        []artifactspec.Descriptor{blobDescriptor},
 		Subject:      &exampleManifestDescriptor})
-	exampleManifestWithBlobsDescriptor = artifactspec.Descriptor{
+	exampleManifestWithBlobsDescriptor = ocispec.Descriptor{
 		MediaType:    artifactspec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
 		Digest:       digest.FromBytes(exampleManifestWithBlobs),
@@ -157,7 +157,7 @@ func TestMain(m *testing.M) {
 			w.Write([]byte(blobContent))
 		case p == fmt.Sprintf("/v2/%s/_oras/artifacts/referrers", exampleRepositoryName):
 			q := r.URL.Query()
-			var referrers []artifactspec.Descriptor
+			var referrers []ocispec.Descriptor
 			switch q.Get("test") {
 			case "page1":
 				referrers = exampleReferrerDescriptors[1]
@@ -168,7 +168,7 @@ func TestMain(m *testing.M) {
 				w.Header().Set("Link", fmt.Sprintf(`<%s?n=1&test=page1>; rel="next"`, p))
 			}
 			result := struct {
-				Referrers []artifactspec.Descriptor `json:"referrers"`
+				Referrers []ocispec.Descriptor `json:"referrers"`
 			}{
 				Referrers: referrers,
 			}
@@ -441,7 +441,7 @@ func ExampleRepository_Fetch_artifactReferenceManifest() {
 		panic(err)
 	}
 	// find its referrers by calling Referrers
-	if err := repo.Referrers(ctx, descriptor, "", func(referrers []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, descriptor, "", func(referrers []ocispec.Descriptor) error {
 		// for each page of the results, do the following:
 		for _, referrer := range referrers {
 			// for each item in this page, pull the manifest and verify its content

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	. "oras.land/oras-go/v2/registry/internal/doc"
@@ -45,32 +44,32 @@ const (
 	exampleLayer            = "Example layer content"
 	exampleUploadUUid       = "0bc84d80-837c-41d9-824e-1907463c53b3"
 	ManifestDigest          = "sha256:0b696106ecd0654e031f19e0a8cbd1aee4ad457d7c9cea881f07b12a930cd307"
-	ReferenceManifestDigest = "sha256:b2122d3fd728173dd6b68a0b73caa129302b78c78273ba43ead541a88169c855"
+	ReferenceManifestDigest = "sha256:6983f495f7ee70d43e571657ae8b39ca3d3ca1b0e77270fd4fbddfb19832a1cf"
 	_                       = ExampleUnplayable
 )
 
 var (
 	exampleLayerDigest        = digest.FromBytes([]byte(exampleLayer)).String()
 	exampleManifestDigest     = digest.FromBytes([]byte(exampleManifest)).String()
-	exampleManifestDescriptor = artifactspec.Descriptor{
+	exampleManifestDescriptor = ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageManifest,
 		Digest:    digest.Digest(exampleManifestDigest),
 		Size:      int64(len(exampleManifest))}
-	exampleSignatureManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleSignatureManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Subject:      &exampleManifestDescriptor})
 	exampleSignatureManifestDescriptor = ocispec.Descriptor{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Digest:       digest.FromBytes(exampleSignatureManifest),
 		Size:         int64(len(exampleSignatureManifest))}
-	exampleSBoMManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleSBoMManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Subject:      &exampleManifestDescriptor})
 	exampleSBoMManifestDescriptor = ocispec.Descriptor{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Digest:       digest.FromBytes(exampleSBoMManifest),
 		Size:         int64(len(exampleSBoMManifest))}
@@ -79,17 +78,17 @@ var (
 		{exampleSignatureManifestDescriptor}, // page 1
 	}
 	blobContent    = "example blob content"
-	blobDescriptor = artifactspec.Descriptor{
+	blobDescriptor = ocispec.Descriptor{
 		MediaType: "application/tar",
 		Digest:    digest.FromBytes([]byte(blobContent)),
 		Size:      int64(len(blobContent))}
-	exampleManifestWithBlobs, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleManifestWithBlobs, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
-		Blobs:        []artifactspec.Descriptor{blobDescriptor},
+		Blobs:        []ocispec.Descriptor{blobDescriptor},
 		Subject:      &exampleManifestDescriptor})
 	exampleManifestWithBlobsDescriptor = ocispec.Descriptor{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
 		Digest:       digest.FromBytes(exampleManifestWithBlobs),
 		Size:         int64(len(exampleManifestWithBlobs))}
@@ -133,25 +132,25 @@ func TestMain(m *testing.M) {
 			w.WriteHeader(http.StatusCreated)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleSignatureManifestDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleSignatureManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSignatureManifest)))
 			w.Write(exampleSignatureManifest)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleSBoMManifestDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleSBoMManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSBoMManifest)))
 			w.Write(exampleSBoMManifest)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleManifestWithBlobsDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleManifestWithBlobsDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleManifestWithBlobs)))
 			w.Write(exampleManifestWithBlobs)
 		case p == fmt.Sprintf("/v2/%s/blobs/%s", exampleRepositoryName, blobDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(blobDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobContent)))
 			w.Write([]byte(blobContent))
@@ -250,14 +249,10 @@ func ExampleRepository_Push() {
 	ctx := context.Background()
 
 	// 1. assemble a descriptor
-	content := []byte("Example layer content")
-	descriptor := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageLayer, // Set media type
-		Digest:    digest.FromBytes(content),   // Calculate digest
-		Size:      int64(len(content)),         // Include content size
-	}
+	layer := []byte("Example layer content")
+	descriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeImageLayer, layer)
 	// 2. push the descriptor and blob content
-	err = repo.Push(ctx, descriptor, bytes.NewReader(content))
+	err = repo.Push(ctx, descriptor, bytes.NewReader(layer))
 	if err != nil {
 		panic(err)
 	}
@@ -279,36 +274,29 @@ func ExampleRepository_Push_artifactReferenceManifest() {
 	manifest := ocispec.Manifest{
 		MediaType: ocispec.MediaTypeImageManifest,
 	}
-	manifestContent, _ := json.Marshal(manifest)
-	manifestDescriptor := artifactspec.Descriptor{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Digest:    digest.FromBytes(manifestContent),
-		Size:      int64(len(manifestContent)),
+	manifestContent, err := json.Marshal(manifest)
+	if err != nil {
+		panic(err)
 	}
+	manifestDescriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestContent)
 
 	// 2. push the manifest descriptor and content
-	err = repo.Push(ctx, ocispec.Descriptor{
-		MediaType: manifestDescriptor.MediaType,
-		Digest:    manifestDescriptor.Digest,
-		Size:      manifestDescriptor.Size,
-	}, bytes.NewReader(manifestContent))
+	err = repo.Push(ctx, manifestDescriptor, bytes.NewReader(manifestContent))
 	if err != nil {
 		panic(err)
 	}
 
 	// 3. assemble the reference artifact manifest
-	referenceManifest := artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	referenceManifest := ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "sbom/example",
 		Subject:      &manifestDescriptor,
 	}
-	referenceManifestContent, _ := json.Marshal(referenceManifest)
-	referenceManifestDescriptor := ocispec.Descriptor{
-		MediaType: artifactspec.MediaTypeArtifactManifest,
-		Digest:    digest.FromBytes(referenceManifestContent),
-		Size:      int64(len(referenceManifestContent)),
+	referenceManifestContent, err := json.Marshal(referenceManifest)
+	if err != nil {
+		panic(err)
 	}
-
+	referenceManifestDescriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, referenceManifestContent)
 	// 4. push the reference manifest descriptor and content
 	err = repo.Push(ctx, referenceManifestDescriptor, bytes.NewReader(referenceManifestContent))
 	if err != nil {
@@ -445,18 +433,12 @@ func ExampleRepository_Fetch_artifactReferenceManifest() {
 		// for each page of the results, do the following:
 		for _, referrer := range referrers {
 			// for each item in this page, pull the manifest and verify its content
-			rc, err := repo.Fetch(ctx, ocispec.Descriptor{
-				MediaType: referrer.MediaType,
-				Digest:    referrer.Digest,
-				Size:      referrer.Size})
+			rc, err := repo.Fetch(ctx, referrer)
 			if err != nil {
 				panic(err)
 			}
 			defer rc.Close() // don't forget to close
-			pulledBlob, err := content.ReadAll(rc, ocispec.Descriptor{
-				MediaType: referrer.MediaType,
-				Digest:    referrer.Digest,
-				Size:      referrer.Size})
+			pulledBlob, err := content.ReadAll(rc, referrer)
 			if err != nil {
 				panic(err)
 			}
@@ -467,8 +449,8 @@ func ExampleRepository_Fetch_artifactReferenceManifest() {
 		panic(err)
 	}
 	// Output:
-	// {"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"example/SBoM","blobs":null,"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
-	// {"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"example/signature","blobs":null,"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
+	// {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"example/SBoM","subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
+	// {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"example/signature","subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
 }
 
 // ExampleRepository_fetchArtifactBlobs gives an example of pulling the blobs
@@ -481,7 +463,7 @@ func ExampleRepository_fetchArtifactBlobs() {
 	ctx := context.Background()
 
 	// 1. Fetch the artifact manifest by digest.
-	exampleDigest := "sha256:73bccdadf23b5df306bf77b23e1b00944c7bbce44cf63439afe15507a73413b5"
+	exampleDigest := "sha256:1907bb31b7add4d47d74d2c5c1c10d67b757a996f8e8186e562113bc9879b1a3"
 	descriptor, rc, err := repo.FetchReference(ctx, exampleDigest)
 	if err != nil {
 		panic(err)
@@ -495,16 +477,12 @@ func ExampleRepository_fetchArtifactBlobs() {
 	fmt.Println(string(pulledContent))
 
 	// 2. Parse the pulled manifest and fetch its blobs.
-	var pulledManifest artifactspec.Manifest
+	var pulledManifest ocispec.Artifact
 	if err := json.Unmarshal(pulledContent, &pulledManifest); err != nil {
 		panic(err)
 	}
 	for _, blob := range pulledManifest.Blobs {
-		content, err := content.FetchAll(ctx, repo, ocispec.Descriptor{
-			MediaType: blob.MediaType,
-			Digest:    blob.Digest,
-			Size:      blob.Size,
-		})
+		content, err := content.FetchAll(ctx, repo, blob)
 		if err != nil {
 			panic(err)
 		}
@@ -512,7 +490,7 @@ func ExampleRepository_fetchArtifactBlobs() {
 	}
 
 	// Output:
-	// {"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"example/manifest","blobs":[{"mediaType":"application/tar","digest":"sha256:8d6497c94694a292c04f85cd055d8b5c03eda835dd311e20dfbbf029ff9748cc","size":20}],"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
+	// {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"example/manifest","blobs":[{"mediaType":"application/tar","digest":"sha256:8d6497c94694a292c04f85cd055d8b5c03eda835dd311e20dfbbf029ff9748cc","size":20}],"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
 	// example blob content
 }
 
@@ -767,13 +745,6 @@ func Example_pushAndTag() {
 	//   |                                                   |
 	//   +--------+ localhost:5000/example/registry +--------+
 
-	generateDescriptor := func(mediaType string, blob []byte) (desc ocispec.Descriptor) {
-		return ocispec.Descriptor{
-			MediaType: mediaType,
-			Digest:    digest.FromBytes(blob), // Calculate digest
-			Size:      int64(len(blob)),       // Include blob size
-		}
-	}
 	generateManifest := func(config ocispec.Descriptor, layers ...ocispec.Descriptor) ([]byte, error) {
 		content := ocispec.Manifest{
 			Config:    config,
@@ -782,17 +753,16 @@ func Example_pushAndTag() {
 		}
 		return json.Marshal(content)
 	}
-
 	// 1. assemble descriptors and manifest
 	layerBlob := []byte("Hello layer")
-	layerDesc := generateDescriptor(ocispec.MediaTypeImageLayer, layerBlob)
+	layerDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageLayer, layerBlob)
 	configBlob := []byte("Hello config")
-	configDesc := generateDescriptor(ocispec.MediaTypeImageConfig, configBlob)
+	configDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageConfig, configBlob)
 	manifestBlob, err := generateManifest(configDesc, layerDesc)
 	if err != nil {
 		panic(err)
 	}
-	manifestDesc := generateDescriptor(ocispec.MediaTypeImageManifest, manifestBlob)
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestBlob)
 
 	// 2. push and tag
 	err = repo.Push(ctx, layerDesc, bytes.NewReader(layerBlob))

--- a/registry/remote/manifest.go
+++ b/registry/remote/manifest.go
@@ -29,7 +29,8 @@ var defaultManifestMediaTypes = []string{
 	docker.MediaTypeManifestList,
 	ocispec.MediaTypeImageManifest,
 	ocispec.MediaTypeImageIndex,
-	artifactspec.MediaTypeArtifactManifest,
+	artifactspec.MediaTypeArtifactManifest, // TODO: deprecate
+	ocispec.MediaTypeArtifactManifest,
 }
 
 // defaultManifestAcceptHeader is the default set in the `Accept` header for

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -37,7 +37,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
-	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/interfaces"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -867,7 +866,7 @@ func TestRepository_Predecessors(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -921,7 +920,7 @@ func TestRepository_Predecessors(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -938,7 +937,7 @@ func TestRepository_Predecessors(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -967,7 +966,7 @@ func TestRepository_Predecessors(t *testing.T) {
 	var want []ocispec.Descriptor
 	for _, referrers := range referrerSet {
 		for _, referrer := range referrers {
-			want = append(want, descriptor.ArtifactToOCI(referrer))
+			want = append(want, referrer)
 		}
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -982,7 +981,7 @@ func TestRepository_Referrers(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1036,7 +1035,7 @@ func TestRepository_Referrers(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1053,7 +1052,7 @@ func TestRepository_Referrers(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -1076,7 +1075,7 @@ func TestRepository_Referrers(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		if index >= len(referrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1121,7 +1120,7 @@ func TestRepository_Referrers_Incompatible(t *testing.T) {
 	repo.PlainHTTP = true
 
 	ctx := context.Background()
-	if err := repo.Referrers(ctx, manifestDesc, "", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Error("Repository.Referrers() incompatible version not rejected")
@@ -1192,7 +1191,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1244,7 +1243,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1256,7 +1255,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			References []artifactspec.Descriptor `json:"references"`
+			References []ocispec.Descriptor `json:"references"`
 		}{
 			References: referrers,
 		}
@@ -1279,7 +1278,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		if index >= len(referrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1301,7 +1300,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1355,7 +1354,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1372,7 +1371,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -1395,7 +1394,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []ocispec.Descriptor) error {
 		if index >= len(referrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1420,7 +1419,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		Digest:    digest.FromBytes(manifest),
 		Size:      int64(len(manifest)),
 	}
-	referrerSet := [][]artifactspec.Descriptor{
+	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1458,7 +1457,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 			},
 		},
 	}
-	filteredReferrerSet := [][]artifactspec.Descriptor{
+	filteredReferrerSet := [][]ocispec.Descriptor{
 		{
 			{
 				MediaType:    artifactspec.MediaTypeArtifactManifest,
@@ -1492,7 +1491,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 			return
 		}
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
-		var referrers []artifactspec.Descriptor
+		var referrers []ocispec.Descriptor
 		switch q.Get("test") {
 		case "foo":
 			referrers = referrerSet[1]
@@ -1509,7 +1508,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 			w.Header().Set("Link", fmt.Sprintf(`<%s?n=2&test=foo>; rel="next"`, path))
 		}
 		result := struct {
-			Referrers []artifactspec.Descriptor `json:"referrers"`
+			Referrers []ocispec.Descriptor `json:"referrers"`
 		}{
 			Referrers: referrers,
 		}
@@ -1532,7 +1531,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 
 	ctx := context.Background()
 	index := 0
-	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []artifactspec.Descriptor) error {
+	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []ocispec.Descriptor) error {
 		if index >= len(filteredReferrerSet) {
 			t.Fatalf("out of index bound: %d", index)
 		}
@@ -1551,7 +1550,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 }
 
 func Test_filterReferrers(t *testing.T) {
-	refs := []artifactspec.Descriptor{
+	refs := []ocispec.Descriptor{
 		{
 			MediaType:    artifactspec.MediaTypeArtifactManifest,
 			Size:         1,
@@ -1584,7 +1583,7 @@ func Test_filterReferrers(t *testing.T) {
 		},
 	}
 	got := filterReferrers(refs, "application/vnd.test")
-	want := []artifactspec.Descriptor{
+	want := []ocispec.Descriptor{
 		{
 			MediaType:    artifactspec.MediaTypeArtifactManifest,
 			Size:         1,
@@ -1604,7 +1603,7 @@ func Test_filterReferrers(t *testing.T) {
 }
 
 func Test_filterReferrers_allMatch(t *testing.T) {
-	refs := []artifactspec.Descriptor{
+	refs := []ocispec.Descriptor{
 		{
 			MediaType:    artifactspec.MediaTypeArtifactManifest,
 			Size:         1,

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/interfaces"
 	"oras.land/oras-go/v2/registry"
@@ -869,13 +868,13 @@ func TestRepository_Predecessors(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -883,13 +882,13 @@ func TestRepository_Predecessors(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -897,7 +896,7 @@ func TestRepository_Predecessors(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -984,13 +983,13 @@ func TestRepository_Referrers(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -998,13 +997,13 @@ func TestRepository_Referrers(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1012,7 +1011,7 @@ func TestRepository_Referrers(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1194,13 +1193,13 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -1208,13 +1207,13 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1222,7 +1221,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1303,13 +1302,13 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -1317,13 +1316,13 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1331,7 +1330,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1422,13 +1421,13 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.foo",
@@ -1436,13 +1435,13 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.bar",
@@ -1450,7 +1449,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.baz",
@@ -1460,7 +1459,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	filteredReferrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
@@ -1468,7 +1467,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
@@ -1552,31 +1551,31 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 func Test_filterReferrers(t *testing.T) {
 	refs := []ocispec.Descriptor{
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         2,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.foo",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         3,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.bar",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("5"),
 			ArtifactType: "application/vnd.baz",
@@ -1585,13 +1584,13 @@ func Test_filterReferrers(t *testing.T) {
 	got := filterReferrers(refs, "application/vnd.test")
 	want := []ocispec.Descriptor{
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
@@ -1605,19 +1604,19 @@ func Test_filterReferrers(t *testing.T) {
 func Test_filterReferrers_allMatch(t *testing.T) {
 	refs := []ocispec.Descriptor{
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.test",

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -20,7 +20,6 @@ import (
 	"io"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 )
 
@@ -97,7 +96,7 @@ type ReferenceFetcher interface {
 // ReferrerFinder provides the Referrers API.
 // Reference: https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md
 type ReferrerFinder interface {
-	Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []artifactspec.Descriptor) error) error
+	Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error
 }
 
 // Tags lists the tags available in the repository.


### PR DESCRIPTION
The work of migrating ORAS Artifact to OCI Artifact is partially done on the `oci-playground/oras-go` main branch.
We will continue the migration work on `oras-project/oras-go` main branch going forward.

Resolves #307 
Resolves #308 
BREAKING CHANGE: change the parameter type of `Referrers`
Signed-off-by: Lixia (Sylvia) Lei <lixlei@microsoft.com>