### PR TITLE
refactor: optimize extended copy filters

### DIFF
--- a/content/graph.go
+++ b/content/graph.go
@@ -62,10 +62,10 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 			return nil, err
 		}
 		var nodes []ocispec.Descriptor
-		nodes = append(nodes, manifest.Config)
 		if manifest.Subject != nil {
 			nodes = append(nodes, *manifest.Subject)
 		}
+		nodes = append(nodes, manifest.Config)
 		return append(nodes, manifest.Layers...), nil
 	case docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex:
 		content, err := FetchAll(ctx, fetcher, node)

--- a/content/graph.go
+++ b/content/graph.go
@@ -61,7 +61,12 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 		if err := json.Unmarshal(content, &manifest); err != nil {
 			return nil, err
 		}
-		return append([]ocispec.Descriptor{manifest.Config}, manifest.Layers...), nil
+		var nodes []ocispec.Descriptor
+		nodes = append(nodes, manifest.Config)
+		if manifest.Subject != nil {
+			nodes = append(nodes, *manifest.Subject)
+		}
+		return append(nodes, manifest.Layers...), nil
 	case docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex:
 		content, err := FetchAll(ctx, fetcher, node)
 		if err != nil {


### PR DESCRIPTION
According to [Open Container Initiative Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers), the `Referrers API` must include the artifact type and annotations of the referrers in the returned descriptor list. 

> The descriptors MUST include an artifactType field that is set to the value of artifactType for an artifact manifest if present, or the configuration descriptor's mediaType for an image manifest. The descriptors MUST include annotations from the image or artifact manifest.

However, the `Predecessors` function implemented by file, OCI, and memory store is not guaranteed to include the artifact type and annotations in the returned descriptors.

This PR is migrated from https://github.com/oci-playground/oras-go/pull/3.

Resolves #310 
Signed-off-by: Lixia (Sylvia) Lei <lixlei@microsoft.com>