### PR TITLE
doc: make the default options displayed next to the option type on godoc

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -36,17 +36,13 @@ import (
 // defaultConcurrency is the default value of CopyGraphOptions.Concurrency.
 const defaultConcurrency = 3 // This value is consistent with dockerd and containerd.
 
-var (
-	// DefaultCopyOptions provides the default CopyOptions.
-	DefaultCopyOptions = CopyOptions{
-		CopyGraphOptions: DefaultCopyGraphOptions,
-	}
-	// DefaultCopyGraphOptions provides the default CopyGraphOptions.
-	DefaultCopyGraphOptions CopyGraphOptions
-)
-
 // errSkipDesc signals copyNode() to stop processing a descriptor.
 var errSkipDesc = errors.New("skip descriptor")
+
+// DefaultCopyOptions provides the default CopyOptions.
+var DefaultCopyOptions CopyOptions = CopyOptions{
+	CopyGraphOptions: DefaultCopyGraphOptions,
+}
 
 // CopyOptions contains parameters for oras.Copy.
 type CopyOptions struct {
@@ -85,6 +81,9 @@ func (opts *CopyOptions) WithTargetPlatform(p *ocispec.Platform) {
 // defaultCopyMaxMetadataBytes is the default value of
 // CopyGraphOptions.MaxMetadataBytes.
 const defaultCopyMaxMetadataBytes int64 = 4 * 1024 * 1024 // 4 MiB
+
+// DefaultCopyGraphOptions provides the default CopyGraphOptions.
+var DefaultCopyGraphOptions CopyGraphOptions
 
 // CopyGraphOptions contains parameters for oras.CopyGraph.
 type CopyGraphOptions struct {

--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -29,20 +29,19 @@ import (
 	"oras.land/oras-go/v2/registry"
 )
 
-var (
-	// DefaultExtendedCopyOptions provides the default ExtendedCopyOptions.
-	DefaultExtendedCopyOptions = ExtendedCopyOptions{
-		ExtendedCopyGraphOptions: DefaultExtendedCopyGraphOptions,
-	}
-	// DefaultExtendedCopyGraphOptions provides the default ExtendedCopyGraphOptions.
-	DefaultExtendedCopyGraphOptions = ExtendedCopyGraphOptions{
-		CopyGraphOptions: DefaultCopyGraphOptions,
-	}
-)
+// DefaultExtendedCopyOptions provides the default ExtendedCopyOptions.
+var DefaultExtendedCopyOptions ExtendedCopyOptions = ExtendedCopyOptions{
+	ExtendedCopyGraphOptions: DefaultExtendedCopyGraphOptions,
+}
 
 // ExtendedCopyOptions contains parameters for oras.ExtendedCopy.
 type ExtendedCopyOptions struct {
 	ExtendedCopyGraphOptions
+}
+
+// DefaultExtendedCopyGraphOptions provides the default ExtendedCopyGraphOptions.
+var DefaultExtendedCopyGraphOptions ExtendedCopyGraphOptions = ExtendedCopyGraphOptions{
+	CopyGraphOptions: DefaultCopyGraphOptions,
 }
 
 // ExtendedCopyGraphOptions contains parameters for oras.ExtendedCopyGraph.

--- a/pack.go
+++ b/pack.go
@@ -38,13 +38,11 @@ const (
 	MediaTypeUnknownArtifact = "application/vnd.unknown.artifact.v1"
 )
 
-var (
-	// ErrInvalidDateTimeFormat is returned by Pack() when
-	// AnnotationArtifactCreated or AnnotationCreated is provided, but its value
-	// is not in RFC 3339 format.
-	// Reference: https://www.rfc-editor.org/rfc/rfc3339#section-5.6
-	ErrInvalidDateTimeFormat = errors.New("invalid date and time format")
-)
+// ErrInvalidDateTimeFormat is returned by Pack() when
+// AnnotationArtifactCreated or AnnotationCreated is provided, but its value
+// is not in RFC 3339 format.
+// Reference: https://www.rfc-editor.org/rfc/rfc3339#section-5.6
+var ErrInvalidDateTimeFormat = errors.New("invalid date and time format")
 
 // PackOptions contains parameters for oras.Pack.
 type PackOptions struct {


### PR DESCRIPTION
**Typed** constants/variables are displayed next to the declaration of their type.

Resolves #304