### PR TITLE
fix!: use absolute path for OCI root

### DIFF
--- a/content/oci/storage.go
+++ b/content/oci/storage.go
@@ -60,8 +60,8 @@ func NewStorage(root string) (*Storage, error) {
 
 	return &Storage{
 		ReadOnlyStorage: NewStorageFromFS(os.DirFS(rootAbs)),
-		root:            root,
-		ingestRoot:      filepath.Join(root, "ingest"),
+		root:            rootAbs,
+		ingestRoot:      filepath.Join(rootAbs, "ingest"),
 	}, nil
 }
 

--- a/content/oci/storage.go
+++ b/content/oci/storage.go
@@ -52,12 +52,17 @@ type Storage struct {
 }
 
 // NewStorage creates a new CAS based on file system with the OCI-Image layout.
-func NewStorage(root string) *Storage {
+func NewStorage(root string) (*Storage, error) {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Storage{
-		ReadOnlyStorage: NewStorageFromFS(os.DirFS(root)),
+		ReadOnlyStorage: NewStorageFromFS(os.DirFS(rootAbs)),
 		root:            root,
 		ingestRoot:      filepath.Join(root, "ingest"),
-	}
+	}, nil
 }
 
 // Push pushes the content, matching the expected descriptor.

--- a/content/oci/storage_test.go
+++ b/content/oci/storage_test.go
@@ -41,11 +41,14 @@ func TestStorage_Success(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
 	// test push
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if err != nil {
 		t.Fatal("Storage.Push() error =", err)
 	}
@@ -85,7 +88,10 @@ func TestStorage_NotFound(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
 	exists, err := s.Exists(ctx, desc)
@@ -111,10 +117,13 @@ func TestStorage_AlreadyExists(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
-	err := s.Push(ctx, desc, bytes.NewReader(content))
+	err = s.Push(ctx, desc, bytes.NewReader(content))
 	if err != nil {
 		t.Fatal("Storage.Push() error =", err)
 	}
@@ -134,10 +143,13 @@ func TestStorage_BadPush(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
-	err := s.Push(ctx, desc, strings.NewReader("foobar"))
+	err = s.Push(ctx, desc, strings.NewReader("foobar"))
 	if err == nil {
 		t.Errorf("Storage.Push() error = %v, wantErr %v", err, true)
 	}
@@ -152,7 +164,10 @@ func TestStorage_Push_Concurrent(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
 	concurrency := 64
@@ -218,7 +233,10 @@ func TestStorage_Fetch_ExistingBlobs(t *testing.T) {
 		t.Fatal("error calling WriteFile(), error =", err)
 	}
 
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
 	exists, err := s.Exists(ctx, desc)
@@ -255,7 +273,10 @@ func TestStorage_Fetch_Concurrent(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	s := NewStorage(tempDir)
+	s, err := NewStorage(tempDir)
+	if err != nil {
+		t.Fatal("Storage.New() error =", err)
+	}
 	ctx := context.Background()
 
 	if err := s.Push(ctx, desc, bytes.NewReader(content)); err != nil {

--- a/internal/fs/tarfs/tarfs.go
+++ b/internal/fs/tarfs/tarfs.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 
 	"oras.land/oras-go/v2/errdef"
 )
@@ -43,8 +44,12 @@ type entry struct {
 
 // New returns a file system (an fs.FS) for a tar archive located at path.
 func New(path string) (*TarFS, error) {
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve absolute path for %s: %w", path, err)
+	}
 	tarfs := &TarFS{
-		path:    path,
+		path:    pathAbs,
 		entries: make(map[string]*entry),
 	}
 	if err := tarfs.indexEntries(); err != nil {

--- a/internal/fs/tarfs/tarfs_test.go
+++ b/internal/fs/tarfs/tarfs_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"path/filepath"
 	"testing"
 
 	"oras.land/oras-go/v2/errdef"
@@ -42,10 +43,19 @@ func TestTarFS_Open_Success(t *testing.T) {
 		"dir/hello":        []byte("hello"),
 		"dir/subdir/world": []byte("world"),
 	}
-	tfs, err := New("testdata/test.tar")
+	tarPath := "testdata/test.tar"
+	tfs, err := New(tarPath)
 	if err != nil {
 		t.Fatalf("New() error = %v, wantErr %v", err, nil)
 	}
+	tarPathAbs, err := filepath.Abs(tarPath)
+	if err != nil {
+		t.Fatal("error calling filepath.Abs(), error =", err)
+	}
+	if tfs.path != tarPathAbs {
+		t.Fatalf("TarFS.path = %s, want %s", tfs.path, tarPathAbs)
+	}
+
 	for name, data := range testFiles {
 		f, err := tfs.Open(name)
 		if err != nil {


### PR DESCRIPTION
Fixes: #404 
BREAKING CHANGE: `oci.NewStorage()` now returns an error