### PR TITLE
Make `errSkipDesc` a publicly available error

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -37,8 +37,8 @@ import (
 // defaultConcurrency is the default value of CopyGraphOptions.Concurrency.
 const defaultConcurrency int = 3 // This value is consistent with dockerd and containerd.
 
-// errSkipDesc signals copyNode() to stop processing a descriptor.
-var errSkipDesc = errors.New("skip descriptor")
+// ErrSkipDesc signals copyNode() to stop processing a descriptor.
+var ErrSkipDesc = errors.New("skip descriptor")
 
 // DefaultCopyOptions provides the default CopyOptions.
 var DefaultCopyOptions CopyOptions = CopyOptions{
@@ -281,7 +281,7 @@ func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.St
 func copyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor, opts CopyGraphOptions) error {
 	if opts.PreCopy != nil {
 		if err := opts.PreCopy(ctx, desc); err != nil {
-			if err == errSkipDesc {
+			if err == ErrSkipDesc {
 				return nil
 			}
 			return err
@@ -373,7 +373,7 @@ func prepareCopy(ctx context.Context, dst Target, dstRef string, proxy *cas.Prox
 				}
 			}
 			// skip the regular copy workflow
-			return errSkipDesc
+			return ErrSkipDesc
 		}
 	} else {
 		postCopy := opts.PostCopy


### PR DESCRIPTION
With this change, `oras.ErrSkipDesc` can be used during `PreCopy` to do custom filtering during copy operations.

This error is needed to be public as `errors.New` will always create a new error instance, even if the text is the same, so you cannot utilize `errors.New("skip descriptor")`.

ex (psuedo code):

```go

        only := []string{"hello.txt", "world.txt"}
	copyOpts.PreCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
		if len(only) > 0 {
			if !utils.sliceContains(only, desc.Annotations[ocispec.AnnotationTitle]) {
				return oras.ErrSkipDesc
			}
		}
		return nil
	}
```