### PR TITLE
    adding field to file.store for ignoring paths from annotationTitle 

### DIFF
--- a/content/file/file.go
+++ b/content/file/file.go
@@ -101,6 +101,10 @@ type Store struct {
 	// manifest and config file, while leaving only named layer files.
 	// Default value: false.
 	IgnoreNoName bool
+	// IgnorePathsFromAnnotationTitle removes full path from org.opencontainers.image.title
+	// and keeps only file name which is downloaded in workingDir.
+	// Default value: false
+	IgnorePathsFromAnnotationTitle bool
 
 	workingDir   string   // the working directory of the file store
 	closed       int32    // if the store is closed - 0: false, 1: true.
@@ -605,6 +609,9 @@ func (s *Store) resolveWritePath(name string) (string, error) {
 		if strings.HasPrefix(rel, "../") || rel == ".." {
 			return "", ErrPathTraversalDisallowed
 		}
+	}
+	if s.IgnorePathsFromAnnotationTitle {
+		path = filepath.Base(name)
 	}
 	if s.DisableOverwrite {
 		if _, err := os.Stat(path); err == nil {


### PR DESCRIPTION
In order to be able to store files to different paths than paths absolute to dir where they were pushed from added `IgnorePathsFromAnnotationTitle` field to `file.Store` struct and adjusted `resolveWritePath` func. 

For instance file from this layer could be downloaded directly to workDir

`
  {
    "layers": [
      {
        "mediaType": "application/vnd.oci.image.layer.v1.tar",
        "digest": "sha256:3b6420de981ca4f6d70be7c0dc96429e85dc6d45b1612bc70b7aeb7698bd1626",
        "size": 271,
        "annotations": {
          "org.opencontainers.image.title": "/var/folders/something-ridiculous/pushed-from-temp.yaml"
        }
      }
    ]
  }
`
