### PR TITLE
docs: display larger example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"oras.land/oras-go/v2"
+	oras "oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/content/oci"
 	"oras.land/oras-go/v2/registry/remote"


### PR DESCRIPTION
Following up issue #434 

Displayed with `godoc -play -http=:6061`, we get [larger examples](https://go.dev/blog/examples#:~:text=ExampleString_second()%0Afunc%20ExampleString_third()-,Larger%20examples,-Sometimes%20we%20need) with godoc.

![image](https://github.com/oras-project/oras-go/assets/103478229/3cd24256-af6a-4c49-b37c-a61f117f9ddb)
