### PR TITLE
refactor: refactor functions related to querying referrers

### DIFF
--- a/registry/remote/errcode/errors.go
+++ b/registry/remote/errcode/errors.go
@@ -24,6 +24,9 @@ import (
 	"unicode"
 )
 
+// References:
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#error-codes
+//   - https://docs.docker.com/registry/spec/api/#errors-2
 const (
 	ErrorCodeBlobUnknown         = "BLOB_UNKNOWN"
 	ErrorCodeBlobUploadInvalid   = "BLOB_UPLOAD_INVALID"
@@ -42,6 +45,9 @@ const (
 
 // Error represents a response inner error returned by the remote
 // registry.
+// References:
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#error-codes
+//   - https://docs.docker.com/registry/spec/api/#errors-2
 type Error struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
@@ -65,8 +71,11 @@ func (e Error) Error() string {
 	return fmt.Sprintf("%s: %s: %v", code, e.Message, e.Detail)
 }
 
-// Errors represents a list of response inner errors returned by
-// the remote server.
+// Errors represents a list of response inner errors returned by the remote
+// server.
+// References:
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#error-codes
+//   - https://docs.docker.com/registry/spec/api/#errors-2
 type Errors []Error
 
 // Error returns a error string describing the error.

--- a/registry/remote/errcode/errors.go
+++ b/registry/remote/errcode/errors.go
@@ -16,6 +16,7 @@ limitations under the License.
 package errcode
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -118,6 +119,15 @@ func (err *ErrorResponse) Unwrap() error {
 	return err.Errors
 }
 
-// func IsErrorCode(err error, code string) bool {
+// IsErrorResponseStatus returns true if err is an ErrorResponse and its
+// / StatusCode equals to statusCode.
+func IsErrorResponseStatus(err error, statusCode int) bool {
+	var errResp *ErrorResponse
+	return errors.As(err, &errResp) && errResp.StatusCode == statusCode
+}
 
-// }
+// IsErrorCode returns true if err is an Error and its Code equals to code.
+func IsErrorCode(err error, code string) bool {
+	var ec Error
+	return errors.As(err, &ec) && ec.Code == code
+}

--- a/registry/remote/errcode/errors.go
+++ b/registry/remote/errcode/errors.go
@@ -16,7 +16,6 @@ limitations under the License.
 package errcode
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -126,17 +125,4 @@ func (err *ErrorResponse) Unwrap() error {
 		return nil
 	}
 	return err.Errors
-}
-
-// IsErrorResponseStatus returns true if err is an ErrorResponse and its
-// StatusCode equals to statusCode.
-func IsErrorResponseStatus(err error, statusCode int) bool {
-	var errResp *ErrorResponse
-	return errors.As(err, &errResp) && errResp.StatusCode == statusCode
-}
-
-// IsErrorCode returns true if err is an Error and its Code equals to code.
-func IsErrorCode(err error, code string) bool {
-	var ec Error
-	return errors.As(err, &ec) && ec.Code == code
 }

--- a/registry/remote/errcode/errors.go
+++ b/registry/remote/errcode/errors.go
@@ -120,7 +120,7 @@ func (err *ErrorResponse) Unwrap() error {
 }
 
 // IsErrorResponseStatus returns true if err is an ErrorResponse and its
-// / StatusCode equals to statusCode.
+// StatusCode equals to statusCode.
 func IsErrorResponseStatus(err error, statusCode int) bool {
 	var errResp *ErrorResponse
 	return errors.As(err, &errResp) && errResp.StatusCode == statusCode

--- a/registry/remote/errcode/errors.go
+++ b/registry/remote/errcode/errors.go
@@ -23,6 +23,22 @@ import (
 	"unicode"
 )
 
+const (
+	ErrorCodeBlobUnknown         = "BLOB_UNKNOWN"
+	ErrorCodeBlobUploadInvalid   = "BLOB_UPLOAD_INVALID"
+	ErrorCodeBlobUploadUnknown   = "BLOB_UPLOAD_UNKNOWN"
+	ErrorCodeDigestInvalid       = "DIGEST_INVALID"
+	ErrorCodeManifestBlobUnknown = "MANIFEST_BLOB_UNKNOWN"
+	ErrorCodeManifestInvalid     = "MANIFEST_INVALID"
+	ErrorCodeManifestUnknown     = "MANIFEST_UNKNOWN"
+	ErrorCodeNameInvalid         = "NAME_INVALID"
+	ErrorCodeNameUnknown         = "NAME_UNKNOWN"
+	ErrorCodeSizeInvalid         = "SIZE_INVALID"
+	ErrorCodeUnauthorized        = "UNAUTHORIZED"
+	ErrorCodeDenied              = "DENIED"
+	ErrorCodeUnsupported         = "UNSUPPORTED"
+)
+
 // Error represents a response inner error returned by the remote
 // registry.
 type Error struct {
@@ -101,3 +117,7 @@ func (err *ErrorResponse) Unwrap() error {
 	}
 	return err.Errors
 }
+
+// func IsErrorCode(err error, code string) bool {
+
+// }

--- a/registry/remote/internal/errutil/errutil.go
+++ b/registry/remote/internal/errutil/errutil.go
@@ -17,6 +17,7 @@ package errutil
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 
@@ -44,4 +45,10 @@ func ParseErrorResponse(resp *http.Response) error {
 		resultErr.Errors = body.Errors
 	}
 	return resultErr
+}
+
+// IsErrorCode returns true if err is an Error and its Code equals to code.
+func IsErrorCode(err error, code string) bool {
+	var ec errcode.Error
+	return errors.As(err, &ec) && ec.Code == code
 }

--- a/registry/remote/internal/errutil/errutil_test.go
+++ b/registry/remote/internal/errutil/errutil_test.go
@@ -126,3 +126,114 @@ func Test_ParseErrorResponse_plain(t *testing.T) {
 		t.Errorf("ParseErrorResponse() error = %v, want err message %v", err, want)
 	}
 }
+
+func TestIsErrorCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code string
+		want bool
+	}{
+		{
+			name: "test errcode.Error, same code",
+			err: errcode.Error{
+				Code: errcode.ErrorCodeNameUnknown,
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: true,
+		},
+		{
+			name: "test errcode.Error, different code",
+			err: errcode.Error{
+				Code: errcode.ErrorCodeUnauthorized,
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: false,
+		},
+		{
+			name: "test errcode.Errors containing single error, same code",
+			err: errcode.Errors{
+				{
+					Code: errcode.ErrorCodeNameUnknown,
+				},
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: true,
+		},
+		{
+			name: "test errcode.Errors containing single error, different code",
+			err: errcode.Errors{
+				{
+					Code: errcode.ErrorCodeNameUnknown,
+				},
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: true,
+		},
+		{
+			name: "test errcode.Errors containing multiple errors, same code",
+			err: errcode.Errors{
+				{
+					Code: errcode.ErrorCodeNameUnknown,
+				},
+				{
+					Code: errcode.ErrorCodeUnauthorized,
+				},
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: false,
+		},
+		{
+			name: "test errcode.ErrorResponse containing single error, same code",
+			err: &errcode.ErrorResponse{
+				Errors: errcode.Errors{
+					{
+						Code: errcode.ErrorCodeNameUnknown,
+					},
+				},
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: true,
+		},
+		{
+			name: "test errcode.ErrorResponse containing single error, different code",
+			err: &errcode.ErrorResponse{
+				Errors: errcode.Errors{
+					{
+						Code: errcode.ErrorCodeUnauthorized,
+					},
+				},
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: false,
+		},
+		{
+			name: "test errcode.ErrorResponse containing multiple errors, same code",
+			err: &errcode.ErrorResponse{
+				Errors: errcode.Errors{
+					{
+						Code: errcode.ErrorCodeNameUnknown,
+					},
+					{
+						Code: errcode.ErrorCodeUnauthorized,
+					},
+				},
+			},
+			code: errcode.ErrorCodeNameUnknown,
+			want: false,
+		},
+		{
+			name: "test unstructured error",
+			err:  errors.New(errcode.ErrorCodeNameUnknown),
+			code: errcode.ErrorCodeNameUnknown,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsErrorCode(tt.err, tt.code); got != tt.want {
+				t.Errorf("IsErrorCode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -45,8 +45,8 @@ import (
 )
 
 const (
-	// dockerContentDigestHeader - The Docker-Content-Digest header, if present on
-	// the response, returns the canonical digest of the uploaded blob.
+	// dockerContentDigestHeader - The Docker-Content-Digest header, if present
+	// on the response, returns the canonical digest of the uploaded blob.
 	// See https://docs.docker.com/registry/spec/api/#digest-header
 	// See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull
 	dockerContentDigestHeader = "Docker-Content-Digest"

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -131,7 +131,7 @@ type Repository struct {
 
 	// referrersPingLock locks the pingReferrersAPI() method and allows only
 	// one go-routine to send the request.
-	referrersPingLock *sync.Mutex
+	referrersPingLock sync.Mutex
 }
 
 // NewRepository creates a client to the remote repository identified by a
@@ -143,8 +143,7 @@ func NewRepository(reference string) (*Repository, error) {
 		return nil, err
 	}
 	return &Repository{
-		Reference:         ref,
-		referrersPingLock: &sync.Mutex{},
+		Reference: ref,
 	}, nil
 }
 

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -50,7 +50,9 @@ const (
 	// See https://docs.docker.com/registry/spec/api/#digest-header
 	// See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull
 	dockerContentDigestHeader = "Docker-Content-Digest"
-	zeroDigest                = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	// zeroDigest represents a digest that consists of zeros. zeroDigest is used
+	// for pinging Referrers API.
+	zeroDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 )
 
 // referrersState represents the state of Referrers API.
@@ -1310,7 +1312,6 @@ func (r *Repository) pingReferrersAPI(ctx context.Context) (bool, error) {
 	case referrersStateUnsupported:
 		return false, nil
 	}
-
 	// referrers state is unknown
 	ref := r.Reference
 	ref.Reference = zeroDigest

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -985,11 +985,11 @@ func (s *manifestStore) indexReferrersForDelete(ctx context.Context, desc ocispe
 	}
 
 	subject := *manifest.Subject
-	yes, err := s.repo.pingReferrersAPI(ctx)
+	ok, err := s.repo.pingReferrersAPI(ctx)
 	if err != nil {
 		return err
 	}
-	if yes {
+	if ok {
 		// referrers API is available, no client-side indexing needed
 		return nil
 	}
@@ -1250,11 +1250,11 @@ func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.
 		return nil
 	}
 
-	yes, err := s.repo.pingReferrersAPI(ctx)
+	ok, err := s.repo.pingReferrersAPI(ctx)
 	if err != nil {
 		return err
 	}
-	if yes {
+	if ok {
 		// referrers API is available, no client-side indexing needed
 		return nil
 	}

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1248,8 +1248,8 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
-	}); !errors.Is(err, errdef.ErrNotFound) {
-		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}); err == nil {
+		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
@@ -1467,8 +1467,8 @@ func TestRepository_Referrers_RepositoryNotFound(t *testing.T) {
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
-	}); !errors.Is(err, errdef.ErrNotFound) {
-		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}); err == nil {
+		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
@@ -5495,9 +5495,8 @@ func TestRepository_pingReferrersAPI_RepositoryNotFound(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	_, err = repo.pingReferrersAPI(ctx)
-	if !errors.Is(err, errdef.ErrNotFound) {
-		t.Fatalf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	if _, err = repo.pingReferrersAPI(ctx); err == nil {
+		t.Fatalf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -5344,7 +5344,7 @@ func Test_generateIndex(t *testing.T) {
 	}
 }
 
-func TestRepository_pingReferrersAPI(t *testing.T) {
+func TestRepository_pingReferrers(t *testing.T) {
 	// referrers available
 	count := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -5375,36 +5375,36 @@ func TestRepository_pingReferrersAPI(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	got, err := repo.pingReferrersAPI(ctx)
+	got, err := repo.pingReferrers(ctx)
 	if err != nil {
-		t.Errorf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.pingReferrers() error = %v, wantErr %v", err, nil)
 	}
 	if got != true {
-		t.Errorf("Repository.pingReferrersAPI() = %v, want %v", got, true)
+		t.Errorf("Repository.pingReferrers() = %v, want %v", got, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.pingReferrersAPI()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 	}
 
 	// 2nd call
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
-	got, err = repo.pingReferrersAPI(ctx)
+	got, err = repo.pingReferrers(ctx)
 	if err != nil {
-		t.Errorf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.pingReferrers() error = %v, wantErr %v", err, nil)
 	}
 	if got != true {
-		t.Errorf("Repository.pingReferrersAPI() = %v, want %v", got, true)
+		t.Errorf("Repository.pingReferrers() = %v, want %v", got, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.pingReferrersAPI()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 	}
 
 	// referrers unavailable
@@ -5437,40 +5437,40 @@ func TestRepository_pingReferrersAPI(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	got, err = repo.pingReferrersAPI(ctx)
+	got, err = repo.pingReferrers(ctx)
 	if err != nil {
-		t.Errorf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.pingReferrers() error = %v, wantErr %v", err, nil)
 	}
 	if got != false {
-		t.Errorf("Repository.pingReferrersAPI() = %v, want %v", got, false)
+		t.Errorf("Repository.pingReferrers() = %v, want %v", got, false)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.pingReferrersAPI()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 	}
 
 	// 2nd call
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
 	}
-	got, err = repo.pingReferrersAPI(ctx)
+	got, err = repo.pingReferrers(ctx)
 	if err != nil {
-		t.Errorf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.pingReferrers() error = %v, wantErr %v", err, nil)
 	}
 	if got != false {
-		t.Errorf("Repository.pingReferrersAPI() = %v, want %v", got, false)
+		t.Errorf("Repository.pingReferrers() = %v, want %v", got, false)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.pingReferrersAPI()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 	}
 }
 
-func TestRepository_pingReferrersAPI_RepositoryNotFound(t *testing.T) {
+func TestRepository_pingReferrers_RepositoryNotFound(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest {
 			w.WriteHeader(http.StatusNotFound)
@@ -5495,15 +5495,15 @@ func TestRepository_pingReferrersAPI_RepositoryNotFound(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	if _, err = repo.pingReferrersAPI(ctx); err == nil {
-		t.Fatalf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, true)
+	if _, err = repo.pingReferrers(ctx); err == nil {
+		t.Fatalf("Repository.pingReferrers() error = %v, wantErr %v", err, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
 }
 
-func TestRepository_pingReferrersAPI_Concurrent(t *testing.T) {
+func TestRepository_pingReferrers_Concurrent(t *testing.T) {
 	// referrers available
 	var count int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -5539,12 +5539,12 @@ func TestRepository_pingReferrersAPI_Concurrent(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		eg.Go(func() func() error {
 			return func() error {
-				got, err := repo.pingReferrersAPI(egCtx)
+				got, err := repo.pingReferrers(egCtx)
 				if err != nil {
-					t.Fatalf("Repository.pingReferrersAPI() error = %v, wantErr %v", err, nil)
+					t.Fatalf("Repository.pingReferrers() error = %v, wantErr %v", err, nil)
 				}
 				if got != true {
-					t.Errorf("Repository.pingReferrersAPI() = %v, want %v", got, true)
+					t.Errorf("Repository.pingReferrers() = %v, want %v", got, true)
 				}
 				return nil
 			}
@@ -5555,7 +5555,7 @@ func TestRepository_pingReferrersAPI_Concurrent(t *testing.T) {
 	}
 
 	if got := atomic.LoadInt32(&count); got != 1 {
-		t.Errorf("count(Repository.pingReferrersAPI()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -5221,6 +5221,13 @@ func Test_getReferrersTag(t *testing.T) {
 		want string
 	}{
 		{
+			name: "zero digest",
+			desc: ocispec.Descriptor{
+				Digest: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+			},
+			want: "sha256-0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
 			name: "sha256",
 			desc: ocispec.Descriptor{
 				Digest: "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
@@ -5338,7 +5345,7 @@ func Test_generateIndex(t *testing.T) {
 	}
 }
 
-func TestRepository_isReferrersAPIAvailable(t *testing.T) {
+func TestRepository_PingReferrersAPI(t *testing.T) {
 	manifest := []byte(`{"layers":[]}`)
 	manifestDesc := ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageManifest,
@@ -5376,36 +5383,36 @@ func TestRepository_isReferrersAPIAvailable(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	got, err := repo.isReferrersAPIAvailable(ctx, manifestDesc)
+	got, err := repo.PingReferrersAPI(ctx)
 	if err != nil {
-		t.Errorf("Repository.isReferrersAPIAvailable() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.PingReferrersAPI() error = %v, wantErr %v", err, nil)
 	}
 	if got != true {
-		t.Errorf("Repository.isReferrersAPIAvailable() = %v, want %v", got, true)
+		t.Errorf("Repository.PingReferrersAPI() = %v, want %v", got, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.isReferrersAPIAvailable()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.PingReferrersAPI()) = %v, want %v", count, 1)
 	}
 
 	// 2nd call
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
-	got, err = repo.isReferrersAPIAvailable(ctx, manifestDesc)
+	got, err = repo.PingReferrersAPI(ctx)
 	if err != nil {
-		t.Errorf("Repository.isReferrersAPIAvailable() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.PingReferrersAPI() error = %v, wantErr %v", err, nil)
 	}
 	if got != true {
-		t.Errorf("Repository.isReferrersAPIAvailable() = %v, want %v", got, true)
+		t.Errorf("Repository.PingReferrersAPI() = %v, want %v", got, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.isReferrersAPIAvailable()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.PingReferrersAPI()) = %v, want %v", count, 1)
 	}
 
 	// referrers unavailable
@@ -5438,35 +5445,35 @@ func TestRepository_isReferrersAPIAvailable(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	got, err = repo.isReferrersAPIAvailable(ctx, manifestDesc)
+	got, err = repo.PingReferrersAPI(ctx)
 	if err != nil {
-		t.Errorf("Repository.isReferrersAPIAvailable() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.PingReferrersAPI() error = %v, wantErr %v", err, nil)
 	}
 	if got != false {
-		t.Errorf("Repository.isReferrersAPIAvailable() = %v, want %v", got, false)
+		t.Errorf("Repository.PingReferrersAPI() = %v, want %v", got, false)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.isReferrersAPIAvailable()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.PingReferrersAPI()) = %v, want %v", count, 1)
 	}
 
 	// 2nd call
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
 	}
-	got, err = repo.isReferrersAPIAvailable(ctx, manifestDesc)
+	got, err = repo.PingReferrersAPI(ctx)
 	if err != nil {
-		t.Errorf("Repository.isReferrersAPIAvailable() error = %v, wantErr %v", err, nil)
+		t.Errorf("Repository.PingReferrersAPI() error = %v, wantErr %v", err, nil)
 	}
 	if got != false {
-		t.Errorf("Repository.isReferrersAPIAvailable() = %v, want %v", got, false)
+		t.Errorf("Repository.PingReferrersAPI() = %v, want %v", got, false)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
 	}
 	if count != 1 {
-		t.Errorf("count(Repository.isReferrersAPIAvailable()) = %v, want %v", count, 1)
+		t.Errorf("count(Repository.PingReferrersAPI()) = %v, want %v", count, 1)
 	}
 }


### PR DESCRIPTION
1. Use zero digest (`sha256:0000000000000000000000000000000000000000000000000000000000000000`) for pinging referrers API
2. Check `NAME_UNKNOWN` error code

Related to #271
Related to #354 
Related to https://github.com/opencontainers/distribution-spec/issues/359
Signed-off-by: Lixia (Sylvia) Lei <lixlei@microsoft.com>