### PR TITLE
build: upgrade image-spec to v1.1.0-rc.3

### DIFF
--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -39,6 +39,7 @@ import (
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/descriptor"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // storageTracker tracks storage API counts.
@@ -2287,14 +2288,14 @@ func TestStore_Predecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest ocispec.Artifact
+		var manifest spec.Artifact
 		manifest.Subject = &subject
 		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/graph.go
+++ b/content/graph.go
@@ -21,6 +21,7 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // PredecessorFinder finds out the nodes directly pointing to a given node of a
@@ -86,13 +87,13 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 			return nil, err
 		}
 		return index.Manifests, nil
-	case ocispec.MediaTypeArtifactManifest:
+	case spec.MediaTypeArtifactManifest:
 		content, err := FetchAll(ctx, fetcher, node)
 		if err != nil {
 			return nil, err
 		}
 
-		var manifest ocispec.Artifact
+		var manifest spec.Artifact
 		if err := json.Unmarshal(content, &manifest); err != nil {
 			return nil, err
 		}

--- a/content/memory/memory_test.go
+++ b/content/memory/memory_test.go
@@ -35,6 +35,7 @@ import (
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
 	"oras.land/oras-go/v2/internal/resolver"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 func TestStoreInterface(t *testing.T) {
@@ -330,14 +331,14 @@ func TestStorePredecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest ocispec.Artifact
+		var manifest spec.Artifact
 		manifest.Subject = &subject
 		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -40,6 +40,7 @@ import (
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
 	"oras.land/oras-go/v2/internal/descriptor"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -991,14 +992,14 @@ func TestStore_Predecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest ocispec.Artifact
+		var manifest spec.Artifact
 		manifest.Subject = &subject
 		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -1103,14 +1104,14 @@ func TestStore_ExistingStore(t *testing.T) {
 	}
 
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest ocispec.Artifact
+		var manifest spec.Artifact
 		manifest.Subject = &subject
 		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -37,6 +37,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -75,8 +76,8 @@ func TestReadOnlyStore(t *testing.T) {
 		appendBlob(manifest.MediaType, manifestJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType: ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType: spec.MediaTypeArtifactManifest,
 			Subject:   &subject,
 			Blobs:     blobs,
 		}
@@ -265,14 +266,14 @@ func TestReadOnlyStore_DirFS(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest ocispec.Artifact
+		var manifest spec.Artifact
 		manifest.Subject = &subject
 		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -554,8 +555,8 @@ func TestReadOnlyStore_Copy_OCIToMemory(t *testing.T) {
 		appendBlob(manifest.MediaType, manifestJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType: ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType: spec.MediaTypeArtifactManifest,
 			Subject:   &subject,
 			Blobs:     blobs,
 		}

--- a/copy_test.go
+++ b/copy_test.go
@@ -36,6 +36,7 @@ import (
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
 	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // storageTracker tracks storage API counts.
@@ -1459,8 +1460,8 @@ func TestCopyGraph_WithConcurrencyLimit(t *testing.T) {
 		appendBlob(manifest.MediaType, manifestJSON)
 	}
 	generateArtifact := func(subject *ocispec.Descriptor, artifactType string, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Subject:      subject,
 			Blobs:        blobs,
 			ArtifactType: artifactType,

--- a/example_test.go
+++ b/example_test.go
@@ -34,25 +34,26 @@ import (
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
 var exampleMemoryStore oras.Target
 var remoteHost string
 var (
-	exampleManifest, _ = json.Marshal(ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	exampleManifest, _ = json.Marshal(spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/content"})
 	exampleManifestDescriptor = ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+		MediaType: spec.MediaTypeArtifactManifest,
 		Digest:    digest.Digest(digest.FromBytes(exampleManifest)),
 		Size:      int64(len(exampleManifest))}
-	exampleSignatureManifest, _ = json.Marshal(ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	exampleSignatureManifest, _ = json.Marshal(spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Subject:      &exampleManifestDescriptor})
 	exampleSignatureManifestDescriptor = ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+		MediaType: spec.MediaTypeArtifactManifest,
 		Digest:    digest.FromBytes(exampleSignatureManifest),
 		Size:      int64(len(exampleSignatureManifest))}
 )
@@ -117,7 +118,7 @@ func TestMain(m *testing.M) {
 		case strings.Contains(p, "/blobs/uploads/"+exampleUploadUUid) && m == "GET":
 			w.WriteHeader(http.StatusCreated)
 		case strings.Contains(p, "/manifests/"+string(exampleSignatureManifestDescriptor.Digest)):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Docker-Content-Digest", string(exampleSignatureManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSignatureManifest)))
 			w.Write(exampleSignatureManifest)
@@ -125,7 +126,7 @@ func TestMain(m *testing.M) {
 			w.WriteHeader(http.StatusCreated)
 		case strings.Contains(p, "/manifests/"+string(exampleManifestDescriptor.Digest)),
 			strings.Contains(p, "/manifests/latest") && m == "HEAD":
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Docker-Content-Digest", string(exampleManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleManifest)))
 			if m == "GET" {

--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -29,6 +29,7 @@ import (
 	"oras.land/oras-go/v2/internal/copyutil"
 	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/internal/status"
 	"oras.land/oras-go/v2/internal/syncutil"
 	"oras.land/oras-go/v2/registry"
@@ -255,7 +256,7 @@ func (opts *ExtendedCopyGraphOptions) FilterAnnotation(key string, regex *regexp
 				switch p.MediaType {
 				case docker.MediaTypeManifest, ocispec.MediaTypeImageManifest,
 					docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex,
-					ocispec.MediaTypeArtifactManifest:
+					spec.MediaTypeArtifactManifest:
 					annotations, err := fetchAnnotations(ctx, src, p)
 					if err != nil {
 						return nil, err
@@ -345,7 +346,7 @@ func (opts *ExtendedCopyGraphOptions) FilterArtifactType(regex *regexp.Regexp) {
 				// if the artifact type is not present in the descriptors,
 				// fetch it from the manifest content.
 				switch p.MediaType {
-				case ocispec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest:
+				case spec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest:
 					artifactType, err := fetchArtifactType(ctx, src, p)
 					if err != nil {
 						return nil, err
@@ -370,8 +371,8 @@ func fetchArtifactType(ctx context.Context, src content.ReadOnlyGraphStorage, de
 	defer rc.Close()
 
 	switch desc.MediaType {
-	case ocispec.MediaTypeArtifactManifest:
-		var manifest ocispec.Artifact
+	case spec.MediaTypeArtifactManifest:
+		var manifest spec.Artifact
 		if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
 			return "", err
 		}

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -37,6 +37,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
@@ -68,8 +69,8 @@ func TestExtendedCopy_FullCopy(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType: ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType: spec.MediaTypeArtifactManifest,
 			Subject:   &subject,
 			Blobs:     blobs,
 		}
@@ -77,7 +78,7 @@ func TestExtendedCopy_FullCopy(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -170,8 +171,8 @@ func TestExtendedCopyGraph_FullCopy(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType: ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType: spec.MediaTypeArtifactManifest,
 			Subject:   &subject,
 			Blobs:     blobs,
 		}
@@ -179,7 +180,7 @@ func TestExtendedCopyGraph_FullCopy(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -377,8 +378,8 @@ func TestExtendedCopyGraph_WithDepthOption(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType: ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType: spec.MediaTypeArtifactManifest,
 			Subject:   &subject,
 			Blobs:     blobs,
 		}
@@ -386,7 +387,7 @@ func TestExtendedCopyGraph_WithDepthOption(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -511,8 +512,8 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		manifest := ocispec.Artifact{
-			MediaType: ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType: spec.MediaTypeArtifactManifest,
 			Subject:   &subject,
 			Blobs:     blobs,
 		}
@@ -520,7 +521,7 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -575,7 +576,7 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 			for _, p := range predecessors {
 				// filter media type
 				switch p.MediaType {
-				case ocispec.MediaTypeArtifactManifest:
+				case spec.MediaTypeArtifactManifest:
 					filtered = append(filtered, p)
 				}
 			}
@@ -617,8 +618,8 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex(t *testing.T) {
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
-		manifest := ocispec.Artifact{
-			MediaType:   ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:   spec.MediaTypeArtifactManifest,
 			Subject:     &subject,
 			Annotations: map[string]string{key: value},
 		}
@@ -626,7 +627,7 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))   // descs[0]
 	generateArtifactManifest(descs[0], "bar", "bluebrown")   // descs[1]
@@ -713,8 +714,8 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex(t *testing.T) {
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
-		manifest := ocispec.Artifact{
-			MediaType:   ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:   spec.MediaTypeArtifactManifest,
 			Subject:     &subject,
 			Annotations: map[string]string{key: value},
 		}
@@ -722,7 +723,7 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))   // descs[0]
 	generateArtifactManifest(descs[0], "bar", "bluebrown")   // descs[1]
@@ -820,8 +821,8 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex_AnnotationInDescriptor(t *t
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
-		manifest := ocispec.Artifact{
-			MediaType:   ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:   spec.MediaTypeArtifactManifest,
 			Subject:     &subject,
 			Annotations: map[string]string{key: value},
 		}
@@ -829,7 +830,7 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex_AnnotationInDescriptor(t *t
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, key, value, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, key, value, manifestJSON)
 	}
 	appendBlob(ocispec.MediaTypeImageLayer, "", "", []byte("foo")) // descs[0]
 	generateArtifactManifest(descs[0], "bar", "bluebrown")         // descs[1]
@@ -890,8 +891,8 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex_Referrers(t *testin
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
-		manifest := ocispec.Artifact{
-			MediaType:   ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:   spec.MediaTypeArtifactManifest,
 			Subject:     &subject,
 			Annotations: map[string]string{key: value},
 		}
@@ -899,7 +900,7 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex_Referrers(t *testin
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, key, value, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, key, value, manifestJSON)
 	}
 	appendBlob(ocispec.MediaTypeImageLayer, "", "", []byte("foo")) // descs[0]
 	generateArtifactManifest(descs[0], "bar", "bluebrown")         // descs[1]
@@ -930,27 +931,27 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex_Referrers(t *testin
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[0])))
 			w.Write(blobs[0])
 		case strings.Contains(p, descs[1].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[1].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[1])))
 			w.Write(blobs[1])
 		case strings.Contains(p, descs[2].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[2].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[2])))
 			w.Write(blobs[2])
 		case strings.Contains(p, descs[3].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[3].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[3])))
 			w.Write(blobs[3])
 		case strings.Contains(p, descs[4].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[4].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[4])))
 			w.Write(blobs[4])
 		case strings.Contains(p, descs[5].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[5].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[5])))
 			w.Write(blobs[5])
@@ -1053,8 +1054,8 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex(t *testing.T) {
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			ArtifactType: artifactType,
 			Subject:      &subject,
 		}
@@ -1062,7 +1063,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo")) // descs[0]
@@ -1135,8 +1136,8 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex(t *testing.T) {
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			ArtifactType: artifactType,
 			Subject:      &subject,
 		}
@@ -1144,7 +1145,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo")) // descs[0]
 	generateArtifactManifest(descs[0], "good-bar-yellow")  // descs[1]
@@ -1230,8 +1231,8 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex_ArtifactTypeInDescriptor(
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			ArtifactType: artifactType,
 			Subject:      &subject,
 		}
@@ -1239,7 +1240,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex_ArtifactTypeInDescriptor(
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, artifactType, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageLayer, "", []byte("foo")) // descs[0]
@@ -1313,8 +1314,8 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex_Referrers(t *test
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			ArtifactType: artifactType,
 			Subject:      &subject,
 		}
@@ -1322,7 +1323,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex_Referrers(t *test
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, artifactType, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageLayer, "", []byte("foo")) // descs[0]
@@ -1353,27 +1354,27 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex_Referrers(t *test
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[0])))
 			w.Write(blobs[0])
 		case strings.Contains(p, descs[1].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[1].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[1])))
 			w.Write(blobs[1])
 		case strings.Contains(p, descs[2].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[2].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[2])))
 			w.Write(blobs[2])
 		case strings.Contains(p, descs[3].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[3].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[3])))
 			w.Write(blobs[3])
 		case strings.Contains(p, descs[4].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[4].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[4])))
 			w.Write(blobs[4])
 		case strings.Contains(p, descs[5].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[5].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[5])))
 			w.Write(blobs[5])
@@ -1444,8 +1445,8 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex(t *t
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string, value string) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			ArtifactType: artifactType,
 			Subject:      &subject,
 			Annotations:  map[string]string{"rank": value},
@@ -1454,7 +1455,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex(t *t
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(spec.MediaTypeArtifactManifest, manifestJSON)
 	}
 	generateImageManifest := func(subject, config ocispec.Descriptor, value string) {
 		manifest := ocispec.Manifest{
@@ -1550,8 +1551,8 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex_Refe
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string, value string) {
-		manifest := ocispec.Artifact{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+		manifest := spec.Artifact{
+			MediaType:    spec.MediaTypeArtifactManifest,
 			ArtifactType: artifactType,
 			Subject:      &subject,
 			Annotations:  map[string]string{"rank": value},
@@ -1560,7 +1561,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex_Refe
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON, value)
+		appendBlob(spec.MediaTypeArtifactManifest, artifactType, manifestJSON, value)
 	}
 	appendBlob(ocispec.MediaTypeImageLayer, "", []byte("foo"), "na") // descs[0]
 	generateArtifactManifest(descs[0], "good-bar-yellow", "1st")     // descs[1]
@@ -1594,47 +1595,47 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex_Refe
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[0])))
 			w.Write(blobs[0])
 		case strings.Contains(p, descs[1].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[1].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[1])))
 			w.Write(blobs[1])
 		case strings.Contains(p, descs[2].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[2].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[2])))
 			w.Write(blobs[2])
 		case strings.Contains(p, descs[3].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[3].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[3])))
 			w.Write(blobs[3])
 		case strings.Contains(p, descs[4].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[4].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[4])))
 			w.Write(blobs[4])
 		case strings.Contains(p, descs[5].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[5].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[5])))
 			w.Write(blobs[5])
 		case strings.Contains(p, descs[6].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[6].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[6])))
 			w.Write(blobs[6])
 		case strings.Contains(p, descs[7].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[7].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[7])))
 			w.Write(blobs[7])
 		case strings.Contains(p, descs[8].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[8].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[8])))
 			w.Write(blobs[8])
 		case strings.Contains(p, descs[9].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", descs[9].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[9])))
 			w.Write(blobs[9])

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.19
 
 require (
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.0-rc2
+	github.com/opencontainers/image-spec v1.1.0-rc.3
 	golang.org/x/sync v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
-github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/opencontainers/image-spec v1.1.0-rc.3 h1:GT9Xon8YrLxz6N7sErbN81V8J4lOQKGUZQmI3ioviqU=
+github.com/opencontainers/image-spec v1.1.0-rc.3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/descriptor/descriptor.go
+++ b/internal/descriptor/descriptor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // DefaultMediaType is the media type used when no media type is specified.
@@ -70,7 +71,7 @@ func IsManifest(desc ocispec.Descriptor) bool {
 		docker.MediaTypeManifestList,
 		ocispec.MediaTypeImageManifest,
 		ocispec.MediaTypeImageIndex,
-		ocispec.MediaTypeArtifactManifest:
+		spec.MediaTypeArtifactManifest:
 		return true
 	default:
 		return false

--- a/internal/spec/artifact.go
+++ b/internal/spec/artifact.go
@@ -1,0 +1,43 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+// AnnotationReferrersFiltersApplied is the annotation key for the comma separated list of filters applied by the registry in the referrers listing.
+const AnnotationReferrersFiltersApplied = "org.opencontainers.referrers.filtersApplied"
+
+// MediaTypeArtifactManifest specifies the media type for a content descriptor.
+const MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json"
+
+// Artifact describes an artifact manifest.
+// This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+type Artifact struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
+	// ArtifactType is the IANA media type of the artifact this schema refers to.
+	ArtifactType string `json:"artifactType"`
+
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []ocispec.Descriptor `json:"blobs,omitempty"`
+
+	// Subject (reference) is an optional link from the artifact to another manifest forming an association between the artifact and the other manifest.
+	Subject *ocispec.Descriptor `json:"subject,omitempty"`
+
+	// Annotations contains arbitrary metadata for the artifact manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/internal/spec/artifact.go
+++ b/internal/spec/artifact.go
@@ -25,6 +25,12 @@ const MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json
 
 // Artifact describes an artifact manifest.
 // This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+//
+// This manifest type was introduced in image-spec v1.1.0-rc1 and was removed in
+// image-spec v1.1.0-rc3. It is not part of the current image-spec and is kept
+// here for Go compatibility.
+//
+// Reference: https://github.com/opencontainers/image-spec/pull/999
 type Artifact struct {
 	// MediaType is the media type of the object this schema refers to.
 	MediaType string `json:"mediaType"`

--- a/pack.go
+++ b/pack.go
@@ -27,6 +27,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 const (
@@ -93,8 +94,8 @@ func packArtifact(ctx context.Context, pusher content.Pusher, artifactType strin
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	manifest := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	manifest := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: artifactType,
 		Blobs:        blobs,
 		Subject:      opts.Subject,
@@ -104,7 +105,7 @@ func packArtifact(ctx context.Context, pusher content.Pusher, artifactType strin
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
 	}
-	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, manifestJSON)
+	manifestDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, manifestJSON)
 	// populate ArtifactType and Annotations of the manifest into manifestDesc
 	manifestDesc.ArtifactType = manifest.ArtifactType
 	manifestDesc.Annotations = manifest.Annotations

--- a/pack_test.go
+++ b/pack_test.go
@@ -30,6 +30,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 func Test_Pack_Default(t *testing.T) {
@@ -50,7 +51,7 @@ func Test_Pack_Default(t *testing.T) {
 	}
 
 	// test blobs
-	var manifest ocispec.Artifact
+	var manifest spec.Artifact
 	rc, err := s.Fetch(ctx, manifestDesc)
 	if err != nil {
 		t.Fatal("Store.Fetch() error =", err)
@@ -66,8 +67,8 @@ func Test_Pack_Default(t *testing.T) {
 	}
 
 	// test media type
-	if got := manifest.MediaType; got != ocispec.MediaTypeArtifactManifest {
-		t.Fatalf("got media type = %s, want %s", got, ocispec.MediaTypeArtifactManifest)
+	if got := manifest.MediaType; got != spec.MediaTypeArtifactManifest {
+		t.Fatalf("got media type = %s, want %s", got, spec.MediaTypeArtifactManifest)
 	}
 
 	// test artifact type
@@ -119,8 +120,8 @@ func Test_Pack_WithOptions(t *testing.T) {
 		t.Fatal("Oras.Pack() error =", err)
 	}
 
-	expectedManifest := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	expectedManifest := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: artifactType,
 		Blobs:        blobs,
 		Subject:      opts.Subject,
@@ -160,7 +161,7 @@ func Test_Pack_NoBlob(t *testing.T) {
 		t.Fatal("Oras.Pack() error =", err)
 	}
 
-	var manifest ocispec.Artifact
+	var manifest spec.Artifact
 	rc, err := s.Fetch(ctx, manifestDesc)
 	if err != nil {
 		t.Fatal("Store.Fetch() error =", err)
@@ -188,7 +189,7 @@ func Test_Pack_NoArtifactType(t *testing.T) {
 		t.Fatal("Oras.Pack() error =", err)
 	}
 
-	var manifest ocispec.Artifact
+	var manifest spec.Artifact
 	rc, err := s.Fetch(ctx, manifestDesc)
 	if err != nil {
 		t.Fatal("Store.Fetch() error =", err)

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -34,6 +34,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/internal/spec"
 	. "oras.land/oras-go/v2/registry/internal/doc"
 	"oras.land/oras-go/v2/registry/remote"
 )
@@ -67,21 +68,21 @@ var (
 	})
 	exampleManifestDescriptor   = content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, exampleManifest)
 	exampleManifestDigest       = exampleManifestDescriptor.Digest.String()
-	exampleSignatureManifest, _ = json.Marshal(ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	exampleSignatureManifest, _ = json.Marshal(spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Subject:      &exampleManifestDescriptor})
 	exampleSignatureManifestDescriptor = ocispec.Descriptor{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Digest:       digest.FromBytes(exampleSignatureManifest),
 		Size:         int64(len(exampleSignatureManifest))}
-	exampleSBoMManifest, _ = json.Marshal(ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	exampleSBoMManifest, _ = json.Marshal(spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Subject:      &exampleManifestDescriptor})
 	exampleSBoMManifestDescriptor = ocispec.Descriptor{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Digest:       digest.FromBytes(exampleSBoMManifest),
 		Size:         int64(len(exampleSBoMManifest))}
@@ -94,13 +95,13 @@ var (
 		MediaType: "application/tar",
 		Digest:    digest.FromBytes([]byte(blobContent)),
 		Size:      int64(len(blobContent))}
-	exampleManifestWithBlobs, _ = json.Marshal(ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	exampleManifestWithBlobs, _ = json.Marshal(spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
 		Blobs:        []ocispec.Descriptor{blobDescriptor},
 		Subject:      &exampleManifestDescriptor})
 	exampleManifestWithBlobsDescriptor = ocispec.Descriptor{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
 		Digest:       digest.FromBytes(exampleManifestWithBlobs),
 		Size:         int64(len(exampleManifestWithBlobs))}
@@ -150,22 +151,22 @@ func TestMain(m *testing.M) {
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, ReferenceManifestDigest) && m == "PUT":
 			w.WriteHeader(http.StatusCreated)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleSignatureManifestDescriptor.Digest) && m == "GET":
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleSignatureManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSignatureManifest)))
 			w.Write(exampleSignatureManifest)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleSBoMManifestDescriptor.Digest) && m == "GET":
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleSBoMManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSBoMManifest)))
 			w.Write(exampleSBoMManifest)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleManifestWithBlobsDescriptor.Digest) && m == "GET":
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleManifestWithBlobsDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleManifestWithBlobs)))
 			w.Write(exampleManifestWithBlobs)
 		case p == fmt.Sprintf("/v2/%s/blobs/%s", exampleRepositoryName, blobDescriptor.Digest) && m == "GET":
-			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", spec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(blobDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobContent)))
 			w.Write([]byte(blobContent))
@@ -317,8 +318,8 @@ func ExampleRepository_Push_artifactReferenceManifest() {
 	}
 
 	// 3. assemble the reference artifact manifest
-	referenceManifest := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	referenceManifest := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "sbom/example",
 		Subject:      &manifestDescriptor,
 	}
@@ -326,7 +327,7 @@ func ExampleRepository_Push_artifactReferenceManifest() {
 	if err != nil {
 		panic(err)
 	}
-	referenceManifestDescriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, referenceManifestContent)
+	referenceManifestDescriptor := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, referenceManifestContent)
 	// 4. push the reference manifest descriptor and content
 	err = repo.Push(ctx, referenceManifestDescriptor, bytes.NewReader(referenceManifestContent))
 	if err != nil {
@@ -507,7 +508,7 @@ func ExampleRepository_fetchArtifactBlobs() {
 	fmt.Println(string(pulledContent))
 
 	// 2. Parse the pulled manifest and fetch its blobs.
-	var pulledManifest ocispec.Artifact
+	var pulledManifest spec.Artifact
 	if err := json.Unmarshal(pulledContent, &pulledManifest); err != nil {
 		panic(err)
 	}

--- a/registry/remote/manifest.go
+++ b/registry/remote/manifest.go
@@ -20,6 +20,7 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // defaultManifestMediaTypes contains the default set of manifests media types.
@@ -28,7 +29,7 @@ var defaultManifestMediaTypes = []string{
 	docker.MediaTypeManifestList,
 	ocispec.MediaTypeImageManifest,
 	ocispec.MediaTypeImageIndex,
-	ocispec.MediaTypeArtifactManifest,
+	spec.MediaTypeArtifactManifest,
 }
 
 // defaultManifestAcceptHeader is the default set in the `Accept` header for

--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -22,6 +22,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/internal/descriptor"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 // zeroDigest represents a digest that consists of zeros. zeroDigest is used
@@ -112,7 +113,7 @@ func buildReferrersTag(desc ocispec.Descriptor) string {
 // isReferrersFilterApplied checks annotations to see if requested is in the
 // applied filter list.
 func isReferrersFilterApplied(annotations map[string]string, requested string) bool {
-	applied := annotations[ocispec.AnnotationReferrersFiltersApplied]
+	applied := annotations[spec.AnnotationReferrersFiltersApplied]
 	if applied == "" || requested == "" {
 		return false
 	}

--- a/registry/remote/referrers_test.go
+++ b/registry/remote/referrers_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/spec"
 )
 
 func Test_buildReferrersTag(t *testing.T) {
@@ -69,31 +70,31 @@ func Test_isReferrersFilterApplied(t *testing.T) {
 	}{
 		{
 			name:        "single filter applied, specified filter matches",
-			annotations: map[string]string{ocispec.AnnotationReferrersFiltersApplied: "artifactType"},
+			annotations: map[string]string{spec.AnnotationReferrersFiltersApplied: "artifactType"},
 			requested:   "artifactType",
 			want:        true,
 		},
 		{
 			name:        "single filter applied, specified filter does not match",
-			annotations: map[string]string{ocispec.AnnotationReferrersFiltersApplied: "foo"},
+			annotations: map[string]string{spec.AnnotationReferrersFiltersApplied: "foo"},
 			requested:   "artifactType",
 			want:        false,
 		},
 		{
 			name:        "multiple filters applied, specified filter matches",
-			annotations: map[string]string{ocispec.AnnotationReferrersFiltersApplied: "foo,artifactType"},
+			annotations: map[string]string{spec.AnnotationReferrersFiltersApplied: "foo,artifactType"},
 			requested:   "artifactType",
 			want:        true,
 		},
 		{
 			name:        "multiple filters applied, specified filter does not match",
-			annotations: map[string]string{ocispec.AnnotationReferrersFiltersApplied: "foo,bar"},
+			annotations: map[string]string{spec.AnnotationReferrersFiltersApplied: "foo,bar"},
 			requested:   "artifactType",
 			want:        false,
 		},
 		{
 			name:        "single filter applied, specified filter empty",
-			annotations: map[string]string{ocispec.AnnotationReferrersFiltersApplied: "foo"},
+			annotations: map[string]string{spec.AnnotationReferrersFiltersApplied: "foo"},
 			requested:   "",
 			want:        false,
 		},
@@ -105,7 +106,7 @@ func Test_isReferrersFilterApplied(t *testing.T) {
 		},
 		{
 			name:        "empty filter applied",
-			annotations: map[string]string{ocispec.AnnotationReferrersFiltersApplied: ""},
+			annotations: map[string]string{spec.AnnotationReferrersFiltersApplied: ""},
 			requested:   "artifactType",
 			want:        false,
 		},
@@ -128,31 +129,31 @@ func Test_isReferrersFilterApplied(t *testing.T) {
 func Test_filterReferrers(t *testing.T) {
 	refs := []ocispec.Descriptor{
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         2,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.foo",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         3,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.bar",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("5"),
 			ArtifactType: "application/vnd.baz",
@@ -161,13 +162,13 @@ func Test_filterReferrers(t *testing.T) {
 	got := filterReferrers(refs, "application/vnd.test")
 	want := []ocispec.Descriptor{
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
@@ -181,19 +182,19 @@ func Test_filterReferrers(t *testing.T) {
 func Test_filterReferrers_allMatch(t *testing.T) {
 	refs := []ocispec.Descriptor{
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.test",

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -39,6 +39,7 @@ import (
 	"oras.land/oras-go/v2/internal/ioutil"
 	"oras.land/oras-go/v2/internal/registryutil"
 	"oras.land/oras-go/v2/internal/slices"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/internal/syncutil"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -946,7 +947,7 @@ func (s *manifestStore) Delete(ctx context.Context, target ocispec.Descriptor) e
 // deleteWithIndexing removes the manifest content identified by the descriptor,
 // and indexes referrers for the manifest when needed.
 func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.Descriptor) error {
-	if target.MediaType == ocispec.MediaTypeArtifactManifest || target.MediaType == ocispec.MediaTypeImageManifest {
+	if target.MediaType == spec.MediaTypeArtifactManifest || target.MediaType == ocispec.MediaTypeImageManifest {
 		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
 			// referrers API is available, no client-side indexing needed
 			return s.repo.delete(ctx, target, true)
@@ -1155,7 +1156,7 @@ func (s *manifestStore) push(ctx context.Context, expected ocispec.Descriptor, c
 // and indexes referrers for the manifest when needed.
 func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.Descriptor, r io.Reader, reference string) error {
 	switch expected.MediaType {
-	case ocispec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest:
+	case spec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest:
 		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
 			// referrers API is available, no client-side indexing needed
 			return s.push(ctx, expected, r, reference)
@@ -1183,8 +1184,8 @@ func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.D
 func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.Descriptor, manifestJSON []byte) error {
 	var subject ocispec.Descriptor
 	switch desc.MediaType {
-	case ocispec.MediaTypeArtifactManifest:
-		var manifest ocispec.Artifact
+	case spec.MediaTypeArtifactManifest:
+		var manifest spec.Artifact
 		if err := json.Unmarshal(manifestJSON, &manifest); err != nil {
 			return fmt.Errorf("failed to decode manifest: %s: %s: %w", desc.Digest, desc.MediaType, err)
 		}

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -40,6 +40,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/interfaces"
+	"oras.land/oras-go/v2/internal/spec"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
@@ -870,13 +871,13 @@ func TestRepository_Predecessors(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -884,13 +885,13 @@ func TestRepository_Predecessors(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -898,7 +899,7 @@ func TestRepository_Predecessors(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -979,13 +980,13 @@ func TestRepository_Referrers(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -993,13 +994,13 @@ func TestRepository_Referrers(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1007,7 +1008,7 @@ func TestRepository_Referrers(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1153,31 +1154,31 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 
 	referrers := []ocispec.Descriptor{
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         2,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         3,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("5"),
 			ArtifactType: "application/vnd.test",
@@ -1530,13 +1531,13 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -1544,13 +1545,13 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1558,7 +1559,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1604,7 +1605,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 			MediaType: ocispec.MediaTypeImageIndex,
 			Manifests: referrers,
 			Annotations: map[string]string{
-				ocispec.AnnotationReferrersFiltersApplied: "artifactType",
+				spec.AnnotationReferrersFiltersApplied: "artifactType",
 			},
 		}
 		if err := json.NewEncoder(w).Encode(result); err != nil {
@@ -1654,13 +1655,13 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.foo",
@@ -1668,13 +1669,13 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.bar",
@@ -1682,7 +1683,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.baz",
@@ -1692,7 +1693,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	filteredReferrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
@@ -1700,7 +1701,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    ocispec.MediaTypeArtifactManifest,
+				MediaType:    spec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
@@ -1793,31 +1794,31 @@ func TestRepository_Referrers_TagSchemaFallback_ClientFiltering(t *testing.T) {
 
 	referrers := []ocispec.Descriptor{
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         2,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.foo",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         3,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.bar",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("5"),
 			ArtifactType: "application/vnd.baz",
@@ -1825,13 +1826,13 @@ func TestRepository_Referrers_TagSchemaFallback_ClientFiltering(t *testing.T) {
 	}
 	filteredReferrers := []ocispec.Descriptor{
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    ocispec.MediaTypeArtifactManifest,
+			MediaType:    spec.MediaTypeArtifactManifest,
 			Size:         3,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.test",
@@ -2785,9 +2786,9 @@ func Test_ManifestStore_Push(t *testing.T) {
 func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
-	artifact := ocispec.Artifact{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
 		Subject:   &subjectDesc,
 	}
 	artifactJSON, err := json.Marshal(artifact)
@@ -2889,10 +2890,10 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
 	referrersTag := strings.Replace(subjectDesc.Digest.String(), ":", "-", 1)
-	artifact := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	artifact := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		Subject:      &subjectDesc,
 		ArtifactType: "application/vnd.test",
 		Annotations:  map[string]string{"foo": "bar"},
@@ -3281,9 +3282,9 @@ func Test_ManifestStore_Delete(t *testing.T) {
 func Test_ManifestStore_Delete_ReferrersAPIAvailable(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
-	artifact := ocispec.Artifact{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
 		Subject:   &subjectDesc,
 	}
 	artifactJSON, err := json.Marshal(artifact)
@@ -3395,10 +3396,10 @@ func Test_ManifestStore_Delete_ReferrersAPIAvailable(t *testing.T) {
 func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
 	referrersTag := strings.Replace(subjectDesc.Digest.String(), ":", "-", 1)
-	artifact := ocispec.Artifact{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
 		Subject:   &subjectDesc,
 	}
 	artifactJSON, err := json.Marshal(artifact)
@@ -3592,10 +3593,10 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
 	referrersTag := strings.Replace(subjectDesc.Digest.String(), ":", "-", 1)
-	artifact := ocispec.Artifact{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
 		Subject:   &subjectDesc,
 	}
 	artifactJSON, err := json.Marshal(artifact)
@@ -3749,7 +3750,7 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 				},
 				MediaType: ocispec.MediaTypeImageIndex,
 				Manifests: []ocispec.Descriptor{
-					content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, []byte("whaterver")),
+					content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, []byte("whaterver")),
 				},
 			}
 			if err := json.NewEncoder(w).Encode(result); err != nil {
@@ -4157,9 +4158,9 @@ func Test_ManifestStore_PushReference(t *testing.T) {
 func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
-	artifact := ocispec.Artifact{
-		MediaType: ocispec.MediaTypeArtifactManifest,
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
 		Subject:   &subjectDesc,
 	}
 	artifactJSON, err := json.Marshal(artifact)
@@ -4264,10 +4265,10 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, subject)
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
 	referrersTag := strings.Replace(subjectDesc.Digest.String(), ":", "-", 1)
-	artifact := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	artifact := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		Subject:      &subjectDesc,
 		ArtifactType: "application/vnd.test",
 		Annotations:  map[string]string{"foo": "bar"},
@@ -5185,16 +5186,16 @@ func TestRepository_SetReferrersCapability(t *testing.T) {
 }
 
 func Test_generateIndex(t *testing.T) {
-	referrer_1 := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	referrer_1 := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "foo",
 	}
 	referrerJSON_1, err := json.Marshal(referrer_1)
 	if err != nil {
 		t.Fatal("failed to marshal manifest:", err)
 	}
-	referrer_2 := ocispec.Artifact{
-		MediaType:    ocispec.MediaTypeArtifactManifest,
+	referrer_2 := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
 		ArtifactType: "bar",
 	}
 	referrerJSON_2, err := json.Marshal(referrer_2)


### PR DESCRIPTION
This PR fixes and only fixes the compiling errors due to the breaking changes introduced by `image-spec v1.1.0-rc.3` where the artifact manifest related specs are removed.

Fix #495.
Fix partially #494 