### PR TITLE
feat: update the implementation of pushing manifest for distribution-spec v1.1.0-rc3

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1326,9 +1326,12 @@ func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.D
 	}
 }
 
-// indexReferrersForPush indexes referrers for image or artifact manifest with
-// the subject field on manifest push.
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#pushing-manifests-with-subject
+// indexReferrersForPush indexes referrers for an artifact manifest or
+// an image manifest or an image index with a subject field on manifest push.
+//
+// References:
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc3/spec.md#pushing-manifests-with-subject
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#pushing-manifests-with-subject
 func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.Descriptor, manifestJSON []byte) error {
 	var subject ocispec.Descriptor
 	switch desc.MediaType {
@@ -1389,8 +1392,8 @@ func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.
 // updateReferrersIndex updates the referrers index for desc referencing subject
 // on manifest push and manifest delete.
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#pushing-manifests-with-subject
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#deleting-manifests
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc3/spec.md#pushing-manifests-with-subject
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc3/spec.md#deleting-manifests
 func (s *manifestStore) updateReferrersIndex(ctx context.Context, subject ocispec.Descriptor, change referrerChange) (err error) {
 	referrersTag := buildReferrersTag(subject)
 

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1281,14 +1281,14 @@ func (s *manifestStore) push(ctx context.Context, expected ocispec.Descriptor, c
 	if resp.StatusCode != http.StatusCreated {
 		return errutil.ParseErrorResponse(resp)
 	}
-	s.checkReferrersSupport(resp)
+	s.checkOCISubjectHeader(resp)
 	return verifyContentDigest(resp, expected.Digest)
 }
 
-// checkReferrersSupport checks the "OCI-Subject" header in the response and
+// checkOCISubjectHeader checks the "OCI-Subject" header in the response and
 // sets referrers capability accordingly.
 // Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc3/spec.md#pushing-manifests-with-subject
-func (s *manifestStore) checkReferrersSupport(resp *http.Response) {
+func (s *manifestStore) checkOCISubjectHeader(resp *http.Response) {
 	// Referrers capability is not set to false when the subject header is not
 	// present, as the server may still conform to an older version of the spec
 	if subjectHeader := resp.Header.Get(headerOCISubject); subjectHeader != "" {
@@ -1326,8 +1326,8 @@ func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.D
 	}
 }
 
-// indexReferrersForPush indexes referrers for an artifact manifest or
-// an image manifest or an image index with a subject field on manifest push.
+// indexReferrersForPush indexes referrers for manifests with a subject field
+// on manifest push.
 //
 // References:
 //   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc3/spec.md#pushing-manifests-with-subject

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1283,6 +1283,7 @@ func (s *manifestStore) push(ctx context.Context, expected ocispec.Descriptor, c
 	return verifyContentDigest(resp, expected.Digest)
 }
 
+// TODO: special handling for index?
 func (s *manifestStore) checkReferrersSupport(resp *http.Response) {
 	if subjectHeader := resp.Header.Get(headerOCISubject); subjectHeader != "" {
 		s.repo.SetReferrersCapability(true)
@@ -1293,7 +1294,7 @@ func (s *manifestStore) checkReferrersSupport(resp *http.Response) {
 // and indexes referrers for the manifest when needed.
 func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.Descriptor, r io.Reader, reference string) error {
 	switch expected.MediaType {
-	// TODO: support index with subject?
+	// TODO: special handling for subject?
 	case spec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
 		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
 			// referrers API is available, no client-side indexing needed

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1316,9 +1316,8 @@ func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.D
 		if err := s.push(ctx, expected, bytes.NewReader(manifestJSON), reference); err != nil {
 			return err
 		}
-		// check referrers again
+		// check referrers API availability again after push
 		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
-			// skip indexing
 			return nil
 		}
 		return s.indexReferrersForPush(ctx, expected, manifestJSON)
@@ -1355,13 +1354,11 @@ func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.
 			return nil
 		}
 		subject = *manifest.Subject
-		// TODO: set artifact type
 		desc.ArtifactType = manifest.ArtifactType
 		if desc.ArtifactType == "" {
 			desc.ArtifactType = manifest.Config.MediaType
 		}
 		desc.Annotations = manifest.Annotations
-		// TODO: support index with subject?
 	case ocispec.MediaTypeImageIndex:
 		var manifest ocispec.Index
 		if err := json.Unmarshal(manifestJSON, &manifest); err != nil {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3287,7 +3287,7 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	}
 	artifactJSON, err := json.Marshal(artifact)
 	if err != nil {
-		t.Errorf("failed to marshal manifest: %v", err)
+		t.Fatalf("failed to marshal manifest: %v", err)
 	}
 	artifactDesc := content.NewDescriptorFromBytes(artifact.MediaType, artifactJSON)
 	manifest := ocispec.Manifest{
@@ -3296,9 +3296,18 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	}
 	manifestJSON, err := json.Marshal(manifest)
 	if err != nil {
-		t.Errorf("failed to marshal manifest: %v", err)
+		t.Fatalf("failed to marshal manifest: %v", err)
 	}
 	manifestDesc := content.NewDescriptorFromBytes(manifest.MediaType, manifestJSON)
+	index := ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Subject:   &subjectDesc,
+	}
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	indexDesc := content.NewDescriptorFromBytes(manifest.MediaType, indexJSON)
 
 	var gotManifest []byte
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -3326,6 +3335,18 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 			}
 			gotManifest = buf.Bytes()
 			w.Header().Set("Docker-Content-Digest", manifestDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexDesc.Digest.String():
+			if contentType := r.Header.Get("Content-Type"); contentType != indexDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
 			w.WriteHeader(http.StatusCreated)
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest:
 			result := ocispec.Index{
@@ -3379,6 +3400,18 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, manifestJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
 	}
+
+	// test push image index with subject
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+	err = repo.Push(ctx, indexDesc, bytes.NewReader(indexJSON))
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, indexJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
+	}
 }
 
 func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
@@ -3394,7 +3427,7 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	}
 	artifactJSON, err := json.Marshal(artifact)
 	if err != nil {
-		t.Errorf("failed to marshal manifest: %v", err)
+		t.Fatalf("failed to marshal manifest: %v", err)
 	}
 	artifactDesc := content.NewDescriptorFromBytes(artifact.MediaType, artifactJSON)
 	artifactDesc.ArtifactType = artifact.ArtifactType
@@ -3412,7 +3445,7 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	}
 	indexJSON_1, err := json.Marshal(index_1)
 	if err != nil {
-		t.Errorf("failed to marshal manifest: %v", err)
+		t.Fatalf("failed to marshal manifest: %v", err)
 	}
 	indexDesc_1 := content.NewDescriptorFromBytes(index_1.MediaType, indexJSON_1)
 	var gotManifest []byte
@@ -3708,6 +3741,108 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	// referrers list should not be changed
 	if !bytes.Equal(gotReferrerIndex, indexJSON_2) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_2))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	}
+
+	// push image index with subject, referrer list should be updated
+	indexManifest := ocispec.Index{
+		MediaType:    ocispec.MediaTypeImageIndex,
+		Subject:      &subjectDesc,
+		ArtifactType: "test/index",
+		Annotations:  map[string]string{"foo": "bar"},
+	}
+	indexManifestJSON, err := json.Marshal(indexManifest)
+	if err != nil {
+		t.Errorf("failed to marshal manifest: %v", err)
+	}
+	indexManifestDesc := content.NewDescriptorFromBytes(indexManifest.MediaType, indexManifestJSON)
+	indexManifestDesc.ArtifactType = indexManifest.ArtifactType
+	indexManifestDesc.Annotations = indexManifest.Annotations
+	index_3 := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{
+			artifactDesc,
+			manifestDesc,
+			indexManifestDesc,
+		},
+	}
+	indexJSON_3, err := json.Marshal(index_3)
+	if err != nil {
+		t.Errorf("failed to marshal manifest: %v", err)
+	}
+	indexDesc_3 := content.NewDescriptorFromBytes(index_3.MediaType, indexJSON_3)
+	manifestDeleted = false
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexManifestDesc.Digest.String():
+			if contentType := r.Header.Get("Content-Type"); contentType != indexManifestDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexManifestDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest:
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/manifests/"+referrersTag:
+			w.Write(indexJSON_2)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+referrersTag:
+			if contentType := r.Header.Get("Content-Type"); contentType != ocispec.MediaTypeImageIndex {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotReferrerIndex = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexDesc_3.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+indexDesc_2.Digest.String():
+			manifestDeleted = true
+			// no "Docker-Content-Digest" header for manifest deletion
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	uri, err = url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	ctx = context.Background()
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.Push(ctx, indexManifestDesc, bytes.NewReader(indexManifestJSON))
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, indexManifestJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexManifestJSON))
+	}
+	if !bytes.Equal(gotReferrerIndex, indexJSON_3) {
+		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_3))
+	}
+	if !manifestDeleted {
+		t.Errorf("manifestDeleted = %v, want %v", manifestDeleted, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3404,14 +3404,6 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	}
 
 	// test pushing image index with subject
-	repo, err = NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
 	err = repo.Push(ctx, indexDesc, bytes.NewReader(indexJSON))
 	if err != nil {
 		t.Fatalf("Manifests.Push() error = %v", err)
@@ -3559,14 +3551,6 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable_NoSubjectHeader(t *testing.T)
 	}
 
 	// test pushing image index with subject
-	repo, err = NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
 	err = repo.Push(ctx, indexDesc, bytes.NewReader(indexJSON))
 	if err != nil {
 		t.Fatalf("Manifests.Push() error = %v", err)
@@ -5166,14 +5150,6 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	}
 
 	// test pushing image index with subject
-	repo, err = NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
 	err = repo.PushReference(ctx, indexDesc, bytes.NewReader(indexJSON), indexRef)
 	if err != nil {
 		t.Fatalf("Manifests.Push() error = %v", err)
@@ -5326,14 +5302,6 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable_NoSubjectHeader(t *t
 	}
 
 	// test pushing image index with subject
-	repo, err = NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
 	err = repo.PushReference(ctx, indexDesc, bytes.NewReader(indexJSON), indexRef)
 	if err != nil {
 		t.Fatalf("Manifests.Push() error = %v", err)

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3277,6 +3277,153 @@ func Test_ManifestStore_Push(t *testing.T) {
 	}
 }
 
+func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
+	// generate test content
+	subject := []byte(`{"layers":[]}`)
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
+		Subject:   &subjectDesc,
+	}
+	artifactJSON, err := json.Marshal(artifact)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	artifactDesc := content.NewDescriptorFromBytes(artifact.MediaType, artifactJSON)
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Subject:   &subjectDesc,
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(manifest.MediaType, manifestJSON)
+	index := ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Subject:   &subjectDesc,
+	}
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	indexDesc := content.NewDescriptorFromBytes(manifest.MediaType, indexJSON)
+
+	var gotManifest []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+artifactDesc.Digest.String():
+			if contentType := r.Header.Get("Content-Type"); contentType != artifactDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", artifactDesc.Digest.String())
+			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+manifestDesc.Digest.String():
+			if contentType := r.Header.Get("Content-Type"); contentType != manifestDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", manifestDesc.Digest.String())
+			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexDesc.Digest.String():
+			if contentType := r.Header.Get("Content-Type"); contentType != indexDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
+			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+	ctx := context.Background()
+
+	// test pushing artifact with subject
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.Push(ctx, artifactDesc, bytes.NewReader(artifactJSON))
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, artifactJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(artifactJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+
+	// test pushing image manifest with subject
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, manifestJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+
+	// test pushing image index with subject
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.Push(ctx, indexDesc, bytes.NewReader(indexJSON))
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, indexJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+}
+
 func Test_ManifestStore_Push_ReferrersAPIAvailable_NoSubjectHeader(t *testing.T) {
 	// generate test content
 	subject := []byte(`{"layers":[]}`)
@@ -3359,153 +3506,6 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable_NoSubjectHeader(t *testing.T)
 			if err := json.NewEncoder(w).Encode(result); err != nil {
 				t.Errorf("failed to write response: %v", err)
 			}
-		default:
-			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer ts.Close()
-	uri, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Fatalf("invalid test http server: %v", err)
-	}
-	ctx := context.Background()
-
-	// test pushing artifact with subject
-	repo, err := NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
-	err = repo.Push(ctx, artifactDesc, bytes.NewReader(artifactJSON))
-	if err != nil {
-		t.Fatalf("Manifests.Push() error = %v", err)
-	}
-	if !bytes.Equal(gotManifest, artifactJSON) {
-		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(artifactJSON))
-	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
-	}
-
-	// test pushing image manifest with subject
-	repo, err = NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
-	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
-	if err != nil {
-		t.Fatalf("Manifests.Push() error = %v", err)
-	}
-	if !bytes.Equal(gotManifest, manifestJSON) {
-		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
-	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
-	}
-
-	// test pushing image index with subject
-	repo, err = NewRepository(uri.Host + "/test")
-	if err != nil {
-		t.Fatalf("NewRepository() error = %v", err)
-	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
-	}
-	err = repo.Push(ctx, indexDesc, bytes.NewReader(indexJSON))
-	if err != nil {
-		t.Fatalf("Manifests.Push() error = %v", err)
-	}
-	if !bytes.Equal(gotManifest, indexJSON) {
-		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
-	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
-	}
-}
-
-func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
-	// generate test content
-	subject := []byte(`{"layers":[]}`)
-	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
-	artifact := spec.Artifact{
-		MediaType: spec.MediaTypeArtifactManifest,
-		Subject:   &subjectDesc,
-	}
-	artifactJSON, err := json.Marshal(artifact)
-	if err != nil {
-		t.Fatalf("failed to marshal manifest: %v", err)
-	}
-	artifactDesc := content.NewDescriptorFromBytes(artifact.MediaType, artifactJSON)
-	manifest := ocispec.Manifest{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Subject:   &subjectDesc,
-	}
-	manifestJSON, err := json.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("failed to marshal manifest: %v", err)
-	}
-	manifestDesc := content.NewDescriptorFromBytes(manifest.MediaType, manifestJSON)
-	index := ocispec.Index{
-		MediaType: ocispec.MediaTypeImageIndex,
-		Subject:   &subjectDesc,
-	}
-	indexJSON, err := json.Marshal(index)
-	if err != nil {
-		t.Fatalf("failed to marshal manifest: %v", err)
-	}
-	indexDesc := content.NewDescriptorFromBytes(manifest.MediaType, indexJSON)
-
-	var gotManifest []byte
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+artifactDesc.Digest.String():
-			if contentType := r.Header.Get("Content-Type"); contentType != artifactDesc.MediaType {
-				w.WriteHeader(http.StatusBadRequest)
-				break
-			}
-			buf := bytes.NewBuffer(nil)
-			if _, err := buf.ReadFrom(r.Body); err != nil {
-				t.Errorf("fail to read: %v", err)
-			}
-			gotManifest = buf.Bytes()
-			w.Header().Set("Docker-Content-Digest", artifactDesc.Digest.String())
-			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
-			w.WriteHeader(http.StatusCreated)
-		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+manifestDesc.Digest.String():
-			if contentType := r.Header.Get("Content-Type"); contentType != manifestDesc.MediaType {
-				w.WriteHeader(http.StatusBadRequest)
-				break
-			}
-			buf := bytes.NewBuffer(nil)
-			if _, err := buf.ReadFrom(r.Body); err != nil {
-				t.Errorf("fail to read: %v", err)
-			}
-			gotManifest = buf.Bytes()
-			w.Header().Set("Docker-Content-Digest", manifestDesc.Digest.String())
-			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
-			w.WriteHeader(http.StatusCreated)
-		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexDesc.Digest.String():
-			if contentType := r.Header.Get("Content-Type"); contentType != indexDesc.MediaType {
-				w.WriteHeader(http.StatusBadRequest)
-				break
-			}
-			buf := bytes.NewBuffer(nil)
-			if _, err := buf.ReadFrom(r.Body); err != nil {
-				t.Errorf("fail to read: %v", err)
-			}
-			gotManifest = buf.Bytes()
-			w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
-			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
-			w.WriteHeader(http.StatusCreated)
 		default:
 			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
 			w.WriteHeader(http.StatusNotFound)
@@ -5049,6 +5049,180 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	manifestDesc := content.NewDescriptorFromBytes(manifest.MediaType, manifestJSON)
 	manifestRef := "bar"
 
+	index := ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Subject:   &subjectDesc,
+	}
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	indexDesc := content.NewDescriptorFromBytes(index.MediaType, indexJSON)
+	indexRef := "baz"
+
+	var gotManifest []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+artifactRef:
+			if contentType := r.Header.Get("Content-Type"); contentType != artifactDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", artifactDesc.Digest.String())
+			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+manifestRef:
+			if contentType := r.Header.Get("Content-Type"); contentType != manifestDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", manifestDesc.Digest.String())
+			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexRef:
+			if contentType := r.Header.Get("Content-Type"); contentType != indexDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
+			w.Header().Set("OCI-Subject", subjectDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest:
+			result := ocispec.Index{
+				Versioned: specs.Versioned{
+					SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+				},
+				MediaType: ocispec.MediaTypeImageIndex,
+				Manifests: []ocispec.Descriptor{},
+			}
+			if err := json.NewEncoder(w).Encode(result); err != nil {
+				t.Errorf("failed to write response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+	ctx := context.Background()
+
+	// test pushing artifact with subject
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.PushReference(ctx, artifactDesc, bytes.NewReader(artifactJSON), artifactRef)
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, artifactJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(artifactJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+
+	// test pushing image manifest with subject
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.PushReference(ctx, manifestDesc, bytes.NewReader(manifestJSON), manifestRef)
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, manifestJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+
+	// test pushing image index with subject
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.PushReference(ctx, indexDesc, bytes.NewReader(indexJSON), indexRef)
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, indexJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+}
+
+func Test_ManifestStore_PushReference_ReferrersAPIAvailable_NoSubjectHeader(t *testing.T) {
+	// generate test content
+	subject := []byte(`{"layers":[]}`)
+	subjectDesc := content.NewDescriptorFromBytes(spec.MediaTypeArtifactManifest, subject)
+	artifact := spec.Artifact{
+		MediaType: spec.MediaTypeArtifactManifest,
+		Subject:   &subjectDesc,
+	}
+	artifactJSON, err := json.Marshal(artifact)
+	if err != nil {
+		t.Errorf("failed to marshal manifest: %v", err)
+	}
+	artifactDesc := content.NewDescriptorFromBytes(artifact.MediaType, artifactJSON)
+	artifactRef := "foo"
+
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Subject:   &subjectDesc,
+	}
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Errorf("failed to marshal manifest: %v", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(manifest.MediaType, manifestJSON)
+	manifestRef := "bar"
+
+	index := ocispec.Index{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Subject:   &subjectDesc,
+	}
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	indexDesc := content.NewDescriptorFromBytes(index.MediaType, indexJSON)
+	indexRef := "baz"
+
 	var gotManifest []byte
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -5076,6 +5250,18 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 			gotManifest = buf.Bytes()
 			w.Header().Set("Docker-Content-Digest", manifestDesc.Digest.String())
 			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexRef:
+			if contentType := r.Header.Get("Content-Type"); contentType != indexDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest:
 			result := ocispec.Index{
 				Versioned: specs.Versioned{
@@ -5097,15 +5283,14 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid test http server: %v", err)
 	}
-
 	ctx := context.Background()
+
+	// test pushing artifact with subject
 	repo, err := NewRepository(uri.Host + "/test")
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
 	repo.PlainHTTP = true
-
-	// test pushing artifact with subject
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
@@ -5116,10 +5301,18 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, artifactJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(artifactJSON))
 	}
-
-	// test pushing image manifest with subject
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+
+	// test pushing image manifest with subject
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
 	err = repo.PushReference(ctx, manifestDesc, bytes.NewReader(manifestJSON), manifestRef)
 	if err != nil {
@@ -5127,6 +5320,29 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	}
 	if !bytes.Equal(gotManifest, manifestJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	}
+
+	// test pushing image index with subject
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.PushReference(ctx, indexDesc, bytes.NewReader(indexJSON), indexRef)
+	if err != nil {
+		t.Fatalf("Manifests.Push() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, indexJSON) {
+		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateSupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
 }
 
@@ -5340,7 +5556,7 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	// test pushing image manifest with subject again, referrers list should not be changed
 	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+manifestDesc.Digest.String():
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+manifestRef:
 			if contentType := r.Header.Get("Content-Type"); contentType != manifestDesc.MediaType {
 				w.WriteHeader(http.StatusBadRequest)
 				break
@@ -5376,16 +5592,119 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if state := repo.loadReferrersState(); state != referrersStateUnknown {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
-	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
+	err = repo.PushReference(ctx, manifestDesc, bytes.NewReader(manifestJSON), manifestRef)
 	if err != nil {
-		t.Fatalf("Manifests.Push() error = %v", err)
+		t.Fatalf("Manifests.PushReference() error = %v", err)
 	}
 	if !bytes.Equal(gotManifest, manifestJSON) {
-		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
+		t.Errorf("Manifests.PushReference() = %v, want %v", string(gotManifest), string(manifestJSON))
 	}
 	// referrers list should not be changed
 	if !bytes.Equal(gotReferrerIndex, indexJSON_2) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_2))
+	}
+	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	}
+
+	// push image index with subject, referrer list should be updated
+	indexManifest := ocispec.Index{
+		MediaType:    ocispec.MediaTypeImageIndex,
+		Subject:      &subjectDesc,
+		ArtifactType: "test/index",
+		Annotations:  map[string]string{"foo": "bar"},
+	}
+	indexManifestJSON, err := json.Marshal(indexManifest)
+	if err != nil {
+		t.Errorf("failed to marshal manifest: %v", err)
+	}
+	indexManifestDesc := content.NewDescriptorFromBytes(indexManifest.MediaType, indexManifestJSON)
+	indexManifestDesc.ArtifactType = indexManifest.ArtifactType
+	indexManifestDesc.Annotations = indexManifest.Annotations
+	indexManifestRef := "baz"
+	index_3 := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{
+			artifactDesc,
+			manifestDesc,
+			indexManifestDesc,
+		},
+	}
+	indexJSON_3, err := json.Marshal(index_3)
+	if err != nil {
+		t.Errorf("failed to marshal manifest: %v", err)
+	}
+	indexDesc_3 := content.NewDescriptorFromBytes(index_3.MediaType, indexJSON_3)
+	manifestDeleted = false
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+indexManifestRef:
+			if contentType := r.Header.Get("Content-Type"); contentType != indexManifestDesc.MediaType {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotManifest = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexManifestDesc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/referrers/"+zeroDigest:
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/test/manifests/"+referrersTag:
+			w.Write(indexJSON_2)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test/manifests/"+referrersTag:
+			if contentType := r.Header.Get("Content-Type"); contentType != ocispec.MediaTypeImageIndex {
+				w.WriteHeader(http.StatusBadRequest)
+				break
+			}
+			buf := bytes.NewBuffer(nil)
+			if _, err := buf.ReadFrom(r.Body); err != nil {
+				t.Errorf("fail to read: %v", err)
+			}
+			gotReferrerIndex = buf.Bytes()
+			w.Header().Set("Docker-Content-Digest", indexDesc_3.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+indexDesc_2.Digest.String():
+			manifestDeleted = true
+			// no "Docker-Content-Digest" header for manifest deletion
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	uri, err = url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	ctx = context.Background()
+	repo, err = NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != referrersStateUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	}
+	err = repo.PushReference(ctx, indexManifestDesc, bytes.NewReader(indexManifestJSON), indexManifestRef)
+	if err != nil {
+		t.Fatalf("Manifests.PushReference() error = %v", err)
+	}
+	if !bytes.Equal(gotManifest, indexManifestJSON) {
+		t.Errorf("Manifests.PushReference() = %v, want %v", string(gotManifest), string(indexManifestJSON))
+	}
+	if !bytes.Equal(gotReferrerIndex, indexJSON_3) {
+		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_3))
+	}
+	if !manifestDeleted {
+		t.Errorf("manifestDeleted = %v, want %v", manifestDeleted, true)
 	}
 	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)


### PR DESCRIPTION
1. Support pushing image index with a subject
2. Check the "OCI-Subject" header

Resolves: #534