### PR TITLE
fix: avoid copying Repository mutex state

### DIFF
--- a/internal/slices/slice.go
+++ b/internal/slices/slice.go
@@ -1,0 +1,24 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slices
+
+// Clone returns a shallow copy of the slice.
+func Clone[S ~[]E, E any](s S) S {
+	if s == nil {
+		return nil
+	}
+	return append(make(S, 0, len(s)), s...)
+}

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -168,11 +168,5 @@ func (r *Registry) Repository(ctx context.Context, name string) (registry.Reposi
 		Registry:   r.Reference.Registry,
 		Repository: name,
 	}
-	if err := ref.ValidateRepository(); err != nil {
-		return nil, err
-	}
-
-	repo := Repository(r.RepositoryOptions)
-	repo.Reference = ref
-	return &repo, nil
+	return newRepositoryWithOptions(ref, &r.RepositoryOptions)
 }

--- a/registry/remote/registry_test.go
+++ b/registry/remote/registry_test.go
@@ -184,13 +184,12 @@ func TestRegistry_Repository(t *testing.T) {
 	reg.MaxMetadataBytes = 8 * 1024 * 1024
 
 	ctx := context.Background()
-	want := &Repository{}
-	*want = Repository(reg.RepositoryOptions)
-	want.Reference.Repository = "hello-world"
 	got, err := reg.Repository(ctx, "hello-world")
 	if err != nil {
 		t.Fatalf("Registry.Repository() error = %v", err)
 	}
+	reg.Reference.Repository = "hello-world"
+	want := (*Repository)(&reg.RepositoryOptions)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Registry.Repository() = %v, want %v", got, want)
 	}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -38,6 +38,7 @@ import (
 	"oras.land/oras-go/v2/internal/httputil"
 	"oras.land/oras-go/v2/internal/ioutil"
 	"oras.land/oras-go/v2/internal/registryutil"
+	"oras.land/oras-go/v2/internal/slices"
 	"oras.land/oras-go/v2/internal/syncutil"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -143,18 +144,11 @@ func newRepositoryWithOptions(ref registry.Reference, opts *RepositoryOptions) (
 		Client:               opts.Client,
 		Reference:            ref,
 		PlainHTTP:            opts.PlainHTTP,
-		ManifestMediaTypes:   cloneSlice(opts.ManifestMediaTypes),
+		ManifestMediaTypes:   slices.Clone(opts.ManifestMediaTypes),
 		TagListPageSize:      opts.TagListPageSize,
 		ReferrerListPageSize: opts.ReferrerListPageSize,
 		MaxMetadataBytes:     opts.MaxMetadataBytes,
 	}, nil
-}
-
-func cloneSlice[S ~[]E, E any](s S) S {
-	if s == nil {
-		return nil
-	}
-	return append(make(S, 0, len(s)), s...)
 }
 
 // SetReferrersCapability indicates the Referrers API capability of the remote

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -128,10 +128,12 @@ func NewRepository(reference string) (*Repository, error) {
 	}, nil
 }
 
-// newRepositoryWithOptions returns a Repository with the given reference and options.
-// RepositoryOptions are part of the Registry struct and may set defaults for the Registry.
-// RepositoryOptions share the same struct definition as Repository and therfore contain
-// unexported state that we must avoid copying around to different Repositories.
+// newRepositoryWithOptions returns a Repository with the given Reference and
+// RepositoryOptions.
+//
+// RepositoryOptions are part of the Registry struct and set its defaults.
+// RepositoryOptions shares the same struct definition as Repository, which
+// contains unexported state that must not be copied to multiple Repositories.
 // To handle this we explicitly copy only the fields that we want to reproduce.
 func newRepositoryWithOptions(ref registry.Reference, opts *RepositoryOptions) (*Repository, error) {
 	if err := ref.ValidateRepository(); err != nil {


### PR DESCRIPTION
The `Repository` struct contains mutex state (in the `sync.Mutex` and `syncutil.Pool`). When converting `RepositoryOptions` values to `Repository` values, this mutex state is copied. This change prevents the internal state from being copied by passing `RepositoryOptions` around by reference and explicitly copying the visible fields.