### PR TITLE
fix!: fix error when extracting folder containing symbolic links

### DIFF
--- a/content/file/example_test.go
+++ b/content/file/example_test.go
@@ -19,7 +19,6 @@ package file_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,14 +47,14 @@ func TestMain(m *testing.M) {
 	content := []byte("foo")
 	filename := "foo.txt"
 	path := filepath.Join(workingDir, filename)
-	if err := ioutil.WriteFile(path, content, 0444); err != nil {
+	if err := os.WriteFile(path, content, 0444); err != nil {
 		panic(err)
 	}
 	// prepare test file 2
 	content = []byte("bar")
 	filename = "bar.txt"
 	path = filepath.Join(workingDir, filename)
-	if err := ioutil.WriteFile(path, content, 0444); err != nil {
+	if err := os.WriteFile(path, content, 0444); err != nil {
 		panic(err)
 	}
 

--- a/content/file/example_test.go
+++ b/content/file/example_test.go
@@ -70,7 +70,10 @@ func TestMain(m *testing.M) {
 // Example_packFiles gives an example of adding files and generating a manifest
 // referencing the files.
 func Example_packFiles() {
-	store := file.New(workingDir)
+	store, err := file.New(workingDir)
+	if err != nil {
+		panic(err)
+	}
 	defer store.Close()
 	ctx := context.Background()
 

--- a/content/file/file.go
+++ b/content/file/file.go
@@ -143,7 +143,7 @@ func NewWithFallbackLimit(workingDir string, limit int64) (*Store, error) {
 func NewWithFallbackStorage(workingDir string, fallbackStorage content.Storage) (*Store, error) {
 	workingDirAbs, err := filepath.Abs(workingDir)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve absolute path for %s: %w", workingDir, err)
 	}
 
 	return &Store{

--- a/content/file/file.go
+++ b/content/file/file.go
@@ -223,7 +223,7 @@ func (s *Store) Push(ctx context.Context, expected ocispec.Descriptor, content i
 
 	if !s.ForceCAS {
 		if err := s.restoreDuplicates(ctx, expected); err != nil {
-			return fmt.Errorf("Failed to restore duplicated file: %w", err)
+			return fmt.Errorf("failed to restore duplicated file: %w", err)
 		}
 	}
 

--- a/content/file/file.go
+++ b/content/file/file.go
@@ -124,7 +124,7 @@ type nameStatus struct {
 // as the fallback storage for contents without names.
 // When pushing content without names, the size of content being pushed
 // cannot exceed the default size limit: 4 MiB.
-func New(workingDir string) *Store {
+func New(workingDir string) (*Store, error) {
 	return NewWithFallbackLimit(workingDir, defaultFallbackPushSizeLimit)
 }
 
@@ -132,7 +132,7 @@ func New(workingDir string) *Store {
 // limited memory CAS as the fallback storage for contents without names.
 // When pushing content without names, the size of content being pushed
 // cannot exceed the size limit specified by the `limit` parameter.
-func NewWithFallbackLimit(workingDir string, limit int64) *Store {
+func NewWithFallbackLimit(workingDir string, limit int64) (*Store, error) {
 	m := cas.NewMemory()
 	ls := content.LimitStorage(m, limit)
 	return NewWithFallbackStorage(workingDir, ls)
@@ -140,13 +140,18 @@ func NewWithFallbackLimit(workingDir string, limit int64) *Store {
 
 // NewWithFallbackStorage creates a file store,
 // using the provided fallback storage for contents without names.
-func NewWithFallbackStorage(workingDir string, fallbackStorage content.Storage) *Store {
+func NewWithFallbackStorage(workingDir string, fallbackStorage content.Storage) (*Store, error) {
+	workingDirAbs, err := filepath.Abs(workingDir)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Store{
-		workingDir:      workingDir,
+		workingDir:      workingDirAbs,
 		fallbackStorage: fallbackStorage,
 		resolver:        resolver.NewMemory(),
 		graph:           graph.NewMemory(),
-	}
+	}, nil
 }
 
 // Close closes the file store and cleans up all the temporary files used by it.

--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -76,7 +76,10 @@ func TestStoreInterface(t *testing.T) {
 
 func TestStore_Success(t *testing.T) {
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -223,11 +226,14 @@ func TestStore_Close(t *testing.T) {
 	ref := "foobar"
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
@@ -314,12 +320,15 @@ func TestStore_File_Push(t *testing.T) {
 		},
 	}
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
@@ -365,7 +374,10 @@ func TestStore_Dir_Push(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -394,7 +406,10 @@ func TestStore_Dir_Push(t *testing.T) {
 
 	anotherTempDir := t.TempDir()
 	// test with another file store instance to mock push gz
-	anotherS := New(anotherTempDir)
+	anotherS, err := New(anotherTempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer anotherS.Close()
 
 	// test push
@@ -470,12 +485,15 @@ func TestStore_Push_NoName(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
@@ -516,12 +534,15 @@ func TestStore_Push_NoName_ExceedLimit(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewWithFallbackLimit(tempDir, 1)
+	s, err := NewWithFallbackLimit(tempDir, 1)
+	if err != nil {
+		t.Fatal("Store.NewWithFallbackLimit() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(blob))
+	err = s.Push(ctx, desc, bytes.NewReader(blob))
 	if !errors.Is(err, errdef.ErrSizeExceedsLimit) {
 		t.Errorf("Store.Push() error = %v, want %v", err, errdef.ErrSizeExceedsLimit)
 	}
@@ -536,12 +557,15 @@ func TestStore_Push_NoName_SizeNotMatch(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewWithFallbackLimit(tempDir, 1)
+	s, err := NewWithFallbackLimit(tempDir, 1)
+	if err != nil {
+		t.Fatal("Store.NewWithFallbackLimit() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(blob))
+	err = s.Push(ctx, desc, bytes.NewReader(blob))
 	if err == nil {
 		t.Errorf("Store.Push() error = nil, want: error")
 	}
@@ -559,7 +583,10 @@ func TestStore_File_NotFound(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -589,11 +616,14 @@ func TestStore_File_ContentBadPush(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
-	err := s.Push(ctx, desc, strings.NewReader("foobar"))
+	err = s.Push(ctx, desc, strings.NewReader("foobar"))
 	if err == nil {
 		t.Errorf("Store.Push() error = %v, wantErr %v", err, true)
 	}
@@ -618,7 +648,10 @@ func TestStore_File_Add(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -671,7 +704,10 @@ func TestStore_Dir_Add(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -740,7 +776,10 @@ func TestStore_File_SameContent_DuplicateName(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -809,7 +848,10 @@ func TestStore_File_DifferentContent_DuplicateName(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -870,12 +912,15 @@ func TestStore_File_Add_MissingName(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test add with empty name
-	_, err := s.Add(ctx, "", mediaType, path)
+	_, err = s.Add(ctx, "", mediaType, path)
 	if !errors.Is(err, ErrMissingName) {
 		t.Errorf("Store.Add() error = %v, want %v", err, ErrMissingName)
 	}
@@ -915,7 +960,10 @@ func TestStore_File_Add_SameContent(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1012,7 +1060,10 @@ func TestStore_File_Push_SameContent(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1098,12 +1149,15 @@ func TestStore_File_Push_DuplicateName(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc_1, bytes.NewReader(content_1))
+	err = s.Push(ctx, desc_1, bytes.NewReader(content_1))
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
@@ -1181,7 +1235,10 @@ func TestStore_File_Push_ForceCAS(t *testing.T) {
 		Size:      int64(len(manifestJSON)),
 	}
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	s.ForceCAS = true
 	defer s.Close()
 	ctx := context.Background()
@@ -1245,7 +1302,10 @@ func TestStore_File_Push_RestoreDuplicates(t *testing.T) {
 		Size:      int64(len(manifestJSON)),
 	}
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1315,7 +1375,10 @@ func TestStore_File_Push_RestoreDuplicates_NotFound(t *testing.T) {
 		Size:      int64(len(manifestJSON)),
 	}
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1346,7 +1409,10 @@ func TestStore_File_Fetch_SameDigest_NoName(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1434,7 +1500,10 @@ func TestStore_File_Fetch_SameDigest_DifferentName(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1502,12 +1571,15 @@ func TestStore_File_Push_Overwrite(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(new_content))
+	err = s.Push(ctx, desc, bytes.NewReader(new_content))
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
@@ -1558,12 +1630,15 @@ func TestStore_File_Push_DisableOverwrite(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	s.DisableOverwrite = true
 
 	ctx := context.Background()
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if !errors.Is(err, ErrOverwriteDisallowed) {
 		t.Errorf("Store.Push() error = %v, want %v", err, ErrOverwriteDisallowed)
 	}
@@ -1591,7 +1666,10 @@ func TestStore_File_Push_IgnoreNoName(t *testing.T) {
 		Size:      int64(len(manifestJSON)),
 	}
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	s.IgnoreNoName = true
 
@@ -1633,11 +1711,14 @@ func TestStore_File_Push_DisallowPathTraversal(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 
 	ctx := context.Background()
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if !errors.Is(err, ErrPathTraversalDisallowed) {
 		t.Errorf("Store.Push() error = %v, want %v", err, ErrPathTraversalDisallowed)
 	}
@@ -1657,7 +1738,10 @@ func TestStore_Dir_Push_DisallowPathTraversal(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1686,7 +1770,10 @@ func TestStore_Dir_Push_DisallowPathTraversal(t *testing.T) {
 
 	anotherTempDir := t.TempDir()
 	// test with another file store instance to mock push gz
-	anotherS := New(anotherTempDir)
+	anotherS, err := New(anotherTempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer anotherS.Close()
 
 	// test push
@@ -1714,7 +1801,10 @@ func TestStore_File_Push_PathTraversal(t *testing.T) {
 		t.Fatal("error creating temp dir, error =", err)
 	}
 
-	s := New(subTempDir)
+	s, err := New(subTempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	s.AllowPathTraversalOnWrite = true
 
@@ -1764,7 +1854,10 @@ func TestStore_File_Push_Concurrent(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1825,7 +1918,10 @@ func TestStore_File_Fetch_Concurrent(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1868,11 +1964,14 @@ func TestStore_TagNotFound(t *testing.T) {
 	ref := "foobar"
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
-	_, err := s.Resolve(ctx, ref)
+	_, err = s.Resolve(ctx, ref)
 	if !errors.Is(err, errdef.ErrNotFound) {
 		t.Errorf("Store.Resolve() error = %v, want %v", err, errdef.ErrNotFound)
 	}
@@ -1888,11 +1987,14 @@ func TestStore_TagUnknownContent(t *testing.T) {
 	ref := "foobar"
 
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
-	err := s.Tag(ctx, desc, ref)
+	err = s.Tag(ctx, desc, ref)
 	if !errors.Is(err, errdef.ErrNotFound) {
 		t.Errorf("Store.Resolve() error = %v, want %v", err, errdef.ErrNotFound)
 	}
@@ -1900,7 +2002,10 @@ func TestStore_TagUnknownContent(t *testing.T) {
 
 func TestStore_RepeatTag(t *testing.T) {
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -1921,7 +2026,7 @@ func TestStore_RepeatTag(t *testing.T) {
 	// initial tag
 	content := []byte("hello world")
 	desc := generate(content)
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if err != nil {
 		t.Fatal("Store.Push() error =", err)
 	}
@@ -1984,7 +2089,10 @@ func TestStore_RepeatTag(t *testing.T) {
 
 func TestStore_Predecessors(t *testing.T) {
 	tempDir := t.TempDir()
-	s := New(tempDir)
+	s, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer s.Close()
 	ctx := context.Background()
 
@@ -2100,7 +2208,10 @@ func TestCopy_File_MemoryToFile_FullCopy(t *testing.T) {
 	src := memory.New()
 
 	tempDir := t.TempDir()
-	dst := New(tempDir)
+	dst, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer dst.Close()
 
 	// generate test content
@@ -2145,7 +2256,7 @@ func TestCopy_File_MemoryToFile_FullCopy(t *testing.T) {
 
 	root := descs[3]
 	ref := "foobar"
-	err := src.Tag(ctx, root, ref)
+	err = src.Tag(ctx, root, ref)
 	if err != nil {
 		t.Fatal("fail to tag root node", err)
 	}
@@ -2184,7 +2295,10 @@ func TestCopyGraph_MemoryToFile_FullCopy(t *testing.T) {
 	src := memory.New()
 
 	tempDir := t.TempDir()
-	dst := New(tempDir)
+	dst, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer dst.Close()
 
 	// generate test content
@@ -2289,7 +2403,10 @@ func TestCopyGraph_MemoryToFile_PartialCopy(t *testing.T) {
 	src := memory.New()
 
 	tempDir := t.TempDir()
-	dst := New(tempDir)
+	dst, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer dst.Close()
 
 	// generate test content
@@ -2404,7 +2521,10 @@ func TestCopyGraph_MemoryToFile_PartialCopy(t *testing.T) {
 
 func TestCopy_File_FileToMemory_FullCopy(t *testing.T) {
 	tempDir := t.TempDir()
-	src := New(tempDir)
+	src, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer src.Close()
 
 	dst := memory.New()
@@ -2451,7 +2571,7 @@ func TestCopy_File_FileToMemory_FullCopy(t *testing.T) {
 
 	root := descs[3]
 	ref := "foobar"
-	err := src.Tag(ctx, root, ref)
+	err = src.Tag(ctx, root, ref)
 	if err != nil {
 		t.Fatal("fail to tag root node", err)
 	}
@@ -2488,7 +2608,10 @@ func TestCopy_File_FileToMemory_FullCopy(t *testing.T) {
 
 func TestCopyGraph_FileToMemory_FullCopy(t *testing.T) {
 	tempDir := t.TempDir()
-	src := New(tempDir)
+	src, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer src.Close()
 
 	dst := memory.New()
@@ -2593,7 +2716,10 @@ func TestCopyGraph_FileToMemory_FullCopy(t *testing.T) {
 
 func TestCopyGraph_FileToMemory_PartialCopy(t *testing.T) {
 	tempDir := t.TempDir()
-	src := New(tempDir)
+	src, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
 	defer src.Close()
 
 	dst := memory.New()

--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -94,7 +93,7 @@ func TestStore_Success(t *testing.T) {
 	}
 
 	path := filepath.Join(tempDir, name)
-	if err := ioutil.WriteFile(path, blob, 0444); err != nil {
+	if err := os.WriteFile(path, blob, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -362,7 +361,7 @@ func TestStore_Dir_Push(t *testing.T) {
 
 	content := []byte("hello world")
 	fileName := "test.txt"
-	if err := ioutil.WriteFile(filepath.Join(dirPath, fileName), content, 0444); err != nil {
+	if err := os.WriteFile(filepath.Join(dirPath, fileName), content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -615,7 +614,7 @@ func TestStore_File_Add(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, name)
-	if err := ioutil.WriteFile(path, content, 0444); err != nil {
+	if err := os.WriteFile(path, content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -668,7 +667,7 @@ func TestStore_Dir_Add(t *testing.T) {
 	}
 
 	content := []byte("hello world")
-	if err := ioutil.WriteFile(filepath.Join(dirPath, "test.txt"), content, 0444); err != nil {
+	if err := os.WriteFile(filepath.Join(dirPath, "test.txt"), content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -737,7 +736,7 @@ func TestStore_File_SameContent_DuplicateName(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, name)
-	if err := ioutil.WriteFile(path, content, 0444); err != nil {
+	if err := os.WriteFile(path, content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -806,7 +805,7 @@ func TestStore_File_DifferentContent_DuplicateName(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path_1 := filepath.Join(tempDir, name_1)
-	if err := ioutil.WriteFile(path_1, content_1, 0444); err != nil {
+	if err := os.WriteFile(path_1, content_1, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -851,7 +850,7 @@ func TestStore_File_DifferentContent_DuplicateName(t *testing.T) {
 
 	// test add duplicate name
 	path_2 := filepath.Join(tempDir, name_2)
-	if err := ioutil.WriteFile(path_2, content_2, 0444); err != nil {
+	if err := os.WriteFile(path_2, content_2, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -867,7 +866,7 @@ func TestStore_File_Add_MissingName(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, name)
-	if err := ioutil.WriteFile(path, content, 0444); err != nil {
+	if err := os.WriteFile(path, content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -908,11 +907,11 @@ func TestStore_File_Add_SameContent(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path_1 := filepath.Join(tempDir, name_1)
-	if err := ioutil.WriteFile(path_1, content, 0444); err != nil {
+	if err := os.WriteFile(path_1, content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 	path_2 := filepath.Join(tempDir, name_2)
-	if err := ioutil.WriteFile(path_2, content, 0444); err != nil {
+	if err := os.WriteFile(path_2, content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -1499,7 +1498,7 @@ func TestStore_File_Push_Overwrite(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, name)
-	if err := ioutil.WriteFile(path, old_content, 0666); err != nil {
+	if err := os.WriteFile(path, old_content, 0666); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -1555,7 +1554,7 @@ func TestStore_File_Push_DisableOverwrite(t *testing.T) {
 
 	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, name)
-	if err := ioutil.WriteFile(path, content, 0444); err != nil {
+	if err := os.WriteFile(path, content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
@@ -1654,7 +1653,7 @@ func TestStore_Dir_Push_DisallowPathTraversal(t *testing.T) {
 
 	content := []byte("hello world")
 	fileName := "test.txt"
-	if err := ioutil.WriteFile(filepath.Join(dirPath, fileName), content, 0444); err != nil {
+	if err := os.WriteFile(filepath.Join(dirPath, fileName), content, 0444); err != nil {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 

--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -213,6 +213,10 @@ func TestStore_Success(t *testing.T) {
 
 func TestStore_RelativeRoot_Success(t *testing.T) {
 	tempDir := t.TempDir()
+	currDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("error calling Getwd(), error=", err)
+	}
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatal("error calling Chdir(), error=", err)
 	}
@@ -224,8 +228,8 @@ func TestStore_RelativeRoot_Success(t *testing.T) {
 	if want := tempDir; s.workingDir != want {
 		t.Errorf("Store.workingDir = %s, want %s", s.workingDir, want)
 	}
-	// cd out to allow the temp directory to be removed
-	if err := os.Chdir("../../"); err != nil {
+	// cd back to allow the temp directory to be removed
+	if err := os.Chdir(currDir); err != nil {
 		t.Fatal("error calling Chdir(), error=", err)
 	}
 	ctx := context.Background()

--- a/content/file/file_unix_test.go
+++ b/content/file/file_unix_test.go
@@ -83,7 +83,7 @@ func TestStore_Dir_ExtractSymlink(t *testing.T) {
 		t.Fatal("oras.Pack() error =", err)
 	}
 
-	// copy to another file store, to trigger extracting directory
+	// copy to another file store created from an absolute root, to trigger extracting directory
 	tempDir = t.TempDir()
 	dstAbs := New(tempDir)
 	defer dstAbs.Close()
@@ -108,7 +108,7 @@ func TestStore_Dir_ExtractSymlink(t *testing.T) {
 		t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
 	}
 
-	// copy to another file store created from a relative path, to trigger extracting directory
+	// copy to another file store created from a relative root, to trigger extracting directory
 	tempDir = t.TempDir()
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatal("error calling Chdir(), error=", err)
@@ -191,7 +191,7 @@ func TestStore_Dir_ExtractSymlinkAbs(t *testing.T) {
 		t.Fatal("oras.Pack() error =", err)
 	}
 
-	// remove the original testing directory and create a new store using an absolute path
+	// remove the original testing directory and create a new store using an absolute root
 	if err := os.RemoveAll(dirPath); err != nil {
 		t.Fatal("error calling RemoveAll(), error =", err)
 	}
@@ -218,33 +218,5 @@ func TestStore_Dir_ExtractSymlinkAbs(t *testing.T) {
 		t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
 	}
 
-	// // remove the original testing directory and create a new store using a relative path
-	// if err := os.RemoveAll(dirPath); err != nil {
-	// 	t.Fatal("error calling RemoveAll(), error =", err)
-	// }
-	// if err := os.Chdir(tempDir); err != nil {
-	// 	t.Fatal("error calling Chdir(), error=", err)
-	// }
-	// dstRel := New(".")
-	// defer dstRel.Close()
-	// if err := oras.CopyGraph(ctx, src, dstRel, manifestDesc, oras.DefaultCopyGraphOptions); err != nil {
-	// 	t.Fatal("oras.CopyGraph() error =", err)
-	// }
-
-	// // compare content
-	// rc, err = dst.Fetch(ctx, desc)
-	// if err != nil {
-	// 	t.Fatal("Store.Fetch() error =", err)
-	// }
-	// got, err = io.ReadAll(rc)
-	// if err != nil {
-	// 	t.Fatal("Store.Fetch().Read() error =", err)
-	// }
-	// err = rc.Close()
-	// if err != nil {
-	// 	t.Error("Store.Fetch().Close() error =", err)
-	// }
-	// if !bytes.Equal(got, gotgz) {
-	// 	t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
-	// }
+	// TODO: test relative root after https://github.com/oras-project/oras-go/issues/404 gets resolved
 }

--- a/content/file/file_unix_test.go
+++ b/content/file/file_unix_test.go
@@ -265,3 +265,54 @@ func TestStore_Dir_ExtractSymlinkAbs(t *testing.T) {
 		t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
 	}
 }
+
+func TestStore_Dir_ExtractSymlinkAbs_Outside(t *testing.T) {
+	// prepare test content
+	tempDir := t.TempDir()
+	dirName := "testdir"
+	dirPath := filepath.Join(tempDir, dirName)
+	if err := os.MkdirAll(dirPath, 0777); err != nil {
+		t.Fatal("error calling Mkdir(), error =", err)
+	}
+
+	content := []byte("hello world")
+	fileName := "test.txt"
+	filePath := filepath.Join(dirPath, fileName)
+	if err := os.WriteFile(filePath, content, 0444); err != nil {
+		t.Fatal("error calling WriteFile(), error =", err)
+	}
+	// create symlink to an absolute path
+	symlink := filepath.Join(dirPath, "test_symlink")
+	if err := os.Symlink(filePath, symlink); err != nil {
+		t.Fatal("error calling Symlink(), error =", err)
+	}
+
+	src, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
+	defer src.Close()
+	ctx := context.Background()
+
+	// add dir
+	desc, err := src.Add(ctx, dirName, "", dirPath)
+	if err != nil {
+		t.Fatal("Store.Add() error =", err)
+	}
+	// pack a manifest
+	manifestDesc, err := oras.Pack(ctx, src, "dir", []ocispec.Descriptor{desc}, oras.PackOptions{})
+	if err != nil {
+		t.Fatal("oras.Pack() error =", err)
+	}
+
+	// copy to another file store created from an absolute root, to trigger extracting directory
+	tempDir = t.TempDir()
+	dst, err := New(tempDir)
+	if err != nil {
+		t.Fatal("Store.New() error =", err)
+	}
+	defer dst.Close()
+	if err := oras.CopyGraph(ctx, src, dst, manifestDesc, oras.DefaultCopyGraphOptions); err == nil {
+		t.Error("oras.CopyGraph() error = nil, wantErr ", true)
+	}
+}

--- a/content/file/file_unix_test.go
+++ b/content/file/file_unix_test.go
@@ -1,0 +1,250 @@
+//go:build !windows
+
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package file
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+)
+
+// Related issue: https://github.com/oras-project/oras-go/issues/402
+func TestStore_Dir_ExtractSymlink(t *testing.T) {
+	// prepare test content
+	tempDir := t.TempDir()
+	dirName := "testdir"
+	dirPath := filepath.Join(tempDir, dirName)
+	if err := os.MkdirAll(dirPath, 0777); err != nil {
+		t.Fatal("error calling Mkdir(), error =", err)
+	}
+
+	content := []byte("hello world")
+	fileName := "test.txt"
+	filePath := filepath.Join(dirPath, fileName)
+	if err := os.WriteFile(filePath, content, 0444); err != nil {
+		t.Fatal("error calling WriteFile(), error =", err)
+	}
+	// create symlink to a relative path
+	symlink := filepath.Join(dirPath, "test_symlink")
+	if err := os.Symlink(fileName, symlink); err != nil {
+		t.Fatal("error calling Symlink(), error =", err)
+	}
+
+	src := New(tempDir)
+	defer src.Close()
+	ctx := context.Background()
+
+	// add dir
+	desc, err := src.Add(ctx, dirName, "", dirPath)
+	if err != nil {
+		t.Fatal("Store.Add() error =", err)
+	}
+	val, ok := src.digestToPath.Load(desc.Digest)
+	if !ok {
+		t.Fatal("failed to find internal gz")
+	}
+	tmpPath := val.(string)
+	zrc, err := os.Open(tmpPath)
+	if err != nil {
+		t.Fatal("failed to open internal gz, error =", err)
+	}
+	gotgz, err := io.ReadAll(zrc)
+	if err != nil {
+		t.Fatal("failed to read internal gz, error =", err)
+	}
+	if err := zrc.Close(); err != nil {
+		t.Error("failed to close internal gz, error =", err)
+	}
+
+	// pack a manifest
+	manifestDesc, err := oras.Pack(ctx, src, "dir", []ocispec.Descriptor{desc}, oras.PackOptions{})
+	if err != nil {
+		t.Fatal("oras.Pack() error =", err)
+	}
+
+	// copy to another file store, to trigger extracting directory
+	tempDir = t.TempDir()
+	dstAbs := New(tempDir)
+	defer dstAbs.Close()
+	if err := oras.CopyGraph(ctx, src, dstAbs, manifestDesc, oras.DefaultCopyGraphOptions); err != nil {
+		t.Fatal("oras.CopyGraph() error =", err)
+	}
+
+	// compare content
+	rc, err := dstAbs.Fetch(ctx, desc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Store.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Store.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, gotgz) {
+		t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
+	}
+
+	// copy to another file store created from a relative path, to trigger extracting directory
+	tempDir = t.TempDir()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatal("error calling Chdir(), error=", err)
+	}
+	dstRel := New(".")
+	defer dstRel.Close()
+	if err := oras.CopyGraph(ctx, src, dstRel, manifestDesc, oras.DefaultCopyGraphOptions); err != nil {
+		t.Fatal("oras.CopyGraph() error =", err)
+	}
+
+	// compare content
+	rc, err = dstAbs.Fetch(ctx, desc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	got, err = io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Store.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Store.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, gotgz) {
+		t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
+	}
+}
+
+// Related issue: https://github.com/oras-project/oras-go/issues/402
+func TestStore_Dir_ExtractSymlinkAbs(t *testing.T) {
+	// prepare test content
+	tempDir := t.TempDir()
+	dirName := "testdir"
+	dirPath := filepath.Join(tempDir, dirName)
+	if err := os.MkdirAll(dirPath, 0777); err != nil {
+		t.Fatal("error calling Mkdir(), error =", err)
+	}
+
+	content := []byte("hello world")
+	fileName := "test.txt"
+	filePath := filepath.Join(dirPath, fileName)
+	if err := os.WriteFile(filePath, content, 0444); err != nil {
+		t.Fatal("error calling WriteFile(), error =", err)
+	}
+	// create symlink to an absolute path
+	symlink := filepath.Join(dirPath, "test_symlink")
+	if err := os.Symlink(filePath, symlink); err != nil {
+		t.Fatal("error calling Symlink(), error =", err)
+	}
+
+	src := New(tempDir)
+	defer src.Close()
+	ctx := context.Background()
+
+	// add dir
+	desc, err := src.Add(ctx, dirName, "", dirPath)
+	if err != nil {
+		t.Fatal("Store.Add() error =", err)
+	}
+	val, ok := src.digestToPath.Load(desc.Digest)
+	if !ok {
+		t.Fatal("failed to find internal gz")
+	}
+	tmpPath := val.(string)
+	zrc, err := os.Open(tmpPath)
+	if err != nil {
+		t.Fatal("failed to open internal gz, error =", err)
+	}
+	gotgz, err := io.ReadAll(zrc)
+	if err != nil {
+		t.Fatal("failed to read internal gz, error =", err)
+	}
+	if err := zrc.Close(); err != nil {
+		t.Error("failed to close internal gz, error =", err)
+	}
+
+	// pack a manifest
+	manifestDesc, err := oras.Pack(ctx, src, "dir", []ocispec.Descriptor{desc}, oras.PackOptions{})
+	if err != nil {
+		t.Fatal("oras.Pack() error =", err)
+	}
+
+	// remove the original testing directory and create a new store using an absolute path
+	if err := os.RemoveAll(dirPath); err != nil {
+		t.Fatal("error calling RemoveAll(), error =", err)
+	}
+	dst := New(tempDir)
+	defer dst.Close()
+	if err := oras.CopyGraph(ctx, src, dst, manifestDesc, oras.DefaultCopyGraphOptions); err != nil {
+		t.Fatal("oras.CopyGraph() error =", err)
+	}
+
+	// compare content
+	rc, err := dst.Fetch(ctx, desc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Store.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Store.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, gotgz) {
+		t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
+	}
+
+	// // remove the original testing directory and create a new store using a relative path
+	// if err := os.RemoveAll(dirPath); err != nil {
+	// 	t.Fatal("error calling RemoveAll(), error =", err)
+	// }
+	// if err := os.Chdir(tempDir); err != nil {
+	// 	t.Fatal("error calling Chdir(), error=", err)
+	// }
+	// dstRel := New(".")
+	// defer dstRel.Close()
+	// if err := oras.CopyGraph(ctx, src, dstRel, manifestDesc, oras.DefaultCopyGraphOptions); err != nil {
+	// 	t.Fatal("oras.CopyGraph() error =", err)
+	// }
+
+	// // compare content
+	// rc, err = dst.Fetch(ctx, desc)
+	// if err != nil {
+	// 	t.Fatal("Store.Fetch() error =", err)
+	// }
+	// got, err = io.ReadAll(rc)
+	// if err != nil {
+	// 	t.Fatal("Store.Fetch().Read() error =", err)
+	// }
+	// err = rc.Close()
+	// if err != nil {
+	// 	t.Error("Store.Fetch().Close() error =", err)
+	// }
+	// if !bytes.Equal(got, gotgz) {
+	// 	t.Errorf("Store.Fetch() = %v, want %v", got, gotgz)
+	// }
+}

--- a/copy_test.go
+++ b/copy_test.go
@@ -1090,7 +1090,10 @@ func TestCopy_WithTargetPlatformOptions(t *testing.T) {
 func TestCopy_RestoreDuplicates(t *testing.T) {
 	src := memory.New()
 	temp := t.TempDir()
-	dst := file.New(temp)
+	dst, err := file.New(temp)
+	if err != nil {
+		t.Fatal("file.New() error =", err)
+	}
 	defer dst.Close()
 
 	// generate test content
@@ -1144,7 +1147,7 @@ func TestCopy_RestoreDuplicates(t *testing.T) {
 
 	root := descs[3]
 	ref := "latest"
-	err := src.Tag(ctx, root, ref)
+	err = src.Tag(ctx, root, ref)
 	if err != nil {
 		t.Fatal("fail to tag root node", err)
 	}
@@ -1182,7 +1185,10 @@ func TestCopy_RestoreDuplicates(t *testing.T) {
 func TestCopy_DiscardDuplicates(t *testing.T) {
 	src := memory.New()
 	temp := t.TempDir()
-	dst := file.New(temp)
+	dst, err := file.New(temp)
+	if err != nil {
+		t.Fatal("file.New() error =", err)
+	}
 	dst.ForceCAS = true
 	defer dst.Close()
 
@@ -1237,7 +1243,7 @@ func TestCopy_DiscardDuplicates(t *testing.T) {
 
 	root := descs[3]
 	ref := "latest"
-	err := src.Tag(ctx, root, ref)
+	err = src.Tag(ctx, root, ref)
 	if err != nil {
 		t.Fatal("fail to tag root node", err)
 	}


### PR DESCRIPTION
Fixes part of #404
Fixes: #402
BREAKING CHANGE: `file.New()` and other constructors now return an error