### PR TITLE
fix: allow chunked responses via HEAD request fallback

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -818,7 +818,11 @@ func (s *blobStore) FetchReference(ctx context.Context, reference string) (desc 
 
 	switch resp.StatusCode {
 	case http.StatusOK: // server does not support seek as `Range` was ignored.
-		desc, err = generateBlobDescriptor(resp, refDigest)
+		if resp.ContentLength == -1 {
+			desc, err = s.Resolve(ctx, reference)
+		} else {
+			desc, err = generateBlobDescriptor(resp, refDigest)
+		}
 		if err != nil {
 			return ocispec.Descriptor{}, nil, err
 		}
@@ -1044,7 +1048,11 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		desc, err = s.generateDescriptor(resp, ref, req.Method)
+		if resp.ContentLength == -1 {
+			desc, err = s.Resolve(ctx, reference)
+		} else {
+			desc, err = s.generateDescriptor(resp, ref, req.Method)
+		}
 		if err != nil {
 			return ocispec.Descriptor{}, nil, err
 		}


### PR DESCRIPTION
The `oras` client and Go SDK may fail when a registry using HTTP/1.1 responds with a chunked response body, as the `content-length` header will be absent (`resp.ContentLength == -1`).

This adds support for registry servers such as `zot` which respond with `transfer-encoding: chunked` responses. 

I have not added tests, being unfamiliar with the testing harness in this library. Contributions to this branch are welcome from maintainers to address that.

Fixes #374

Before:

```shell
# start Zot in one shell
docker run -p 5000:5000 ghcr.io/project-zot/zot-linux-amd64:latest
```

```shell
# in another shell

# start in an empty temp dir
cd $(mktemp -d)

# create 20 test artifacts:
for f in $(seq 1 20); do echo "$f" > "artifact-${f}.txt"; done

# push those to a zot registry:
oras push localhost:5000/foo/bar:v1.0 artifact-*.txt

# fetch the manifest
oras manifest fetch localhost:5000/foo/bar:v1.0
# Error: GET "http://localhost:5000/v2/foo/bar/manifests/v5.21.1": unknown response Content-Length
```

After:

```shell
oras manifest fetch localhost:5000/foo/bar:v5.21.1
# {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"application/vnd.unknown.artifact.v1",...
```

## Alternatives

I considered modifying `content.ReadAll`, however the word "safely" in the doc comment suggested to me there was a safety concern with allowing unbounded reads. If that's not accurate, then that would be the simplest change to make: allow `content.ReadAll()` to read from an OCI descriptor of length -1.

If that isn't possible, I'd recommend a refactoring of `registry.go`, removing `http.Response` typed arguments from various functions. Passing the response around is unsafe due to reading from `Body` having the side effect of invalidating future reads.