### PR TITLE
fix: Broken tests for mac

### DIFF
--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -212,7 +212,10 @@ func TestStore_Success(t *testing.T) {
 }
 
 func TestStore_RelativeRoot_Success(t *testing.T) {
-	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal("error calling filepath.EvalSymlinks(), error =", err)
+	}
 	currDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal("error calling Getwd(), error=", err)

--- a/content/file/file_unix_test.go
+++ b/content/file/file_unix_test.go
@@ -132,7 +132,10 @@ func TestStore_Dir_ExtractSymlinkRel(t *testing.T) {
 // Related issue: https://github.com/oras-project/oras-go/issues/402
 func TestStore_Dir_ExtractSymlinkAbs(t *testing.T) {
 	// prepare test content
-	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal("error calling filepath.EvalSymlinks(), error =", err)
+	}
 	dirName := "testdir"
 	dirPath := filepath.Join(tempDir, dirName)
 	if err := os.MkdirAll(dirPath, 0777); err != nil {

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -194,7 +194,10 @@ func TestStore_RelativeRoot_Success(t *testing.T) {
 	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifest)
 	ref := "foobar"
 
-	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal("error calling filepath.EvalSymlinks(), error =", err)
+	}
 	currDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal("error calling Getwd(), error=", err)

--- a/content/oci/storage_test.go
+++ b/content/oci/storage_test.go
@@ -87,7 +87,10 @@ func TestStorage_RelativeRoot_Success(t *testing.T) {
 		Size:      int64(len(content)),
 	}
 
-	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal("error calling filepath.EvalSymlinks(), error =", err)
+	}
 	currDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal("error calling Getwd(), error=", err)


### PR DESCRIPTION
These tests are broken for mac because `/var/folder` is a sym link to `/private/var/folder`.

Signed-off-by: Terry Howe <tlhowe@amazon.com>