### PR TITLE
chore: add CODEOWNERS based on OWNERS.md

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -30,6 +30,7 @@ header:
 
   paths-ignore:
     - '**/*.md'
+    - 'CODEOWNERS'
     - 'LICENSE'
     - 'go.mod'
     - 'go.sum'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Derived from OWNERS.md
+* @deitch
+* @jdolitsky
+* @sajayantony
+* @shizhMSFT
+* @stevelasker
+* @Wwwsylvia


### PR DESCRIPTION
Add [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) based on the [OWNERS.md](https://github.com/oras-project/oras-go/blob/main/OWNERS.md) file.