### PR TITLE
refactor!: update the type of `Concurrency` options to `int`

### DIFF
--- a/content.go
+++ b/content.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	// defaultTagConcurrency is the default concurrency of tagging.
-	defaultTagConcurrency int64 = 5 // This value is consistent with dockerd
+	defaultTagConcurrency int = 5 // This value is consistent with dockerd
 
 	// defaultTagNMaxMetadataBytes is the default value of
 	// TagNOptions.MaxMetadataBytes.
@@ -58,7 +58,7 @@ var DefaultTagNOptions TagNOptions
 type TagNOptions struct {
 	// Concurrency limits the maximum number of concurrent tag tasks.
 	// If less than or equal to 0, a default (currently 5) is used.
-	Concurrency int64
+	Concurrency int
 
 	// MaxMetadataBytes limits the maximum size of metadata that can be cached
 	// in the memory.
@@ -118,7 +118,7 @@ func TagN(ctx context.Context, target Target, srcReference string, dstReferences
 			return err
 		}
 
-		eg, egCtx := syncutil.LimitGroup(ctx, int(opts.Concurrency))
+		eg, egCtx := syncutil.LimitGroup(ctx, opts.Concurrency)
 		for _, dstRef := range dstReferences {
 			eg.Go(func(dst string) func() error {
 				return func() error {
@@ -137,7 +137,7 @@ func TagN(ctx context.Context, target Target, srcReference string, dstReferences
 	if err != nil {
 		return err
 	}
-	eg, egCtx := syncutil.LimitGroup(ctx, int(opts.Concurrency))
+	eg, egCtx := syncutil.LimitGroup(ctx, opts.Concurrency)
 	for _, dstRef := range dstReferences {
 		eg.Go(func(dst string) func() error {
 			return func() error {
@@ -354,7 +354,7 @@ var DefaultTagBytesNOptions TagBytesNOptions
 type TagBytesNOptions struct {
 	// Concurrency limits the maximum number of concurrent tag tasks.
 	// If less than or equal to 0, a default (currently 5) is used.
-	Concurrency int64
+	Concurrency int
 }
 
 // TagBytesN describes the contentBytes using the given mediaType, pushes it,
@@ -369,7 +369,7 @@ func TagBytesN(ctx context.Context, target Target, mediaType string, contentByte
 	if opts.Concurrency <= 0 {
 		opts.Concurrency = defaultTagConcurrency
 	}
-	eg, egCtx := syncutil.LimitGroup(ctx, int(opts.Concurrency))
+	eg, egCtx := syncutil.LimitGroup(ctx, opts.Concurrency)
 	if refPusher, ok := target.(registry.ReferencePusher); ok {
 		for _, reference := range references {
 			eg.Go(func(ref string) func() error {

--- a/copy.go
+++ b/copy.go
@@ -34,7 +34,7 @@ import (
 )
 
 // defaultConcurrency is the default value of CopyGraphOptions.Concurrency.
-const defaultConcurrency = 3 // This value is consistent with dockerd and containerd.
+const defaultConcurrency int = 3 // This value is consistent with dockerd and containerd.
 
 // errSkipDesc signals copyNode() to stop processing a descriptor.
 var errSkipDesc = errors.New("skip descriptor")
@@ -89,7 +89,7 @@ var DefaultCopyGraphOptions CopyGraphOptions
 type CopyGraphOptions struct {
 	// Concurrency limits the maximum number of concurrent copy tasks.
 	// If less than or equal to 0, a default (currently 3) is used.
-	Concurrency int64
+	Concurrency int
 	// MaxMetadataBytes limits the maximum size of the metadata that can be
 	// cached in the memory.
 	// If less than or equal to 0, a default (currently 4 MiB) is used.
@@ -178,7 +178,7 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 	if opts.Concurrency <= 0 {
 		opts.Concurrency = defaultConcurrency
 	}
-	limiter := semaphore.NewWeighted(opts.Concurrency)
+	limiter := semaphore.NewWeighted(int64(opts.Concurrency))
 	// track content status
 	tracker := status.NewTracker()
 

--- a/copy_test.go
+++ b/copy_test.go
@@ -1488,7 +1488,7 @@ func TestCopyGraph_WithConcurrencyLimit(t *testing.T) {
 	opts := oras.DefaultCopyGraphOptions
 	for i := 1; i <= directSuccessorsNum; i++ {
 		dst := cas.NewMemory()
-		opts.Concurrency = int64(i)
+		opts.Concurrency = i
 		if err := oras.CopyGraph(ctx, src, dst, root, opts); err != nil {
 			t.Fatalf("CopyGraph(concurrency: %d) error = %v, wantErr %v", i, err, false)
 		}


### PR DESCRIPTION
BREAKING CHANGE: Changed the type of `Concurrency` options to `int` from `int64`

Resolves #375 
Signed-off-by: Lixia (Sylvia) Lei <lixlei@microsoft.com>