### PR TITLE
chore: update owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @deitch @jdolitsky @sajayantony @shizhMSFT @stevelasker @Wwwsylvia
+* @sajayantony @shizhMSFT @stevelasker @Wwwsylvia

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,9 +1,11 @@
 # Owners
 
 Owners:
-  - Avi Deitcher (@deitch)
-  - Josh Dolitsky (@jdolitsky)
   - Sajay Antony (@sajayantony)
   - Shiwei Zhang (@shizhMSFT)
   - Steve Lasker (@stevelasker)
   - Sylvia Lei (@Wwwsylvia)
+
+Emeritus:
+  - Avi Deitcher (@deitch)
+  - Josh Dolitsky (@jdolitsky)


### PR DESCRIPTION
This PR aggregates the following changes:
- Move Avi Deitcher (@deitch) to emeritus (as requested by https://github.com/oras-project/community/issues/37)
- Move Josh Dolitsky (@jdolitsky) to emeritus (as requested by https://github.com/oras-project/community/issues/32)