### PR TITLE
deps: update docker/docker to v24.0.2 (v1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2
 	github.com/docker/cli v24.0.2+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/docker/docker v23.0.6+incompatible
+	github.com/docker/docker v24.0.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m3
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v23.0.6+incompatible h1:aBD4np894vatVX99UTx/GyOUOK4uEcROwA3+bQhEcoU=
 github.com/docker/docker v23.0.6+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.2+incompatible h1:eATx+oLz9WdNVkQrr0qjQ8HvRJ4bOOxfzEo8R+dA3cg=
+github.com/docker/docker v24.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/pkg/auth/docker/login_tls.go
+++ b/pkg/auth/docker/login_tls.go
@@ -59,7 +59,7 @@ func (lcs loginCredentialStore) SetRefreshToken(u *url.URL, service, token strin
 // loginWithTLS tries to login to the v2 registry server.
 // A custom tls.Config is used to override the default TLS configuration of the different registry endpoints.
 // The tls.Config is created using the provided certificate, certificate key and certificate authority.
-func (c *Client) loginWithTLS(ctx context.Context, service registry.Service, certFile, keyFile, caFile string, authConfig *types.AuthConfig, userAgent string) (string, string, error) {
+func (c *Client) loginWithTLS(ctx context.Context, service *registry.Service, certFile, keyFile, caFile string, authConfig *types.AuthConfig, userAgent string) (string, string, error) {
 	tlsConfig, err := tlsconfig.Client(tlsconfig.Options{CAFile: caFile, CertFile: certFile, KeyFile: keyFile})
 	if err != nil {
 		return "", "", err
@@ -91,7 +91,7 @@ func (c *Client) loginWithTLS(ctx context.Context, service registry.Service, cer
 }
 
 // getEndpoints returns the endpoints for the given hostname.
-func (c *Client) getEndpoints(address string, service registry.Service) ([]registry.APIEndpoint, error) {
+func (c *Client) getEndpoints(address string, service *registry.Service) ([]registry.APIEndpoint, error) {
 	var registryHostName = IndexHostname
 
 	if address != "" {


### PR DESCRIPTION
Handle `registry.Service` change from interface to struct.

I've seen https://github.com/oras-project/oras-go/pull/517 and https://github.com/oras-project/oras-go/pull/519 and am not clear why they were closed.

The old docker/docker dependency is blocking updating other dependencies in the containers ecosystem, where oras-go v1 is still in use. Would be grateful if the update could be applied to v1.