### PR TITLE
fix: attempt range query only if server explicitly supports

### DIFF
--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -185,6 +185,7 @@ func TestMain(m *testing.M) {
 		case p == fmt.Sprintf("/v2/%s/blobs/%s", exampleRepositoryName, exampleLayerDigest):
 			w.Header().Set("Content-Type", ocispec.MediaTypeImageLayer)
 			w.Header().Set("Docker-Content-Digest", string(exampleLayerDigest))
+			w.Header().Set("Accept-Ranges", "bytes")
 			var start, end = 0, len(exampleLayer) - 1
 			if h := r.Header.Get("Range"); h != "" {
 				w.WriteHeader(http.StatusPartialContent)

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -825,7 +825,6 @@ func (s *blobStore) FetchReference(ctx context.Context, reference string) (desc 
 
 		// check server range request capability.
 		// Docker spec allows range header form of "Range: bytes=<start>-<end>".
-		// The form of "Range: bytes=<start>-" is also acceptable.
 		// However, the remote server may still not RFC 7233 compliant.
 		// Reference: https://docs.docker.com/registry/spec/api/#blob
 		if rangeUnit := resp.Header.Get("Accept-Ranges"); rangeUnit == "bytes" {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -623,14 +623,6 @@ func (s *blobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io
 		return nil, err
 	}
 
-	// probe server range request ability.
-	// Docker spec allows range header form of "Range: bytes=<start>-<end>".
-	// However, the remote server may still not RFC 7233 compliant.
-	// Reference: https://docs.docker.com/registry/spec/api/#blob
-	if target.Size > 0 {
-		req.Header.Set("Range", fmt.Sprintf("bytes=0-%d", target.Size-1))
-	}
-
 	resp, err := s.repo.client().Do(req)
 	if err != nil {
 		return nil, err
@@ -646,9 +638,15 @@ func (s *blobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io
 		if size := resp.ContentLength; size != -1 && size != target.Size {
 			return nil, fmt.Errorf("%s %q: mismatch Content-Length", resp.Request.Method, resp.Request.URL)
 		}
+
+		// check server range request capability.
+		// Docker spec allows range header form of "Range: bytes=<start>-<end>".
+		// However, the remote server may still not RFC 7233 compliant.
+		// Reference: https://docs.docker.com/registry/spec/api/#blob
+		if rangeUnit := resp.Header.Get("Accept-Ranges"); rangeUnit == "bytes" {
+			return httputil.NewReadSeekCloser(s.repo.client(), req, resp.Body, target.Size), nil
+		}
 		return resp.Body, nil
-	case http.StatusPartialContent:
-		return httputil.NewReadSeekCloser(s.repo.client(), req, resp.Body, target.Size), nil
 	case http.StatusNotFound:
 		return nil, fmt.Errorf("%s: %w", target.Digest, errdef.ErrNotFound)
 	default:

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -2489,6 +2489,9 @@ func Test_BlobStore_FetchReference_Seek(t *testing.T) {
 		case "/v2/test/blobs/" + blobDesc.Digest.String():
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Docker-Content-Digest", blobDesc.Digest.String())
+			if seekable {
+				w.Header().Set("Accept-Ranges", "bytes")
+			}
 			rangeHeader := r.Header.Get("Range")
 			if !seekable || rangeHeader == "" {
 				w.WriteHeader(http.StatusOK)

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -45,7 +45,6 @@ import (
 )
 
 type testIOStruct struct {
-	name                    string
 	isTag                   bool
 	clientSuppliedReference string
 	serverCalculatedDigest  digest.Digest // for non-HEAD (body-containing) requests only
@@ -1967,6 +1966,9 @@ func Test_BlobStore_Fetch_Seek(t *testing.T) {
 		case "/v2/test/blobs/" + blobDesc.Digest.String():
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.Header().Set("Docker-Content-Digest", blobDesc.Digest.String())
+			if seekable {
+				w.Header().Set("Accept-Ranges", "bytes")
+			}
 			rangeHeader := r.Header.Get("Range")
 			if !seekable || rangeHeader == "" {
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Fixes #368 