### PR TITLE
fix: improve errors for `ReadAll` and `loadIndexfile`

### DIFF
--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -102,7 +102,7 @@ func NewWithContext(ctx context.Context, root string) (*Store, error) {
 		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
 	}
 	if err := store.loadIndexFile(ctx); err != nil {
-		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
+		return nil, fmt.Errorf("invalid OCI Image Index: %w", err)
 	}
 
 	return store, nil

--- a/content/oci/readonlyoci.go
+++ b/content/oci/readonlyoci.go
@@ -57,7 +57,7 @@ func NewFromFS(ctx context.Context, fsys fs.FS) (*ReadOnlyStore, error) {
 		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
 	}
 	if err := store.loadIndexFile(ctx); err != nil {
-		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
+		return nil, fmt.Errorf("invalid OCI Image Index: %w", err)
 	}
 
 	return store, nil


### PR DESCRIPTION
NewWithContext refers to both the `oci-layout` and `index.json` as "OCI Image Layout", this PR fixes the latter.

ReadAll is a deeper change that will improve error reporting for a lot of cases, at the cost of error volume. Some or all of that change could happen higher up to satisfy this particular issue. I think the expected/actual size output belongs here. There seem to be more than a few code paths in this and other repos that end up calling ReadAll multiple times without reporting which call produced an error so I think it's appropriate to also output the digest here, but that's less compelling.

The Verify comment clears up confusion I encountered while working on this issue. "verifies size" implies checking for both too big AND too small, but it only checks if the file is bigger (or reader is longer) than expected.

Fixes #432 