### PR TITLE
fix: OCI store resolve returns full descriptor

### DIFF
--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -165,7 +165,11 @@ func (s *Store) tag(ctx context.Context, desc ocispec.Descriptor, reference stri
 	return nil
 }
 
-// Resolve resolves a reference to a descriptor.
+// Resolve resolves a reference to a descriptor. If the reference to be resolved
+// is a tag, the returned descriptor will be a full descriptor declared by
+// github.com/opencontainers/image-spec/specs-go/v1. If the reference is a
+// digest the returned descriptor will be a plain descriptor (containing only
+// the digest, media type and size).
 func (s *Store) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
 	if reference == "" {
 		return ocispec.Descriptor{}, errdef.ErrMissingReference
@@ -180,7 +184,12 @@ func (s *Store) Resolve(ctx context.Context, reference string) (ocispec.Descript
 		}
 		return ocispec.Descriptor{}, err
 	}
-	return descriptor.Plain(desc), nil
+
+	if reference == desc.Digest.String() {
+		return descriptor.Plain(desc), nil
+	}
+
+	return desc, nil
 }
 
 // Predecessors returns the nodes directly pointing to the current node.

--- a/content/oci/readonlyoci.go
+++ b/content/oci/readonlyoci.go
@@ -83,7 +83,11 @@ func (s *ReadOnlyStore) Exists(ctx context.Context, target ocispec.Descriptor) (
 	return s.storage.Exists(ctx, target)
 }
 
-// Resolve resolves a reference to a descriptor.
+// Resolve resolves a reference to a descriptor. If the reference to be resolved
+// is a tag, the returned descriptor will be a full descriptor declared by
+// github.com/opencontainers/image-spec/specs-go/v1. If the reference is a
+// digest the returned descriptor will be a plain descriptor (containing only
+// the digest, media type and size).
 func (s *ReadOnlyStore) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
 	if reference == "" {
 		return ocispec.Descriptor{}, errdef.ErrMissingReference
@@ -98,7 +102,12 @@ func (s *ReadOnlyStore) Resolve(ctx context.Context, reference string) (ocispec.
 		}
 		return ocispec.Descriptor{}, err
 	}
-	return descriptor.Plain(desc), nil
+
+	if reference == desc.Digest.String() {
+		return descriptor.Plain(desc), nil
+	}
+
+	return desc, nil
 }
 
 // Predecessors returns the nodes directly pointing to the current node.

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -34,6 +34,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/internal/docker"
 	"oras.land/oras-go/v2/registry"
@@ -148,8 +149,15 @@ func TestReadOnlyStore(t *testing.T) {
 	if err != nil {
 		t.Error("ReadOnlyStore.Resolve() error =", err)
 	}
-	if want := descs[2]; !reflect.DeepEqual(gotDesc, want) {
+	if want := descs[2]; !content.Equal(gotDesc, want) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, want)
+	}
+
+	// descriptor resolved by tag should have annotations
+	if gotDesc.Annotations[ocispec.AnnotationRefName] != subjectTag {
+		t.Errorf("ReadOnlyStore.Resolve() returned descriptor without annotations %v, want %v",
+			gotDesc.Annotations,
+			map[string]string{ocispec.AnnotationRefName: subjectTag})
 	}
 
 	// test resolving artifact by digest
@@ -318,7 +326,7 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 	if err != nil {
 		t.Fatal("ReadOnlyStore: Resolve() error =", err)
 	}
-	if !reflect.DeepEqual(gotDesc, indexRoot) {
+	if !content.Equal(gotDesc, indexRoot) {
 		t.Errorf("ReadOnlyStore.Resolve() = %v, want %v", gotDesc, indexRoot)
 	}
 
@@ -613,7 +621,7 @@ func TestReadOnlyStore_Copy_OCIToMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Copy() error = %v, wantErr %v", err, false)
 	}
-	if !reflect.DeepEqual(gotDesc, root) {
+	if !content.Equal(gotDesc, root) {
 		t.Errorf("Copy() = %v, want %v", gotDesc, root)
 	}
 
@@ -633,7 +641,7 @@ func TestReadOnlyStore_Copy_OCIToMemory(t *testing.T) {
 	if err != nil {
 		t.Fatal("dst.Resolve() error =", err)
 	}
-	if !reflect.DeepEqual(gotDesc, root) {
+	if !content.Equal(gotDesc, root) {
 		t.Errorf("dst.Resolve() = %v, want %v", gotDesc, root)
 	}
 }


### PR DESCRIPTION
Based on discussion on https://github.com/oras-project/oras-go/issues/457, this PR returns a full descriptor on Resolve when the method it's called by tag and it returns a plain descriptor when the method it's called by digest.