### PR TITLE
feat: change foreign layer error message at repository.Fetch()

### DIFF
--- a/content.go
+++ b/content.go
@@ -26,6 +26,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/docker"
 	"oras.land/oras-go/v2/internal/interfaces"
 	"oras.land/oras-go/v2/internal/platform"
@@ -273,6 +274,9 @@ func Fetch(ctx context.Context, target ReadOnlyTarget, reference string, opts Fe
 		}
 		rc, err := target.Fetch(ctx, desc)
 		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) && descriptor.IsForeignLayer(desc) {
+				return ocispec.Descriptor{}, nil, fmt.Errorf("the artifact with foreign layer %s is not supported: %w", desc.Digest, err)
+			}
 			return ocispec.Descriptor{}, nil, err
 		}
 		return desc, rc, nil
@@ -291,6 +295,9 @@ func Fetch(ctx context.Context, target ReadOnlyTarget, reference string, opts Fe
 	proxy.StopCaching = true
 	rc, err := proxy.Fetch(ctx, desc)
 	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) && descriptor.IsForeignLayer(desc) {
+			return ocispec.Descriptor{}, nil, fmt.Errorf("the artifact with foreign layer %s is not supported: %w", desc.Digest, err)
+		}
 		return ocispec.Descriptor{}, nil, err
 	}
 	return desc, rc, nil

--- a/content.go
+++ b/content.go
@@ -26,7 +26,6 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
-	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/docker"
 	"oras.land/oras-go/v2/internal/interfaces"
 	"oras.land/oras-go/v2/internal/platform"
@@ -274,9 +273,6 @@ func Fetch(ctx context.Context, target ReadOnlyTarget, reference string, opts Fe
 		}
 		rc, err := target.Fetch(ctx, desc)
 		if err != nil {
-			if errors.Is(err, errdef.ErrNotFound) && descriptor.IsForeignLayer(desc) {
-				return ocispec.Descriptor{}, nil, fmt.Errorf("the artifact with foreign layer %s is not supported: %w", desc.Digest, err)
-			}
 			return ocispec.Descriptor{}, nil, err
 		}
 		return desc, rc, nil
@@ -295,9 +291,6 @@ func Fetch(ctx context.Context, target ReadOnlyTarget, reference string, opts Fe
 	proxy.StopCaching = true
 	rc, err := proxy.Fetch(ctx, desc)
 	if err != nil {
-		if errors.Is(err, errdef.ErrNotFound) && descriptor.IsForeignLayer(desc) {
-			return ocispec.Descriptor{}, nil, fmt.Errorf("the artifact with foreign layer %s is not supported: %w", desc.Digest, err)
-		}
 		return ocispec.Descriptor{}, nil, err
 	}
 	return desc, rc, nil

--- a/copy.go
+++ b/copy.go
@@ -26,6 +26,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/platform"
 	"oras.land/oras-go/v2/internal/registryutil"
 	"oras.land/oras-go/v2/internal/status"
@@ -258,6 +259,9 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor) error {
 	rc, err := src.Fetch(ctx, desc)
 	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) && descriptor.IsForeignLayer(desc) {
+			return fmt.Errorf("the artifact with foreign layer %s is not supported: %w", desc.Digest, err)
+		}
 		return err
 	}
 	defer rc.Close()

--- a/copy.go
+++ b/copy.go
@@ -259,7 +259,7 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor) error {
 	rc, err := src.Fetch(ctx, desc)
 	if err != nil {
-		if errors.Is(err, errdef.ErrNotFound) && descriptor.IsForeignLayer(desc) {
+		if descriptor.IsForeignLayer(desc) && errors.Is(err, errdef.ErrNotFound) {
 			return fmt.Errorf("the artifact with foreign layer %s is not supported: %w", desc.Digest, err)
 		}
 		return err

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -47,6 +47,7 @@ func FromOCI(desc ocispec.Descriptor) Descriptor {
 	}
 }
 
+// IsForeignLayer checks if a descriptor describes a foreign layer.
 func IsForeignLayer(desc ocispec.Descriptor) bool {
 	switch desc.MediaType {
 	case ocispec.MediaTypeImageLayerNonDistributable,

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -18,6 +18,7 @@ package descriptor
 import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/docker"
 )
 
 // Descriptor contains the minimun information to describe the disposition of
@@ -43,5 +44,17 @@ func FromOCI(desc ocispec.Descriptor) Descriptor {
 		MediaType: desc.MediaType,
 		Digest:    desc.Digest,
 		Size:      desc.Size,
+	}
+}
+
+func IsForeignLayer(desc ocispec.Descriptor) bool {
+	switch desc.MediaType {
+	case ocispec.MediaTypeImageLayerNonDistributable,
+		ocispec.MediaTypeImageLayerNonDistributableGzip,
+		ocispec.MediaTypeImageLayerNonDistributableZstd,
+		docker.MediaTypeForeignLayer:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/docker/mediatype.go
+++ b/internal/docker/mediatype.go
@@ -20,4 +20,5 @@ const (
 	MediaTypeConfig       = "application/vnd.docker.container.image.v1+json"
 	MediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	MediaTypeManifest     = "application/vnd.docker.distribution.manifest.v2+json"
+	MediaTypeForeignLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
 )


### PR DESCRIPTION
Resolves #319

Current result with oras-cli:
```
$ oras copy docker.io/library/hello-world@sha256:314cc0309465c7be2936df274b258c843f5a49eb21f63b719d60b51564070b8f wxxacr.azurecr.io/temp439:test00

$ Error: the artifact with foreign layer sha256:5ead999142ecce15e02523c49706a633fa708374d94bb65a254e3a3c117d609b is not supported: sha256:5ead999142ecce15e02523c49706a633fa708374d94bb65a254e3a3c117d609b: not found
```

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>