### PR TITLE
refactor: refactor OCI store to fully support `Predecessors()` and `Resolve()`

### DIFF
--- a/content/descriptor.go
+++ b/content/descriptor.go
@@ -18,16 +18,14 @@ package content
 import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/descriptor"
 )
-
-// defaultMediaType is the media type used when no media type is specified.
-const defaultMediaType string = "application/octet-stream"
 
 // NewDescriptorFromBytes returns a descriptor, given the content and media type.
 // If no media type is specified, "application/octet-stream" will be used.
 func NewDescriptorFromBytes(mediaType string, content []byte) ocispec.Descriptor {
 	if mediaType == "" {
-		mediaType = defaultMediaType
+		mediaType = descriptor.DefaultMediaType
 	}
 	return ocispec.Descriptor{
 		MediaType: mediaType,

--- a/content/descriptor_test.go
+++ b/content/descriptor_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/descriptor"
 )
 
 func TestGenerateDescriptor(t *testing.T) {
@@ -56,7 +57,7 @@ func TestGenerateDescriptor(t *testing.T) {
 			name: "missing media type",
 			args: args{contentBar, ""},
 			want: ocispec.Descriptor{
-				MediaType: defaultMediaType,
+				MediaType: descriptor.DefaultMediaType,
 				Digest:    digest.FromBytes(contentBar),
 				Size:      int64(len(contentBar))},
 		},

--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -203,12 +203,12 @@ func (s *Store) ensureOCILayoutFile() error {
 	}
 	defer layoutFile.Close()
 
-	var layout *ocispec.ImageLayout
+	var layout ocispec.ImageLayout
 	err = json.NewDecoder(layoutFile).Decode(&layout)
 	if err != nil {
 		return fmt.Errorf("failed to decode OCI layout file: %w", err)
 	}
-	return validateOCILayout(*layout)
+	return validateOCILayout(&layout)
 }
 
 // loadIndexFile reads index.json from the file system.
@@ -227,10 +227,12 @@ func (s *Store) loadIndexFile(ctx context.Context) error {
 	}
 	defer indexFile.Close()
 
-	if err := json.NewDecoder(indexFile).Decode(&s.index); err != nil {
+	var index ocispec.Index
+	if err := json.NewDecoder(indexFile).Decode(&index); err != nil {
 		return fmt.Errorf("failed to decode index file: %w", err)
 	}
-	return loadIndex(ctx, *s.index, s.storage, s.tagResolver, s.graph)
+	s.index = &index
+	return loadIndex(ctx, s.index, s.storage, s.tagResolver, s.graph)
 }
 
 // SaveIndex writes the `index.json` file to the file system.

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -766,6 +766,15 @@ func TestStore_ExistingStore(t *testing.T) {
 		t.Errorf("Store.Resolve() = %v, want %v", gotDesc, artifactRootDesc)
 	}
 
+	// test resolving blob by digest
+	gotDesc, err = anotherS.Resolve(ctx, descs[0].Digest.String())
+	if err != nil {
+		t.Fatal("Store: Resolve() error =", err)
+	}
+	if want := descs[0]; gotDesc.Size != want.Size || gotDesc.Digest != want.Digest {
+		t.Errorf("Store.Resolve() = %v, want %v", gotDesc, want)
+	}
+
 	// test fetching OCI root index
 	exists, err := anotherS.Exists(ctx, indexRoot)
 	if err != nil {

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -121,7 +121,7 @@ func TestStore_Success(t *testing.T) {
 		t.Errorf("resolver.Map() = %v, want %v", got, want)
 	}
 
-	// test resolve blob by digest
+	// test resolving blob by digest
 	gotDesc, err := s.Resolve(ctx, blobDesc.Digest.String())
 	if err != nil {
 		t.Fatal("Store.Resolve() error =", err)
@@ -130,7 +130,7 @@ func TestStore_Success(t *testing.T) {
 		t.Errorf("Store.Resolve() = %v, want %v", gotDesc, blobDesc)
 	}
 
-	// test resolve manifest by digest
+	// test resolving manifest by digest
 	gotDesc, err = s.Resolve(ctx, manifestDesc.Digest.String())
 	if err != nil {
 		t.Fatal("Store.Resolve() error =", err)
@@ -148,7 +148,7 @@ func TestStore_Success(t *testing.T) {
 		t.Errorf("resolver.Map() = %v, want %v", got, want)
 	}
 
-	// test resolve manifest by tag
+	// test resolving manifest by tag
 	gotDesc, err = s.Resolve(ctx, ref)
 	if err != nil {
 		t.Fatal("Store.Resolve() error =", err)
@@ -368,7 +368,7 @@ func TestStore_DisableAutoSaveIndex(t *testing.T) {
 		t.Errorf("resolver.Map() = %v, want %v", got, want)
 	}
 
-	// test resolve by digest
+	// test resolving by digest
 	gotDesc, err := s.Resolve(ctx, desc.Digest.String())
 	if err != nil {
 		t.Fatal("Store.Resolve() error =", err)
@@ -386,7 +386,7 @@ func TestStore_DisableAutoSaveIndex(t *testing.T) {
 		t.Errorf("resolver.Map() = %v, want %v", got, want)
 	}
 
-	// test resolve by digest
+	// test resolving by digest
 	gotDesc, err = s.Resolve(ctx, ref)
 	if err != nil {
 		t.Fatal("Store.Resolve() error =", err)

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -109,7 +109,7 @@ func TestStore_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
-	internalResolver := s.resolver
+	internalResolver := s.tagResolver
 	if got, want := len(internalResolver.Map()), 1; got != want {
 		t.Errorf("resolver.Map() = %v, want %v", got, want)
 	}
@@ -347,7 +347,7 @@ func TestStore_DisableAutoSaveIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
-	internalResolver := s.resolver
+	internalResolver := s.tagResolver
 	if got, want := len(internalResolver.Map()), 1; got != want {
 		t.Errorf("resolver.Map() = %v, want %v", got, want)
 	}
@@ -409,7 +409,7 @@ func TestStore_RepeatTag(t *testing.T) {
 	ref := "foobar"
 
 	// get internal resolver
-	internalResolver := s.resolver
+	internalResolver := s.tagResolver
 
 	// first tag a manifest
 	manifest := []byte(`{"layers":[]}`)

--- a/content/oci/readonlyoci.go
+++ b/content/oci/readonlyoci.go
@@ -177,9 +177,13 @@ func resolveBlob(fsys fs.FS, dgst string) (ocispec.Descriptor, error) {
 		return ocispec.Descriptor{}, err
 	}
 	fi, err := fs.Stat(fsys, path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return ocispec.Descriptor{}, errdef.ErrNotFound
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ocispec.Descriptor{}, errdef.ErrNotFound
+		}
+		return ocispec.Descriptor{}, err
 	}
+
 	return ocispec.Descriptor{
 		MediaType: descriptor.DefaultMediaType,
 		Size:      fi.Size(),

--- a/content/oci/readonlyoci.go
+++ b/content/oci/readonlyoci.go
@@ -87,7 +87,15 @@ func (s *ReadOnlyStore) Resolve(ctx context.Context, reference string) (ocispec.
 		return ocispec.Descriptor{}, errdef.ErrMissingReference
 	}
 
-	return s.resolver.Resolve(ctx, reference)
+	desc, err := s.resolver.Resolve(ctx, reference)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return ocispec.Descriptor{
+		MediaType: desc.MediaType,
+		Size:      desc.Size,
+		Digest:    desc.Digest,
+	}, nil
 }
 
 // Predecessors returns the nodes directly pointing to the current node.

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -128,7 +128,7 @@ func TestReadOnlyStore(t *testing.T) {
 		t.Fatal("NewFromFS() error =", err)
 	}
 
-	// test resolve subject by digest
+	// test resolving subject by digest
 	gotDesc, err := s.Resolve(ctx, descs[2].Digest.String())
 	if err != nil {
 		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
@@ -137,7 +137,7 @@ func TestReadOnlyStore(t *testing.T) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
 	}
 
-	// test resolve subject by tag
+	// test resolving subject by tag
 	gotDesc, err = s.Resolve(ctx, subjectTag)
 	if err != nil {
 		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
@@ -146,7 +146,7 @@ func TestReadOnlyStore(t *testing.T) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
 	}
 
-	// test resolve artifact by digest
+	// test resolving artifact by digest
 	gotDesc, err = s.Resolve(ctx, descs[3].Digest.String())
 	if err != nil {
 		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
@@ -155,7 +155,7 @@ func TestReadOnlyStore(t *testing.T) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
 	}
 
-	// test resolve blob by digest
+	// test resolving blob by digest
 	gotDesc, err = s.Resolve(ctx, descs[0].Digest.String())
 	if err != nil {
 		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
@@ -452,7 +452,7 @@ func TestReadOnlyStore_TarFS(t *testing.T) {
 		},
 	}
 
-	// test Resolve by tag
+	// test resolving by tag
 	for _, desc := range descs {
 		gotDesc, err := s.Resolve(ctx, desc.Digest.String())
 		if err != nil {
@@ -462,7 +462,7 @@ func TestReadOnlyStore_TarFS(t *testing.T) {
 			t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
 		}
 	}
-	// test Resolve by tag
+	// test resolving by tag
 	gotDesc, err := s.Resolve(ctx, "latest")
 	if err != nil {
 		t.Fatal("ReadOnlyStore: Resolve() error =", err)

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -101,7 +101,6 @@ func TestReadOnlyStore(t *testing.T) {
 			SchemaVersion: 2, // historical value
 		},
 		Manifests: []ocispec.Descriptor{
-			descs[2],
 			subjectWithRef,
 			descs[3],
 		},
@@ -132,7 +131,7 @@ func TestReadOnlyStore(t *testing.T) {
 	if err != nil {
 		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
 	}
-	if want := descs[2]; !reflect.DeepEqual(gotDesc, want) {
+	if want := subjectWithRef; !reflect.DeepEqual(gotDesc, want) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
 	}
 

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -88,9 +88,6 @@ func TestReadOnlyStore(t *testing.T) {
 	subjectTag := "subject"
 	subjectWithRef := descs[2]
 	subjectWithRef.Annotations = map[string]string{ocispec.AnnotationRefName: subjectTag}
-	artifactTag := "foobar"
-	artifactWithRef := descs[3]
-	artifactWithRef.Annotations = map[string]string{ocispec.AnnotationRefName: artifactTag}
 
 	layout := ocispec.ImageLayout{
 		Version: ocispec.ImageLayoutVersion,
@@ -104,22 +101,9 @@ func TestReadOnlyStore(t *testing.T) {
 			SchemaVersion: 2, // historical value
 		},
 		Manifests: []ocispec.Descriptor{
-			{
-				MediaType: descs[2].MediaType,
-				Digest:    descs[2].Digest,
-				Size:      descs[2].Size,
-				Annotations: map[string]string{
-					ocispec.AnnotationRefName: subjectTag,
-				},
-			},
-			{
-				MediaType: descs[3].MediaType,
-				Digest:    descs[3].Digest,
-				Size:      descs[3].Size,
-				Annotations: map[string]string{
-					ocispec.AnnotationRefName: artifactTag,
-				},
-			},
+			descs[2],
+			subjectWithRef,
+			descs[3],
 		},
 	}
 	indexJSON, err := json.Marshal(index)
@@ -143,12 +127,30 @@ func TestReadOnlyStore(t *testing.T) {
 		t.Fatal("NewFromFS() error =", err)
 	}
 
-	// test resolve subject tag
-	gotDesc, err := s.Resolve(ctx, subjectTag)
+	// test resolve subject by digest
+	gotDesc, err := s.Resolve(ctx, descs[2].Digest.String())
+	if err != nil {
+		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
+	}
+	if want := descs[2]; !reflect.DeepEqual(gotDesc, want) {
+		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
+	}
+
+	// test resolve subject by tag
+	gotDesc, err = s.Resolve(ctx, subjectTag)
 	if err != nil {
 		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
 	}
 	if want := subjectWithRef; !reflect.DeepEqual(gotDesc, want) {
+		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
+	}
+
+	// test resolve artifact by digest
+	gotDesc, err = s.Resolve(ctx, descs[3].Digest.String())
+	if err != nil {
+		t.Error("ReadOnlyReadOnlyStore.Resolve() error =", err)
+	}
+	if want := descs[3]; !reflect.DeepEqual(gotDesc, want) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
 	}
 
@@ -182,10 +184,10 @@ func TestReadOnlyStore(t *testing.T) {
 
 	// test predecessors
 	wants := [][]ocispec.Descriptor{
-		{subjectWithRef},  // blob 0
-		{subjectWithRef},  // blob 1
-		{artifactWithRef}, // blob 2,
-		{},                // blob 3
+		{descs[2]}, // blob 0
+		{descs[2]}, // blob 1
+		{descs[3]}, // blob 2,
+		{},         // blob 3
 	}
 	for i, want := range wants {
 		predecessors, err := s.Predecessors(ctx, descs[i])
@@ -238,7 +240,6 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 		}
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
-
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
 		var manifest ocispec.Artifact
 		manifest.Subject = &subject
@@ -283,40 +284,15 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// test artifact root node
-	artifactRootDesc := descs[12]
-	// tag artifact manifest by digest
-	dgstRef := "@" + artifactRootDesc.Digest.String()
-	artifactRootDescWithRef := artifactRootDesc
-	artifactRootDescWithRef.Annotations = map[string]string{
-		ocispec.AnnotationRefName: dgstRef,
+	// tag index root
+	indexRoot := descs[10]
+	tag := "latest"
+	indexRootWithRef := indexRoot
+	indexRootWithRef.Annotations = map[string]string{
+		ocispec.AnnotationRefName: tag,
 	}
-	if err := s.Tag(ctx, artifactRootDesc, dgstRef); err != nil {
-		t.Fatal("ReadOnlyStore.Tag(artifactRootDesc) error =", err)
-	}
-
-	// OCI root node
-	ociRootRef := "root"
-	ociRootIndex := ocispec.Index{
-		Manifests: []ocispec.Descriptor{
-			descs[7],  // can reach descs[0:6] and descs[7]
-			descs[14], // can reach descs[0:10], descs[13] and descs[14]
-		},
-	}
-	ociRootIndexJSON, err := json.Marshal(ociRootIndex)
-	if err != nil {
-		t.Fatal("json.Marshal() error =", err)
-	}
-	ociRootIndexDesc := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageIndex,
-		Digest:    digest.FromBytes(ociRootIndexJSON),
-		Size:      int64(len(ociRootIndexJSON)),
-	}
-	if err := s.Push(ctx, ociRootIndexDesc, bytes.NewReader(ociRootIndexJSON)); err != nil {
-		t.Fatal("ReadOnlyStore.Push(ociRootIndex) error =", err)
-	}
-	if err := s.Tag(ctx, ociRootIndexDesc, ociRootRef); err != nil {
-		t.Fatal("ReadOnlyStore.Tag(ociRootIndex) error =", err)
+	if err := s.Tag(ctx, indexRoot, tag); err != nil {
+		t.Fatal("Tag() error =", err)
 	}
 
 	// test read-only store
@@ -325,52 +301,32 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 		t.Fatal("New() error =", err)
 	}
 
-	// test resolving artifact manifest
-	gotDesc, err := readonlyS.Resolve(ctx, dgstRef)
+	// test resolving index root by tag
+	gotDesc, err := readonlyS.Resolve(ctx, tag)
 	if err != nil {
-		t.Fatal("AnotherStore: Resolve() error =", err)
+		t.Fatal("ReadOnlyStore: Resolve() error =", err)
 	}
-	if !reflect.DeepEqual(gotDesc, artifactRootDescWithRef) {
-		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, artifactRootDescWithRef)
+	if !reflect.DeepEqual(gotDesc, indexRootWithRef) {
+		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, indexRootWithRef)
 	}
 
-	// verify OCI root index
-	gotDesc, err = readonlyS.Resolve(ctx, ociRootRef)
+	// test resolving index root by digest
+	gotDesc, err = readonlyS.Resolve(ctx, indexRoot.Digest.String())
 	if err != nil {
-		t.Fatal("AnotherStore: Resolve() error =", err)
+		t.Fatal("ReadOnlyStore: Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, indexRoot) {
+		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, indexRoot)
 	}
 
-	rootIndexDescWithRef := ociRootIndexDesc
-	rootIndexDescWithRef.Annotations = map[string]string{
-		ocispec.AnnotationRefName: ociRootRef,
-	}
-	if !reflect.DeepEqual(gotDesc, rootIndexDescWithRef) {
-		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, rootIndexDescWithRef)
-	}
-
-	// test fetching OCI root index
-	exists, err := readonlyS.Exists(ctx, rootIndexDescWithRef)
+	// test resolving artifact manifest by digest
+	artifactRootDesc := descs[12]
+	gotDesc, err = readonlyS.Resolve(ctx, artifactRootDesc.Digest.String())
 	if err != nil {
-		t.Fatal("ReadOnlyStore.Exists() error =", err)
+		t.Fatal("ReadOnlyStore: Resolve() error =", err)
 	}
-	if !exists {
-		t.Errorf("ReadOnlyStore.Exists() = %v, want %v", exists, true)
-	}
-
-	rc, err := readonlyS.Fetch(ctx, rootIndexDescWithRef)
-	if err != nil {
-		t.Fatal("ReadOnlyStore.Fetch() error =", err)
-	}
-	got, err := io.ReadAll(rc)
-	if err != nil {
-		t.Fatal("ReadOnlyStore.Fetch().Read() error =", err)
-	}
-	err = rc.Close()
-	if err != nil {
-		t.Error("ReadOnlyStore.Fetch().Close() error =", err)
-	}
-	if !bytes.Equal(got, ociRootIndexJSON) {
-		t.Errorf("ReadOnlyStore.Fetch() = %v, want %v", got, ociRootIndexJSON)
+	if !reflect.DeepEqual(gotDesc, artifactRootDesc) {
+		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, artifactRootDesc)
 	}
 
 	// test fetching blobs
@@ -402,21 +358,21 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 
 	// verify predecessors
 	wants := [][]ocispec.Descriptor{
-		descs[4:7],                          // Blob 0
-		{descs[4], descs[6]},                // Blob 1
-		{descs[4], descs[6]},                // Blob 2
-		{descs[5], descs[6]},                // Blob 3
-		{descs[7]},                          // Blob 4
-		{descs[7]},                          // Blob 5
-		{descs[8], artifactRootDescWithRef}, // Blob 6
-		{descs[10], rootIndexDescWithRef},   // Blob 7
-		{descs[10]},                         // Blob 8
-		{descs[10]},                         // Blob 9
-		{descs[14]},                         // Blob 10
-		{artifactRootDescWithRef},           // Blob 11
-		nil,                                 // Blob 12, no predecessors
-		{descs[14]},                         // Blob 13
-		{rootIndexDescWithRef},              // Blob 14
+		descs[4:7],            // Blob 0
+		{descs[4], descs[6]},  // Blob 1
+		{descs[4], descs[6]},  // Blob 2
+		{descs[5], descs[6]},  // Blob 3
+		{descs[7]},            // Blob 4
+		{descs[7]},            // Blob 5
+		{descs[8], descs[12]}, // Blob 6
+		{descs[10]},           // Blob 7
+		{descs[10]},           // Blob 8
+		{descs[10]},           // Blob 9
+		{descs[14]},           // Blob 10
+		{descs[12]},           // Blob 11
+		nil,                   // Blob 12, no predecessors
+		{descs[14]},           // Blob 13
+		nil,                   // Blob 14, no predecessors
 	}
 	for i, want := range wants {
 		predecessors, err := readonlyS.Predecessors(ctx, descs[i])
@@ -460,9 +416,18 @@ func TestReadOnlyStore_TarFS(t *testing.T) {
 		},
 	}
 
-	// test Resolve
+	// test Resolve by tag
 	tag := "latest"
 	gotDesc, err := s.Resolve(ctx, tag)
+	if err != nil {
+		t.Fatal("ReadOnlyStore.Resolve() error =", err)
+	}
+	if !reflect.DeepEqual(gotDesc, wantDesc) {
+		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, wantDesc)
+	}
+
+	// test Resolve by digest
+	gotDesc, err = s.Resolve(ctx, "sha256:faa03e786c97f07ef34423fccceeec2398ec8a5759259f94d99078f264e9d7af")
 	if err != nil {
 		t.Fatal("ReadOnlyStore.Resolve() error =", err)
 	}

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -327,6 +327,15 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, artifactRootDesc)
 	}
 
+	// test resolving blob by digest
+	gotDesc, err = readonlyS.Resolve(ctx, descs[0].Digest.String())
+	if err != nil {
+		t.Fatal("Store: Resolve() error =", err)
+	}
+	if want := descs[0]; gotDesc.Size != want.Size || gotDesc.Digest != want.Digest {
+		t.Errorf("Store.Resolve() = %v, want %v", gotDesc, want)
+	}
+
 	// test fetching blobs
 	for i := range blobs {
 		eg.Go(func(i int) func() error {

--- a/content/oci/readonlystorage.go
+++ b/content/oci/readonlystorage.go
@@ -92,7 +92,8 @@ func (s *ReadOnlyStorage) Exists(_ context.Context, target ocispec.Descriptor) (
 // blobPath calculates blob path from the given digest.
 func blobPath(dgst digest.Digest) (string, error) {
 	if err := dgst.Validate(); err != nil {
-		return "", fmt.Errorf("cannot calculate blob path from invalid digest %s: %v", dgst.String(), err)
+		return "", fmt.Errorf("cannot calculate blob path from invalid digest %s: %w: %v",
+			dgst.String(), errdef.ErrInvalidDigest, err)
 	}
 	return path.Join("blobs", dgst.Algorithm().String(), dgst.Encoded()), nil
 }

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -21,6 +21,9 @@ import (
 	"oras.land/oras-go/v2/internal/docker"
 )
 
+// DefaultMediaType is the media type used when no media type is specified.
+const DefaultMediaType string = "application/octet-stream"
+
 // Descriptor contains the minimun information to describe the disposition of
 // targeted content.
 // Since it only has strings and integers, Descriptor is a comparable struct.
@@ -71,5 +74,14 @@ func IsManifest(desc ocispec.Descriptor) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// Plain returns a descriptor that contains only MediaType, Digest and Size.
+func Plain(desc ocispec.Descriptor) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: desc.MediaType,
+		Digest:    desc.Digest,
+		Size:      desc.Size,
 	}
 }

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -59,3 +59,17 @@ func IsForeignLayer(desc ocispec.Descriptor) bool {
 		return false
 	}
 }
+
+// IsManifest checks if a descriptor describes a manifest.
+func IsManifest(desc ocispec.Descriptor) bool {
+	switch desc.MediaType {
+	case docker.MediaTypeManifest,
+		docker.MediaTypeManifestList,
+		ocispec.MediaTypeImageManifest,
+		ocispec.MediaTypeImageIndex,
+		ocispec.MediaTypeArtifactManifest:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -77,7 +77,8 @@ func IsManifest(desc ocispec.Descriptor) bool {
 	}
 }
 
-// Plain returns a descriptor that contains only MediaType, Digest and Size.
+// Plain returns a plain descriptor that contains only MediaType, Digest and
+// Size.
 func Plain(desc ocispec.Descriptor) ocispec.Descriptor {
 	return ocispec.Descriptor{
 		MediaType: desc.MediaType,


### PR DESCRIPTION
1. Support discovering predecessors that are not tagged
2. Support resolving a manifest by its digest
3. Support resolving a blob by its digest

Resolves: #342 