### PR TITLE
feat!: retryable http client

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -182,7 +182,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	remoteHost = u.Host
-	http.DefaultClient = httpsServer.Client()
+	http.DefaultTransport = httpsServer.Client().Transport
 
 	os.Exit(m.Run())
 }

--- a/registry/example_test.go
+++ b/registry/example_test.go
@@ -65,7 +65,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	host = u.Host
-	http.DefaultClient = ts.Client()
+	http.DefaultTransport = ts.Client().Transport
 
 	os.Exit(m.Run())
 }

--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -28,10 +28,12 @@ import (
 	"strings"
 
 	"oras.land/oras-go/v2/registry/remote/internal/errutil"
+	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
 // DefaultClient is the default auth-decorated client.
 var DefaultClient = &Client{
+	Client: retry.DefaultClient,
 	Header: http.Header{
 		"User-Agent": {"oras-go"},
 	},

--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -70,6 +70,11 @@ type Client struct {
 	// Client is the underlying HTTP client used to access the remote
 	// server.
 	// If nil, http.DefaultClient is used.
+	// It is possible to use the default retry client from the package
+	// `oras.land/oras-go/v2/registry/remote/retry`. That client is already available
+	// in the DefaultClient.
+	// It is also possible to use a custom client. For example, github.com/hashicorp/go-retryablehttp
+	// is a popular HTTP client that supports retries.
 	Client *http.Client
 
 	// Header contains the custom headers to be added to each request.

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -1842,8 +1842,6 @@ func TestClient_Do_Anonymous_Pull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
 	}
-	// override the DefaultClient client to avoid retries
-	DefaultClient.Client = &http.Client{}
 	resp, err := DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Client.Do() error = %v", err)

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -1842,6 +1842,8 @@ func TestClient_Do_Anonymous_Pull(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
 	}
+	// override the DefaultClient client to avoid retries
+	DefaultClient.Client = &http.Client{}
 	resp, err := DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("Client.Do() error = %v", err)

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -214,7 +214,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	host = u.Host
-	http.DefaultClient = ts.Client()
+	http.DefaultTransport = ts.Client().Transport
 
 	os.Exit(m.Run())
 }

--- a/registry/remote/retry/client.go
+++ b/registry/remote/retry/client.go
@@ -1,0 +1,101 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"time"
+)
+
+// // DefaultClient is a client with the default retry policy
+var DefaultClient = NewClient()
+
+// NewClient creates an HTTP client with the default retry policy
+func NewClient() *http.Client {
+	return &http.Client{
+		Transport: NewTransport(nil),
+	}
+}
+
+// Transport is an HTTP transport with retry policy
+type Transport struct {
+	// Base is the underlying HTTP transport to use.
+	// If nil, http.DefaultTransport is used for round trips.
+	Base http.RoundTripper
+
+	// Policy returns a retry Policy to use for the request.
+	// If nil, DefaultPolicy is used to determine if the request should be retried.
+	Policy func() Policy
+}
+
+// NewTransport creates an HTTP Transport with the default retry policy
+func NewTransport(base http.RoundTripper) *Transport {
+	return &Transport{
+		Base: base,
+	}
+}
+
+// RoundTrip executes a single HTTP transaction, returning a Response for the provided Request.
+// It relies on the configured Policy to determine if the request should be retried and to backoff.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	policy := t.policy()
+	attempt := 0
+	for {
+		resp, respErr := t.roundTrip(req)
+		duration, err := policy.Retry(ctx, attempt, resp, respErr)
+		if duration < 0 {
+			return resp, err
+		}
+
+		// rewind the body if necessary
+		if req.Body != nil {
+			var buf bytes.Buffer
+			if _, err = buf.ReadFrom(resp.Body); err != nil {
+				return resp, err
+			}
+			if err = resp.Body.Close(); err != nil {
+				return resp, err
+			}
+			req.Body = io.NopCloser(&buf)
+		}
+
+		timer := time.NewTimer(duration)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+		attempt++
+	}
+}
+
+func (t *Transport) roundTrip(req *http.Request) (*http.Response, error) {
+	if t.Base == nil {
+		return http.DefaultTransport.RoundTrip(req)
+	}
+	return t.Base.RoundTrip(req)
+}
+
+func (t *Transport) policy() Policy {
+	if t.Policy == nil {
+		return DefaultPolicy
+	}
+	return t.Policy()
+}

--- a/registry/remote/retry/client_test.go
+++ b/registry/remote/retry/client_test.go
@@ -35,11 +35,6 @@ func Test_Client(t *testing.T) {
 			attempts: 1, retryAfter: false, StatusCode: http.StatusOK, expectedErr: false,
 		},
 		{
-			name: "successful request with 1 retry caused by 401",
-			// 1 request + 1 retry = 2 attempts
-			attempts: 2, retryAfter: false, StatusCode: http.StatusUnauthorized, expectedErr: false,
-		},
-		{
 			name: "successful request with 1 retry caused by rate limit",
 			// 1 request + 1 retry = 2 attempts
 			attempts: 2, retryAfter: true, StatusCode: http.StatusTooManyRequests, expectedErr: false,

--- a/registry/remote/retry/client_test.go
+++ b/registry/remote/retry/client_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_Client(t *testing.T) {
+	testCases := []struct {
+		name        string
+		attempts    int
+		retryAfter  bool
+		StatusCode  int
+		expectedErr bool
+	}{
+		{
+			name:     "successful request with 0 retry",
+			attempts: 1, retryAfter: false, StatusCode: http.StatusOK, expectedErr: false,
+		},
+		{
+			name: "successful request with 1 retry caused by 401",
+			// 1 request + 1 retry = 2 attempts
+			attempts: 2, retryAfter: false, StatusCode: http.StatusUnauthorized, expectedErr: false,
+		},
+		{
+			name: "successful request with 1 retry caused by rate limit",
+			// 1 request + 1 retry = 2 attempts
+			attempts: 2, retryAfter: true, StatusCode: http.StatusTooManyRequests, expectedErr: false,
+		},
+		{
+			name: "successful request with 1 retry caused by 408",
+			// 1 request + 1 retry = 2 attempts
+			attempts: 2, retryAfter: false, StatusCode: http.StatusRequestTimeout, expectedErr: false,
+		},
+		{
+			name: "successful request with 2 retries caused by 429",
+			// 1 request + 2 retries = 3 attempts
+			attempts: 3, retryAfter: false, StatusCode: http.StatusTooManyRequests, expectedErr: false,
+		},
+		{
+			name: "unsuccessful request with 6 retries caused by too many retries",
+			// 1 request + 6 retries = 7 attempts
+			attempts: 7, retryAfter: false, StatusCode: http.StatusServiceUnavailable, expectedErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			count := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				count++
+				if count < tc.attempts {
+					if tc.retryAfter {
+						w.Header().Set("Retry-After", "1")
+					}
+					http.Error(w, "error", tc.StatusCode)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			req, err := http.NewRequest(http.MethodPost, ts.URL, bytes.NewReader([]byte("test")))
+			if err != nil {
+				t.Fatalf("failed to create test request: %v", err)
+			}
+
+			resp, err := DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("failed to do test request: %v", err)
+			}
+			if tc.expectedErr {
+				if count != (tc.attempts - 1) {
+					t.Errorf("expected attempts %d, got %d", tc.attempts, count)
+				}
+				if resp.StatusCode != http.StatusServiceUnavailable {
+					t.Errorf("expected status code %d, got %d", http.StatusServiceUnavailable, resp.StatusCode)
+				}
+				return
+			}
+			if tc.attempts != count {
+				t.Errorf("expected attempts %d, got %d", tc.attempts, count)
+			}
+		})
+	}
+}

--- a/registry/remote/retry/policy.go
+++ b/registry/remote/retry/policy.go
@@ -1,0 +1,146 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// headerRetryAfter is the header key for Retry-After.
+const headerRetryAfter = "Retry-After"
+
+// DefaultPolicy is a policy with fine-tuned retry parameters.
+// It uses an exponential backoff with jitter.
+var DefaultPolicy Policy = &GenericPolicy{
+	Retryable: DefaultPredicate,
+	Backoff:   DefaultBackoff,
+	MinWait:   200 * time.Millisecond,
+	MaxWait:   3 * time.Second,
+	MaxRetry:  5,
+}
+
+// DefaultPredicate is a predicate that retries on 5xx errors, 429 Too Many
+// Requests, 401 Unauthorized and 408 Request Timeout.
+var DefaultPredicate Predicate = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return true, nil
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true, nil
+	}
+
+	if resp.StatusCode == 0 || resp.StatusCode >= 500 {
+		return true, fmt.Errorf("unexpected HTTP status %s", resp.Status)
+	}
+
+	return false, nil
+}
+
+// DefaultBackoff is a backoff that uses an exponential backoff with jitter.
+// It uses a base of 250ms, a factor of 2 and a jitter of 10%.
+var DefaultBackoff Backoff = ExponentialBackoff(250*time.Millisecond, 2, 0.1)
+
+// Policy is a retry policy.
+type Policy interface {
+	// Retry returns the duration to wait before retrying the request.
+	Retry(ctx context.Context, attempt int, resp *http.Response, err error) (time.Duration, error)
+}
+
+// Predicate is a function that returns true if the request should be retried.
+type Predicate func(ctx context.Context, resp *http.Response, err error) (bool, error)
+
+// Backoff is a function that returns the duration to wait before retrying the
+// request. The attempt, is the next attempt number. The response is the
+// response from the previous request.
+type Backoff func(attempt int, resp *http.Response) time.Duration
+
+// ExponentialBackoff returns a Backoff that uses an exponential backoff with
+// jitter. The backoff is calculated as:
+//
+//	backoff * factor ^ attempt + rand.Int63n(jitter * backoff)
+//
+// The HTTP response is checked for a Retry-After header. If it is present, the
+// value is used as the backoff duration and jitter is applied.
+func ExponentialBackoff(backoff time.Duration, factor int, jitter float64) Backoff {
+	return func(attempt int, resp *http.Response) time.Duration {
+		// Seed random number generator with nanoseconds
+		rand := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+		// check Retry-After
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			if v := resp.Header.Get(headerRetryAfter); v != "" {
+				if retryAfter, _ := strconv.ParseInt(v, 10, 64); retryAfter > 0 {
+					return time.Duration(retryAfter + rand.Int63n(int64(jitter*float64(backoff))))
+				}
+			}
+		}
+
+		// do exponential backoff with jitter
+		b := time.Duration(float64(backoff) * math.Pow(float64(factor), float64(attempt)))
+		return b + time.Duration(rand.Int63n(int64(jitter*float64(backoff))))
+	}
+}
+
+// GenericPolicy is a generic retry policy.
+type GenericPolicy struct {
+	// Retryable is a predicate that returns true if the request should be
+	// retried.
+	Retryable Predicate
+
+	// Backoff is a function that returns the duration to wait before retrying.
+	Backoff Backoff
+
+	// MinWait is the minimum duration to wait before retrying.
+	MinWait time.Duration
+
+	// MaxWait is the maximum duration to wait before retrying.
+	MaxWait time.Duration
+
+	// MaxRetry is the maximum number of retries.
+	MaxRetry int
+}
+
+// Retry returns the duration to wait before retrying the request.
+// It returns -1 if the request should not be retried.
+func (p *GenericPolicy) Retry(ctx context.Context, attempt int, resp *http.Response, err error) (time.Duration, error) {
+	if attempt >= p.MaxRetry {
+		return -1, err
+	}
+	if ok, err := p.Retryable(ctx, resp, err); !ok {
+		return -1, err
+	}
+	backoff := p.Backoff(attempt, resp)
+	if backoff < p.MinWait {
+		backoff = p.MinWait
+	}
+	if backoff > p.MaxWait {
+		backoff = p.MaxWait
+	}
+	return backoff, nil
+}

--- a/registry/remote/retry/policy_test.go
+++ b/registry/remote/retry/policy_test.go
@@ -27,27 +27,27 @@ func Test_ExponentialBackoff(t *testing.T) {
 		expectedBackoff time.Duration
 	}{
 		{
-			name:    "attempt 0 should have a backoff of 0,25s",
+			name:    "attempt 0 should have a backoff of 0,25s ± 10%",
 			attempt: 0, expectedBackoff: 250 * time.Millisecond,
 		},
 		{
-			name:    "attempt 1 should have a backoff of 0,5s",
+			name:    "attempt 1 should have a backoff of 0,5s ± 10%",
 			attempt: 1, expectedBackoff: 500 * time.Millisecond,
 		},
 		{
-			name:    "attempt 2 should have a backoff of 1s",
+			name:    "attempt 2 should have a backoff of 1s ± 10%",
 			attempt: 2, expectedBackoff: 1 * time.Second,
 		},
 		{
-			name:    "attempt 3 should have a backoff of 2s",
+			name:    "attempt 3 should have a backoff of 2s ± 10%",
 			attempt: 3, expectedBackoff: 2 * time.Second,
 		},
 		{
-			name:    "attempt 4 should have a backoff of 4s",
+			name:    "attempt 4 should have a backoff of 4s ± 10%",
 			attempt: 4, expectedBackoff: 4 * time.Second,
 		},
 		{
-			name:    "attempt 5 should have a backoff of 8s",
+			name:    "attempt 5 should have a backoff of 8s ± 10%",
 			attempt: 5, expectedBackoff: 8 * time.Second,
 		},
 	}
@@ -55,8 +55,9 @@ func Test_ExponentialBackoff(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			b := DefaultBackoff(tc.attempt, nil)
-			if !(b > tc.expectedBackoff && b <= time.Duration(float64(tc.expectedBackoff)+float64(250*time.Millisecond)*0.1)) {
-				t.Errorf("expected backoff to be %s + jitter, got %s", tc.expectedBackoff, b)
+			base := float64(tc.expectedBackoff)
+			if !(b >= time.Duration(base*0.9) && b <= time.Duration(base+base*0.1)) {
+				t.Errorf("expected backoff to be %s + jitter, got %s", time.Duration(base), b)
 			}
 		})
 	}

--- a/registry/remote/retry/policy_test.go
+++ b/registry/remote/retry/policy_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_ExponentialBackoff(t *testing.T) {
+	testCases := []struct {
+		name            string
+		attempt         int
+		expectedBackoff time.Duration
+	}{
+		{
+			name:    "attempt 0 should have a backoff of 0,25s",
+			attempt: 0, expectedBackoff: 250 * time.Millisecond,
+		},
+		{
+			name:    "attempt 1 should have a backoff of 0,5s",
+			attempt: 1, expectedBackoff: 500 * time.Millisecond,
+		},
+		{
+			name:    "attempt 2 should have a backoff of 1s",
+			attempt: 2, expectedBackoff: 1 * time.Second,
+		},
+		{
+			name:    "attempt 3 should have a backoff of 2s",
+			attempt: 3, expectedBackoff: 2 * time.Second,
+		},
+		{
+			name:    "attempt 4 should have a backoff of 4s",
+			attempt: 4, expectedBackoff: 4 * time.Second,
+		},
+		{
+			name:    "attempt 5 should have a backoff of 8s",
+			attempt: 5, expectedBackoff: 8 * time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := DefaultBackoff(tc.attempt, nil)
+			if !(b > tc.expectedBackoff && b <= time.Duration(float64(tc.expectedBackoff)+float64(250*time.Millisecond)*0.1)) {
+				t.Errorf("expected backoff to be %s + jitter, got %s", tc.expectedBackoff, b)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #147 

If implemented, this will provide a default http client with retry.

The retry function is an exponential back off 0.25s * 2^n ± 10% and max 5 attempts.

The client is the default client of `auth.Client`

Co-authored-by: Shiwei Zhang <shizh@microsoft.com>
Signed-off-by: Soule BA <bah.soule@gmail.com>

cc @shizhMSFT 