### PR TITLE
chore: patch for release-2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,13 @@ name: build
 
 on:
   push:
-    branches: main
+    branches: 
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches:
+      - main
+      - release-*
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,9 +15,13 @@ name: CodeQL
 
 on:
   push:
-    branches: main
+    branches:
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches:
+      - main
+      - release-*
   schedule:
     - cron: '34 13 * * 3'
 

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,9 +15,13 @@ name: License Checker
 
 on:
   push:
-    branches: main
+    branches:
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches:
+      - main
+      - release-*
 
 permissions:
   contents: write

--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -102,7 +102,7 @@ func NewWithContext(ctx context.Context, root string) (*Store, error) {
 		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
 	}
 	if err := store.loadIndexFile(ctx); err != nil {
-		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
+		return nil, fmt.Errorf("invalid OCI Image Index: %w", err)
 	}
 
 	return store, nil

--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -43,6 +43,11 @@ import (
 // Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/image-layout.md#indexjson-file
 const ociImageIndexFile = "index.json"
 
+// ociBlobsDir is the name of the blobs directory
+// from the OCI Image Layout Specification.
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/image-layout.md#content
+const ociBlobsDir = "blobs"
+
 // Store implements `oras.Target`, and represents a content store
 // based on file system with the OCI-Image layout.
 // Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/image-layout.md
@@ -90,7 +95,7 @@ func NewWithContext(ctx context.Context, root string) (*Store, error) {
 		graph:         graph.NewMemory(),
 	}
 
-	if err := ensureDir(rootAbs); err != nil {
+	if err := ensureDir(filepath.Join(rootAbs, ociBlobsDir)); err != nil {
 		return nil, err
 	}
 	if err := store.ensureOCILayoutFile(); err != nil {

--- a/content/oci/readonlyoci.go
+++ b/content/oci/readonlyoci.go
@@ -57,7 +57,7 @@ func NewFromFS(ctx context.Context, fsys fs.FS) (*ReadOnlyStore, error) {
 		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
 	}
 	if err := store.loadIndexFile(ctx); err != nil {
-		return nil, fmt.Errorf("invalid OCI Image Layout: %w", err)
+		return nil, fmt.Errorf("invalid OCI Image Index: %w", err)
 	}
 
 	return store, nil

--- a/content/oci/readonlyoci_test.go
+++ b/content/oci/readonlyoci_test.go
@@ -123,7 +123,7 @@ func TestReadOnlyStore(t *testing.T) {
 	// build fs
 	fsys := fstest.MapFS{}
 	for i, desc := range descs {
-		path := strings.Join([]string{"blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded()}, "/")
+		path := strings.Join([]string{ociBlobsDir, desc.Digest.Algorithm().String(), desc.Digest.Encoded()}, "/")
 		fsys[path] = &fstest.MapFile{Data: blobs[i]}
 	}
 	fsys[ocispec.ImageLayoutFile] = &fstest.MapFile{Data: layoutJSON}
@@ -603,7 +603,7 @@ func TestReadOnlyStore_Copy_OCIToMemory(t *testing.T) {
 	// build fs
 	fsys := fstest.MapFS{}
 	for i, desc := range descs {
-		path := strings.Join([]string{"blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded()}, "/")
+		path := strings.Join([]string{ociBlobsDir, desc.Digest.Algorithm().String(), desc.Digest.Encoded()}, "/")
 		fsys[path] = &fstest.MapFile{Data: blobs[i]}
 	}
 	fsys[ocispec.ImageLayoutFile] = &fstest.MapFile{Data: layoutJSON}
@@ -717,7 +717,7 @@ func TestReadOnlyStore_Tags(t *testing.T) {
 	// build fs
 	fsys := fstest.MapFS{}
 	for i, desc := range descs {
-		path := strings.Join([]string{"blobs", desc.Digest.Algorithm().String(), desc.Digest.Encoded()}, "/")
+		path := strings.Join([]string{ociBlobsDir, desc.Digest.Algorithm().String(), desc.Digest.Encoded()}, "/")
 		fsys[path] = &fstest.MapFile{Data: blobs[i]}
 	}
 	fsys[ocispec.ImageLayoutFile] = &fstest.MapFile{Data: layoutJSON}

--- a/content/oci/readonlystorage.go
+++ b/content/oci/readonlystorage.go
@@ -95,5 +95,5 @@ func blobPath(dgst digest.Digest) (string, error) {
 		return "", fmt.Errorf("cannot calculate blob path from invalid digest %s: %w: %v",
 			dgst.String(), errdef.ErrInvalidDigest, err)
 	}
-	return path.Join("blobs", dgst.Algorithm().String(), dgst.Encoded()), nil
+	return path.Join(ociBlobsDir, dgst.Algorithm().String(), dgst.Encoded()), nil
 }

--- a/content/oci/readonlystorage_test.go
+++ b/content/oci/readonlystorage_test.go
@@ -38,7 +38,7 @@ func TestReadOnlyStorage_Exists(t *testing.T) {
 	dgst := digest.FromBytes(blob)
 	desc := content.NewDescriptorFromBytes("", blob)
 	fsys := fstest.MapFS{
-		strings.Join([]string{"blobs", dgst.Algorithm().String(), dgst.Encoded()}, "/"): {},
+		strings.Join([]string{ociBlobsDir, dgst.Algorithm().String(), dgst.Encoded()}, "/"): {},
 	}
 	s := NewStorageFromFS(fsys)
 	ctx := context.Background()
@@ -76,7 +76,7 @@ func TestReadOnlyStorage_Fetch(t *testing.T) {
 	dgst := digest.FromBytes(blob)
 	desc := content.NewDescriptorFromBytes("", blob)
 	fsys := fstest.MapFS{
-		strings.Join([]string{"blobs", dgst.Algorithm().String(), dgst.Encoded()}, "/"): {
+		strings.Join([]string{ociBlobsDir, dgst.Algorithm().String(), dgst.Encoded()}, "/"): {
 			Data: blob,
 		},
 	}
@@ -123,7 +123,7 @@ func TestReadOnlyStorage_DirFS(t *testing.T) {
 	dgst := digest.FromBytes(blob)
 	desc := content.NewDescriptorFromBytes("test", blob)
 	// write blob to disk
-	path := filepath.Join(tempDir, "blobs", dgst.Algorithm().String(), dgst.Encoded())
+	path := filepath.Join(tempDir, ociBlobsDir, dgst.Algorithm().String(), dgst.Encoded())
 	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 		t.Fatal("error calling Mkdir(), error =", err)
 	}

--- a/content/oci/storage_test.go
+++ b/content/oci/storage_test.go
@@ -289,7 +289,7 @@ func TestStorage_Fetch_ExistingBlobs(t *testing.T) {
 	}
 
 	tempDir := t.TempDir()
-	path := filepath.Join(tempDir, "blobs", dgst.Algorithm().String(), dgst.Encoded())
+	path := filepath.Join(tempDir, ociBlobsDir, dgst.Algorithm().String(), dgst.Encoded())
 	if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
 		t.Fatal("error calling Mkdir(), error =", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.19
 
 require (
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.0-rc.3
+	github.com/opencontainers/image-spec v1.1.0-rc4
 	golang.org/x/sync v0.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.19
 require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc.3
-	golang.org/x/sync v0.2.0
+	golang.org/x/sync v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc.3 h1:GT9Xon8YrLxz6N7sErbN81V8J4lOQKGUZQmI3ioviqU=
 github.com/opencontainers/image-spec v1.1.0-rc.3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
-golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
-golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.1.0-rc.3 h1:GT9Xon8YrLxz6N7sErbN81V8J4lOQKGUZQmI3ioviqU=
-github.com/opencontainers/image-spec v1.1.0-rc.3/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
+github.com/opencontainers/image-spec v1.1.0-rc4 h1:oOxKUJWnFC4YGHCCMNql1x4YaDfYBTS5Y4x/Cgeo1E0=
+github.com/opencontainers/image-spec v1.1.0-rc4/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=

--- a/internal/spec/artifact.go
+++ b/internal/spec/artifact.go
@@ -17,8 +17,16 @@ package spec
 
 import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-// AnnotationReferrersFiltersApplied is the annotation key for the comma separated list of filters applied by the registry in the referrers listing.
-const AnnotationReferrersFiltersApplied = "org.opencontainers.referrers.filtersApplied"
+const (
+	// AnnotationArtifactCreated is the annotation key for the date and time on which the artifact was built, conforming to RFC 3339.
+	AnnotationArtifactCreated = "org.opencontainers.artifact.created"
+
+	// AnnotationArtifactDescription is the annotation key for the human readable description for the artifact.
+	AnnotationArtifactDescription = "org.opencontainers.artifact.description"
+
+	// AnnotationReferrersFiltersApplied is the annotation key for the comma separated list of filters applied by the registry in the referrers listing.
+	AnnotationReferrersFiltersApplied = "org.opencontainers.referrers.filtersApplied"
+)
 
 // MediaTypeArtifactManifest specifies the media type for a content descriptor.
 const MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json"

--- a/pack.go
+++ b/pack.go
@@ -90,7 +90,7 @@ func packArtifact(ctx context.Context, pusher content.Pusher, artifactType strin
 		artifactType = MediaTypeUnknownArtifact
 	}
 
-	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, ocispec.AnnotationArtifactCreated)
+	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, spec.AnnotationArtifactCreated)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}

--- a/pack_test.go
+++ b/pack_test.go
@@ -77,9 +77,9 @@ func Test_Pack_Default(t *testing.T) {
 	}
 
 	// test created time annotation
-	createdTime, ok := manifest.Annotations[ocispec.AnnotationArtifactCreated]
+	createdTime, ok := manifest.Annotations[spec.AnnotationArtifactCreated]
 	if !ok {
-		t.Errorf("Annotation %s = %v, want %v", ocispec.AnnotationArtifactCreated, ok, true)
+		t.Errorf("Annotation %s = %v, want %v", spec.AnnotationArtifactCreated, ok, true)
 	}
 	_, err = time.Parse(time.RFC3339, createdTime)
 	if err != nil {
@@ -98,7 +98,7 @@ func Test_Pack_WithOptions(t *testing.T) {
 
 	artifactType := "application/vnd.test"
 	annotations := map[string]string{
-		ocispec.AnnotationArtifactCreated: "2000-01-01T00:00:00Z",
+		spec.AnnotationArtifactCreated: "2000-01-01T00:00:00Z",
 	}
 	subjectManifest := []byte(`{"layers":[]}`)
 	subjectDesc := ocispec.Descriptor{
@@ -216,7 +216,7 @@ func Test_Pack_InvalidDateTimeFormat(t *testing.T) {
 	ctx := context.Background()
 	opts := PackOptions{
 		ManifestAnnotations: map[string]string{
-			ocispec.AnnotationArtifactCreated: "2000/01/01 00:00:00",
+			spec.AnnotationArtifactCreated: "2000/01/01 00:00:00",
 		},
 	}
 	artifactType := "application/vnd.test"


### PR DESCRIPTION
Cherry-picked the following commits from the main branch:

- [b4400e1e522dfd7736af4eae1aacb90b43686629](https://github.com/oras-project/oras-go/commit/b4400e1e522dfd7736af4eae1aacb90b43686629)
- [2e7b65f1b60d11cd861ce6b68bc53e23a1fd9306](https://github.com/oras-project/oras-go/commit/2e7b65f1b60d11cd861ce6b68bc53e23a1fd9306)
- [6b5bd4b4372b8ba8f5ec0251ddffba8f360f5cf1](https://github.com/oras-project/oras-go/commit/6b5bd4b4372b8ba8f5ec0251ddffba8f360f5cf1)
- [4763cd4ba3b7040dd72de5b06c970c9a9008607b](https://github.com/oras-project/oras-go/commit/4763cd4ba3b7040dd72de5b06c970c9a9008607b)
- [babfc511e0a0d61293e4a305f29f206d0b4ac984](https://github.com/oras-project/oras-go/commit/babfc511e0a0d61293e4a305f29f206d0b4ac984)