### PR TITLE
refactor: add `PackManifest` and deprecate `Pack`  

### DIFF
--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -25,43 +25,7 @@ import (
 	"oras.land/oras-go/v2/content/memory"
 )
 
-// ExampleDefaultManifestType demonstrates packing an default type of
-// OCI Image Manifest.
-func ExamplePackManifest_defaultManifestType() {
-	// 0. Create a storage
-	store := memory.New()
-
-	// 1. Set optional parameters
-	opts := oras.PackManifestOptions{
-		ManifestAnnotations: map[string]string{
-			// this timestamp will be automatically generated if not specified
-			// use a fix value here in order to test the output
-			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
-		},
-	}
-	ctx := context.Background()
-
-	// 2. Pack a manifest
-	artifactType := "application/vnd.example+type"
-	manifestDesc, err := oras.PackManifest(ctx, store, oras.DefaultPackManifestType, artifactType, opts)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("Manifest descriptor:", manifestDesc)
-
-	// 3. Verify the packed manifest
-	manifestData, err := content.FetchAll(ctx, store, manifestDesc)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("Manifest content:", string(manifestData))
-
-	// Output:
-	// Manifest descriptor: {application/vnd.oci.image.manifest.v1+json sha256:c259a195a48d8029d75449579c81269ca6225cd5b57d36073a7de6458afdfdbd 528 [] map[org.opencontainers.image.created:2000-01-01T00:00:00Z] [] <nil> application/vnd.example+type}
-	// Manifest content: {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.example+type","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="},"layers":[{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="}],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
-}
-
-// ExampleImageV11RC4 demonstrates packing an OCI Image Manifest as defined since
+// ExampleImageV11RC4 demonstrates packing an OCI Image Manifest as defined in
 // image-spec v1.1.0-rc4.
 func ExamplePackManifest_imageV11RC4() {
 	// 0. Create a storage
@@ -79,7 +43,7 @@ func ExamplePackManifest_imageV11RC4() {
 
 	// 2. Pack a manifest
 	artifactType := "application/vnd.example+type"
-	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestTypeImageV1_1_RC4, artifactType, opts)
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestVersionV1_1_RC4, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}
@@ -115,7 +79,7 @@ func ExamplePackManifest_imageV10() {
 
 	// 2. Pack a manifest
 	artifactType := "application/vnd.example+type"
-	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestTypeImageV1_0, artifactType, opts)
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestVersionV1_0, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/content/memory"
+)
+
+func ExamplePackManifest_imageV1() {
+	store := memory.New()
+
+	data := [][]byte{
+		[]byte(`hello`),
+		[]byte(`world`),
+	}
+	layers := make([]ocispec.Descriptor, 0, len(data))
+	ctx := context.Background()
+	for _, data := range data {
+		desc := content.NewDescriptorFromBytes("test/layer", data)
+		layers = append(layers, desc)
+		if err := store.Push(ctx, desc, bytes.NewReader(data)); err != nil {
+			panic(err)
+		}
+	}
+
+	opts := oras.PackManifestOptions{
+		ManifestAnnotations: map[string]string{
+			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z", // for testing purpose
+		},
+	}
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestTypeImageV1_0, "test/artifact", opts)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(manifestDesc)
+
+	// verify manifest
+	manifestData, err := content.FetchAll(ctx, store, manifestDesc)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(manifestData))
+
+	// Output:
+	// {application/vnd.oci.image.manifest.v1+json sha256:b3b0939bcc66de501485cf003c2c2aca7b6c38e58b6b0d458548d7ef6bd4decc 293 [] map[org.opencontainers.image.created:2000-01-01T00:00:00Z] [] <nil> test/artifact}
+	// {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"test/artifact","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
+}

--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -25,7 +25,8 @@ import (
 	"oras.land/oras-go/v2/content/memory"
 )
 
-// ExampleImageV11RC4 demonstrates packing an OCI Image Manifest.
+// ExampleDefaultManifestType demonstrates packing an default type of
+// OCI Image Manifest.
 func ExamplePackManifest_defaultManifestType() {
 	// 0. Create a storage
 	store := memory.New()
@@ -96,9 +97,9 @@ func ExamplePackManifest_imageV11RC4() {
 	// Manifest content: {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.example+type","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="},"layers":[{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="}],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
 }
 
-// ExampleImageV1 demonstrates packing an OCI Image Manifest as defined in
+// ExampleImageV10 demonstrates packing an OCI Image Manifest as defined in
 // image-spec v1.0.2.
-func ExamplePackManifest_imageV1() {
+func ExamplePackManifest_imageV10() {
 	// 0. Create a storage
 	store := memory.New()
 

--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -35,7 +35,7 @@ func ExamplePackManifest_imageV11RC4() {
 	opts := oras.PackManifestOptions{
 		ManifestAnnotations: map[string]string{
 			// this timestamp will be automatically generated if not specified
-			// use a fix value here in order to test the output
+			// use a fixed value here in order to test the output
 			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
 		},
 	}
@@ -71,7 +71,7 @@ func ExamplePackManifest_imageV10() {
 	opts := oras.PackManifestOptions{
 		ManifestAnnotations: map[string]string{
 			// this timestamp will be automatically generated if not specified
-			// use a fix value here in order to test the output
+			// use a fixed value here in order to test the output
 			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
 		},
 	}

--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -43,7 +43,7 @@ func ExamplePackManifest_imageV11RC4() {
 
 	// 2. Pack a manifest
 	artifactType := "application/vnd.example+type"
-	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestVersionV1_1_RC4, artifactType, opts)
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_1_RC4, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}
@@ -79,7 +79,7 @@ func ExamplePackManifest_imageV10() {
 
 	// 2. Pack a manifest
 	artifactType := "application/vnd.example+type"
-	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestVersionV1_0, artifactType, opts)
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_0, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -16,52 +16,118 @@ limitations under the License.
 package oras_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 )
 
-func ExamplePackManifest_imageV1() {
+// ExampleImageV11RC4 demonstrates packing an OCI Image Manifest.
+func ExamplePackManifest_defaultManifestType() {
+	// 0. Create a storage
 	store := memory.New()
 
-	data := [][]byte{
-		[]byte(`hello`),
-		[]byte(`world`),
-	}
-	layers := make([]ocispec.Descriptor, 0, len(data))
-	ctx := context.Background()
-	for _, data := range data {
-		desc := content.NewDescriptorFromBytes("test/layer", data)
-		layers = append(layers, desc)
-		if err := store.Push(ctx, desc, bytes.NewReader(data)); err != nil {
-			panic(err)
-		}
-	}
-
+	// 1. Set optional parameters
 	opts := oras.PackManifestOptions{
 		ManifestAnnotations: map[string]string{
-			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z", // for testing purpose
+			// this timestamp will be automatically generated if not specified
+			// use a fix value here in order to test the output
+			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
 		},
 	}
-	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestTypeImageV1_0, "test/artifact", opts)
+	ctx := context.Background()
+
+	// 2. Pack a manifest
+	artifactType := "application/vnd.example+type"
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.DefaultPackManifestType, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(manifestDesc)
+	fmt.Println("Manifest descriptor:", manifestDesc)
 
-	// verify manifest
+	// 3. Verify the packed manifest
 	manifestData, err := content.FetchAll(ctx, store, manifestDesc)
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(string(manifestData))
+	fmt.Println("Manifest content:", string(manifestData))
 
 	// Output:
-	// {application/vnd.oci.image.manifest.v1+json sha256:b3b0939bcc66de501485cf003c2c2aca7b6c38e58b6b0d458548d7ef6bd4decc 293 [] map[org.opencontainers.image.created:2000-01-01T00:00:00Z] [] <nil> test/artifact}
-	// {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"test/artifact","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
+	// Manifest descriptor: {application/vnd.oci.image.manifest.v1+json sha256:c259a195a48d8029d75449579c81269ca6225cd5b57d36073a7de6458afdfdbd 528 [] map[org.opencontainers.image.created:2000-01-01T00:00:00Z] [] <nil> application/vnd.example+type}
+	// Manifest content: {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.example+type","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="},"layers":[{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="}],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
+}
+
+// ExampleImageV11RC4 demonstrates packing an OCI Image Manifest as defined since
+// image-spec v1.1.0-rc4.
+func ExamplePackManifest_imageV11RC4() {
+	// 0. Create a storage
+	store := memory.New()
+
+	// 1. Set optional parameters
+	opts := oras.PackManifestOptions{
+		ManifestAnnotations: map[string]string{
+			// this timestamp will be automatically generated if not specified
+			// use a fix value here in order to test the output
+			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
+		},
+	}
+	ctx := context.Background()
+
+	// 2. Pack a manifest
+	artifactType := "application/vnd.example+type"
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestTypeImageV1_1_RC4, artifactType, opts)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Manifest descriptor:", manifestDesc)
+
+	// 3. Verify the packed manifest
+	manifestData, err := content.FetchAll(ctx, store, manifestDesc)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Manifest content:", string(manifestData))
+
+	// Output:
+	// Manifest descriptor: {application/vnd.oci.image.manifest.v1+json sha256:c259a195a48d8029d75449579c81269ca6225cd5b57d36073a7de6458afdfdbd 528 [] map[org.opencontainers.image.created:2000-01-01T00:00:00Z] [] <nil> application/vnd.example+type}
+	// Manifest content: {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.example+type","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="},"layers":[{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="}],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
+}
+
+// ExampleImageV1 demonstrates packing an OCI Image Manifest as defined in
+// image-spec v1.0.2.
+func ExamplePackManifest_imageV1() {
+	// 0. Create a storage
+	store := memory.New()
+
+	// 1. Set optional parameters
+	opts := oras.PackManifestOptions{
+		ManifestAnnotations: map[string]string{
+			// this timestamp will be automatically generated if not specified
+			// use a fix value here in order to test the output
+			ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
+		},
+	}
+	ctx := context.Background()
+
+	// 2. Pack a manifest
+	artifactType := "application/vnd.example+type"
+	manifestDesc, err := oras.PackManifest(ctx, store, oras.PackManifestTypeImageV1_0, artifactType, opts)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Manifest descriptor:", manifestDesc)
+
+	// 3. Verify the packed manifest
+	manifestData, err := content.FetchAll(ctx, store, manifestDesc)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Manifest content:", string(manifestData))
+
+	// Output:
+	// Manifest descriptor: {application/vnd.oci.image.manifest.v1+json sha256:da221a11559704e4971c3dcf6564303707a333c8de8cb5475fc48b0072b36c19 308 [] map[org.opencontainers.image.created:2000-01-01T00:00:00Z] [] <nil> application/vnd.example+type}
+	// Manifest content: {"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.example+type","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[],"annotations":{"org.opencontainers.image.created":"2000-01-01T00:00:00Z"}}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -128,7 +128,7 @@ func Example_pushFilesToRemoteRepository() {
 	opts := oras.PackManifestOptions{
 		Layers: fileDescriptors,
 	}
-	manifestDescriptor, err := oras.PackManifest(ctx, fs, oras.DefaultPackManifestType, artifactType, opts)
+	manifestDescriptor, err := oras.PackManifest(ctx, fs, oras.PackManifestVersionV1_1_RC4, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -125,7 +125,10 @@ func Example_pushFilesToRemoteRepository() {
 
 	// 2. Pack the files and tag the packed manifest
 	artifactType := "example/files"
-	manifestDescriptor, err := oras.PackManifest(ctx, fs, artifactType, fileDescriptors, oras.PackManifestOptions{})
+	opts := oras.PackManifestOptions{
+		Layers: fileDescriptors,
+	}
+	manifestDescriptor, err := oras.PackManifest(ctx, fs, oras.DefaultPackManifestType, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -128,7 +128,7 @@ func Example_pushFilesToRemoteRepository() {
 	opts := oras.PackManifestOptions{
 		Layers: fileDescriptors,
 	}
-	manifestDescriptor, err := oras.PackManifest(ctx, fs, oras.PackManifestVersionV1_1_RC4, artifactType, opts)
+	manifestDescriptor, err := oras.PackManifest(ctx, fs, oras.PackManifestVersion1_1_RC4, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -15,146 +15,146 @@ limitations under the License.
 
 package oras_test
 
-// import (
-// 	"context"
-// 	"fmt"
+import (
+	"context"
+	"fmt"
 
-// 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-// 	oras "oras.land/oras-go/v2"
-// 	"oras.land/oras-go/v2/content/file"
-// 	"oras.land/oras-go/v2/content/oci"
-// 	"oras.land/oras-go/v2/registry/remote"
-// 	"oras.land/oras-go/v2/registry/remote/auth"
-// 	"oras.land/oras-go/v2/registry/remote/retry"
-// )
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/file"
+	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
 
-// // ExamplePullFilesFromRemoteRepository gives an example of pulling files from
-// // a remote repository to the local file system.
-// func Example_pullFilesFromRemoteRepository() {
-// 	// 0. Create a file store
-// 	fs, err := file.New("/tmp/")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	defer fs.Close()
+// ExamplePullFilesFromRemoteRepository gives an example of pulling files from
+// a remote repository to the local file system.
+func Example_pullFilesFromRemoteRepository() {
+	// 0. Create a file store
+	fs, err := file.New("/tmp/")
+	if err != nil {
+		panic(err)
+	}
+	defer fs.Close()
 
-// 	// 1. Connect to a remote repository
-// 	ctx := context.Background()
-// 	reg := "myregistry.example.com"
-// 	repo, err := remote.NewRepository(reg + "/myrepo")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	// Note: The below code can be omitted if authentication is not required
-// 	repo.Client = &auth.Client{
-// 		Client: retry.DefaultClient,
-// 		Cache:  auth.DefaultCache,
-// 		Credential: auth.StaticCredential(reg, auth.Credential{
-// 			Username: "username",
-// 			Password: "password",
-// 		}),
-// 	}
+	// 1. Connect to a remote repository
+	ctx := context.Background()
+	reg := "myregistry.example.com"
+	repo, err := remote.NewRepository(reg + "/myrepo")
+	if err != nil {
+		panic(err)
+	}
+	// Note: The below code can be omitted if authentication is not required
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.DefaultCache,
+		Credential: auth.StaticCredential(reg, auth.Credential{
+			Username: "username",
+			Password: "password",
+		}),
+	}
 
-// 	// 2. Copy from the remote repository to the file store
-// 	tag := "latest"
-// 	manifestDescriptor, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	fmt.Println("manifest descriptor:", manifestDescriptor)
-// }
+	// 2. Copy from the remote repository to the file store
+	tag := "latest"
+	manifestDescriptor, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("manifest descriptor:", manifestDescriptor)
+}
 
-// // ExamplePullImageFromRemoteRepository gives an example of pulling an image
-// // from a remote repository to an OCI Image layout folder.
-// func Example_pullImageFromRemoteRepository() {
-// 	// 0. Create an OCI layout store
-// 	store, err := oci.New("/tmp/oci-layout-root")
-// 	if err != nil {
-// 		panic(err)
-// 	}
+// ExamplePullImageFromRemoteRepository gives an example of pulling an image
+// from a remote repository to an OCI Image layout folder.
+func Example_pullImageFromRemoteRepository() {
+	// 0. Create an OCI layout store
+	store, err := oci.New("/tmp/oci-layout-root")
+	if err != nil {
+		panic(err)
+	}
 
-// 	// 1. Connect to a remote repository
-// 	ctx := context.Background()
-// 	reg := "myregistry.example.com"
-// 	repo, err := remote.NewRepository(reg + "/myrepo")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	// Note: The below code can be omitted if authentication is not required
-// 	repo.Client = &auth.Client{
-// 		Client: retry.DefaultClient,
-// 		Cache:  auth.DefaultCache,
-// 		Credential: auth.StaticCredential(reg, auth.Credential{
-// 			Username: "username",
-// 			Password: "password",
-// 		}),
-// 	}
+	// 1. Connect to a remote repository
+	ctx := context.Background()
+	reg := "myregistry.example.com"
+	repo, err := remote.NewRepository(reg + "/myrepo")
+	if err != nil {
+		panic(err)
+	}
+	// Note: The below code can be omitted if authentication is not required
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.DefaultCache,
+		Credential: auth.StaticCredential(reg, auth.Credential{
+			Username: "username",
+			Password: "password",
+		}),
+	}
 
-// 	// 2. Copy from the remote repository to the OCI layout store
-// 	tag := "latest"
-// 	manifestDescriptor, err := oras.Copy(ctx, repo, tag, store, tag, oras.DefaultCopyOptions)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	fmt.Println("manifest descriptor:", manifestDescriptor)
-// }
+	// 2. Copy from the remote repository to the OCI layout store
+	tag := "latest"
+	manifestDescriptor, err := oras.Copy(ctx, repo, tag, store, tag, oras.DefaultCopyOptions)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("manifest descriptor:", manifestDescriptor)
+}
 
-// // ExamplePushFilesToRemoteRepository gives an example of pushing local files
-// // to a remote repository.
-// func Example_pushFilesToRemoteRepository() {
-// 	// 0. Create a file store
-// 	fs, err := file.New("/tmp/")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	defer fs.Close()
-// 	ctx := context.Background()
+// ExamplePushFilesToRemoteRepository gives an example of pushing local files
+// to a remote repository.
+func Example_pushFilesToRemoteRepository() {
+	// 0. Create a file store
+	fs, err := file.New("/tmp/")
+	if err != nil {
+		panic(err)
+	}
+	defer fs.Close()
+	ctx := context.Background()
 
-// 	// 1. Add files to the file store
-// 	mediaType := "example/file"
-// 	fileNames := []string{"/tmp/myfile"}
-// 	fileDescriptors := make([]v1.Descriptor, 0, len(fileNames))
-// 	for _, name := range fileNames {
-// 		fileDescriptor, err := fs.Add(ctx, name, mediaType, "")
-// 		if err != nil {
-// 			panic(err)
-// 		}
-// 		fileDescriptors = append(fileDescriptors, fileDescriptor)
-// 		fmt.Printf("file descriptor for %s: %v\n", name, fileDescriptor)
-// 	}
+	// 1. Add files to the file store
+	mediaType := "example/file"
+	fileNames := []string{"/tmp/myfile"}
+	fileDescriptors := make([]v1.Descriptor, 0, len(fileNames))
+	for _, name := range fileNames {
+		fileDescriptor, err := fs.Add(ctx, name, mediaType, "")
+		if err != nil {
+			panic(err)
+		}
+		fileDescriptors = append(fileDescriptors, fileDescriptor)
+		fmt.Printf("file descriptor for %s: %v\n", name, fileDescriptor)
+	}
 
-// 	// 2. Pack the files and tag the packed manifest
-// 	artifactType := "example/files"
-// 	manifestDescriptor, err := oras.Pack(ctx, fs, artifactType, fileDescriptors, oras.DefaultPackOptions)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	fmt.Println("manifest descriptor:", manifestDescriptor)
+	// 2. Pack the files and tag the packed manifest
+	artifactType := "example/files"
+	manifestDescriptor, err := oras.PackManifest(ctx, fs, artifactType, fileDescriptors, oras.PackManifestOptions{})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("manifest descriptor:", manifestDescriptor)
 
-// 	tag := "latest"
-// 	if err = fs.Tag(ctx, manifestDescriptor, tag); err != nil {
-// 		panic(err)
-// 	}
+	tag := "latest"
+	if err = fs.Tag(ctx, manifestDescriptor, tag); err != nil {
+		panic(err)
+	}
 
-// 	// 3. Connect to a remote repository
-// 	reg := "myregistry.example.com"
-// 	repo, err := remote.NewRepository(reg + "/myrepo")
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	// Note: The below code can be omitted if authentication is not required
-// 	repo.Client = &auth.Client{
-// 		Client: retry.DefaultClient,
-// 		Cache:  auth.DefaultCache,
-// 		Credential: auth.StaticCredential(reg, auth.Credential{
-// 			Username: "username",
-// 			Password: "password",
-// 		}),
-// 	}
+	// 3. Connect to a remote repository
+	reg := "myregistry.example.com"
+	repo, err := remote.NewRepository(reg + "/myrepo")
+	if err != nil {
+		panic(err)
+	}
+	// Note: The below code can be omitted if authentication is not required
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.DefaultCache,
+		Credential: auth.StaticCredential(reg, auth.Credential{
+			Username: "username",
+			Password: "password",
+		}),
+	}
 
-// 	// 3. Copy from the file store to the remote repository
-// 	_, err = oras.Copy(ctx, fs, tag, repo, tag, oras.DefaultCopyOptions)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// }
+	// 3. Copy from the file store to the remote repository
+	_, err = oras.Copy(ctx, fs, tag, repo, tag, oras.DefaultCopyOptions)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -15,146 +15,146 @@ limitations under the License.
 
 package oras_test
 
-import (
-	"context"
-	"fmt"
+// import (
+// 	"context"
+// 	"fmt"
 
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	oras "oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/file"
-	"oras.land/oras-go/v2/content/oci"
-	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
-	"oras.land/oras-go/v2/registry/remote/retry"
-)
+// 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+// 	oras "oras.land/oras-go/v2"
+// 	"oras.land/oras-go/v2/content/file"
+// 	"oras.land/oras-go/v2/content/oci"
+// 	"oras.land/oras-go/v2/registry/remote"
+// 	"oras.land/oras-go/v2/registry/remote/auth"
+// 	"oras.land/oras-go/v2/registry/remote/retry"
+// )
 
-// ExamplePullFilesFromRemoteRepository gives an example of pulling files from
-// a remote repository to the local file system.
-func Example_pullFilesFromRemoteRepository() {
-	// 0. Create a file store
-	fs, err := file.New("/tmp/")
-	if err != nil {
-		panic(err)
-	}
-	defer fs.Close()
+// // ExamplePullFilesFromRemoteRepository gives an example of pulling files from
+// // a remote repository to the local file system.
+// func Example_pullFilesFromRemoteRepository() {
+// 	// 0. Create a file store
+// 	fs, err := file.New("/tmp/")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	defer fs.Close()
 
-	// 1. Connect to a remote repository
-	ctx := context.Background()
-	reg := "myregistry.example.com"
-	repo, err := remote.NewRepository(reg + "/myrepo")
-	if err != nil {
-		panic(err)
-	}
-	// Note: The below code can be omitted if authentication is not required
-	repo.Client = &auth.Client{
-		Client: retry.DefaultClient,
-		Cache:  auth.DefaultCache,
-		Credential: auth.StaticCredential(reg, auth.Credential{
-			Username: "username",
-			Password: "password",
-		}),
-	}
+// 	// 1. Connect to a remote repository
+// 	ctx := context.Background()
+// 	reg := "myregistry.example.com"
+// 	repo, err := remote.NewRepository(reg + "/myrepo")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	// Note: The below code can be omitted if authentication is not required
+// 	repo.Client = &auth.Client{
+// 		Client: retry.DefaultClient,
+// 		Cache:  auth.DefaultCache,
+// 		Credential: auth.StaticCredential(reg, auth.Credential{
+// 			Username: "username",
+// 			Password: "password",
+// 		}),
+// 	}
 
-	// 2. Copy from the remote repository to the file store
-	tag := "latest"
-	manifestDescriptor, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("manifest descriptor:", manifestDescriptor)
-}
+// 	// 2. Copy from the remote repository to the file store
+// 	tag := "latest"
+// 	manifestDescriptor, err := oras.Copy(ctx, repo, tag, fs, tag, oras.DefaultCopyOptions)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	fmt.Println("manifest descriptor:", manifestDescriptor)
+// }
 
-// ExamplePullImageFromRemoteRepository gives an example of pulling an image
-// from a remote repository to an OCI Image layout folder.
-func Example_pullImageFromRemoteRepository() {
-	// 0. Create an OCI layout store
-	store, err := oci.New("/tmp/oci-layout-root")
-	if err != nil {
-		panic(err)
-	}
+// // ExamplePullImageFromRemoteRepository gives an example of pulling an image
+// // from a remote repository to an OCI Image layout folder.
+// func Example_pullImageFromRemoteRepository() {
+// 	// 0. Create an OCI layout store
+// 	store, err := oci.New("/tmp/oci-layout-root")
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	// 1. Connect to a remote repository
-	ctx := context.Background()
-	reg := "myregistry.example.com"
-	repo, err := remote.NewRepository(reg + "/myrepo")
-	if err != nil {
-		panic(err)
-	}
-	// Note: The below code can be omitted if authentication is not required
-	repo.Client = &auth.Client{
-		Client: retry.DefaultClient,
-		Cache:  auth.DefaultCache,
-		Credential: auth.StaticCredential(reg, auth.Credential{
-			Username: "username",
-			Password: "password",
-		}),
-	}
+// 	// 1. Connect to a remote repository
+// 	ctx := context.Background()
+// 	reg := "myregistry.example.com"
+// 	repo, err := remote.NewRepository(reg + "/myrepo")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	// Note: The below code can be omitted if authentication is not required
+// 	repo.Client = &auth.Client{
+// 		Client: retry.DefaultClient,
+// 		Cache:  auth.DefaultCache,
+// 		Credential: auth.StaticCredential(reg, auth.Credential{
+// 			Username: "username",
+// 			Password: "password",
+// 		}),
+// 	}
 
-	// 2. Copy from the remote repository to the OCI layout store
-	tag := "latest"
-	manifestDescriptor, err := oras.Copy(ctx, repo, tag, store, tag, oras.DefaultCopyOptions)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("manifest descriptor:", manifestDescriptor)
-}
+// 	// 2. Copy from the remote repository to the OCI layout store
+// 	tag := "latest"
+// 	manifestDescriptor, err := oras.Copy(ctx, repo, tag, store, tag, oras.DefaultCopyOptions)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	fmt.Println("manifest descriptor:", manifestDescriptor)
+// }
 
-// ExamplePushFilesToRemoteRepository gives an example of pushing local files
-// to a remote repository.
-func Example_pushFilesToRemoteRepository() {
-	// 0. Create a file store
-	fs, err := file.New("/tmp/")
-	if err != nil {
-		panic(err)
-	}
-	defer fs.Close()
-	ctx := context.Background()
+// // ExamplePushFilesToRemoteRepository gives an example of pushing local files
+// // to a remote repository.
+// func Example_pushFilesToRemoteRepository() {
+// 	// 0. Create a file store
+// 	fs, err := file.New("/tmp/")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	defer fs.Close()
+// 	ctx := context.Background()
 
-	// 1. Add files to the file store
-	mediaType := "example/file"
-	fileNames := []string{"/tmp/myfile"}
-	fileDescriptors := make([]v1.Descriptor, 0, len(fileNames))
-	for _, name := range fileNames {
-		fileDescriptor, err := fs.Add(ctx, name, mediaType, "")
-		if err != nil {
-			panic(err)
-		}
-		fileDescriptors = append(fileDescriptors, fileDescriptor)
-		fmt.Printf("file descriptor for %s: %v\n", name, fileDescriptor)
-	}
+// 	// 1. Add files to the file store
+// 	mediaType := "example/file"
+// 	fileNames := []string{"/tmp/myfile"}
+// 	fileDescriptors := make([]v1.Descriptor, 0, len(fileNames))
+// 	for _, name := range fileNames {
+// 		fileDescriptor, err := fs.Add(ctx, name, mediaType, "")
+// 		if err != nil {
+// 			panic(err)
+// 		}
+// 		fileDescriptors = append(fileDescriptors, fileDescriptor)
+// 		fmt.Printf("file descriptor for %s: %v\n", name, fileDescriptor)
+// 	}
 
-	// 2. Pack the files and tag the packed manifest
-	artifactType := "example/files"
-	manifestDescriptor, err := oras.Pack(ctx, fs, artifactType, fileDescriptors, oras.DefaultPackOptions)
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("manifest descriptor:", manifestDescriptor)
+// 	// 2. Pack the files and tag the packed manifest
+// 	artifactType := "example/files"
+// 	manifestDescriptor, err := oras.Pack(ctx, fs, artifactType, fileDescriptors, oras.DefaultPackOptions)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	fmt.Println("manifest descriptor:", manifestDescriptor)
 
-	tag := "latest"
-	if err = fs.Tag(ctx, manifestDescriptor, tag); err != nil {
-		panic(err)
-	}
+// 	tag := "latest"
+// 	if err = fs.Tag(ctx, manifestDescriptor, tag); err != nil {
+// 		panic(err)
+// 	}
 
-	// 3. Connect to a remote repository
-	reg := "myregistry.example.com"
-	repo, err := remote.NewRepository(reg + "/myrepo")
-	if err != nil {
-		panic(err)
-	}
-	// Note: The below code can be omitted if authentication is not required
-	repo.Client = &auth.Client{
-		Client: retry.DefaultClient,
-		Cache:  auth.DefaultCache,
-		Credential: auth.StaticCredential(reg, auth.Credential{
-			Username: "username",
-			Password: "password",
-		}),
-	}
+// 	// 3. Connect to a remote repository
+// 	reg := "myregistry.example.com"
+// 	repo, err := remote.NewRepository(reg + "/myrepo")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	// Note: The below code can be omitted if authentication is not required
+// 	repo.Client = &auth.Client{
+// 		Client: retry.DefaultClient,
+// 		Cache:  auth.DefaultCache,
+// 		Credential: auth.StaticCredential(reg, auth.Credential{
+// 			Username: "username",
+// 			Password: "password",
+// 		}),
+// 	}
 
-	// 3. Copy from the file store to the remote repository
-	_, err = oras.Copy(ctx, fs, tag, repo, tag, oras.DefaultCopyOptions)
-	if err != nil {
-		panic(err)
-	}
-}
+// 	// 3. Copy from the file store to the remote repository
+// 	_, err = oras.Copy(ctx, fs, tag, repo, tag, oras.DefaultCopyOptions)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// }

--- a/pack.go
+++ b/pack.go
@@ -31,10 +31,12 @@ import (
 )
 
 const (
-	// MediaTypeUnknownConfig is the default mediaType used for [Pack] when
-	// PackOptions.PackImageManifest is true and PackOptions.PackManifestType
-	// is PackManifestTypeImageV1_1_0_RC2 and PackOptions.ConfigDescriptor
-	// is not specified.
+	// MediaTypeUnknownConfig is the default config mediaType used
+	//   - for [Pack] when PackOptions.PackImageManifest is true and
+	//     PackOptions.ConfigDescriptor is not specified.
+	//   - for [PackManifest] when PackManifestOptions.PackManifestType is
+	//     PackManifestTypeImageV1_0 and PackManifestOptions.ConfigDescriptor is
+	//     not specified.
 	MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json"
 
 	// MediaTypeUnknownArtifact is the default artifactType used for [Pack]
@@ -44,14 +46,15 @@ const (
 )
 
 var (
-	// ErrInvalidDateTimeFormat is returned by [Pack] when
+	// ErrInvalidDateTimeFormat is returned by [Pack] and [PackManifest] when
 	// AnnotationArtifactCreated or AnnotationCreated is provided, but its value
 	// is not in RFC 3339 format.
 	// Reference: https://www.rfc-editor.org/rfc/rfc3339#section-5.6
 	ErrInvalidDateTimeFormat = errors.New("invalid date and time format")
 
-	// ErrMissingArtifactType is returned by [Pack] when artifactType is not
-	// specified and the config media type is set to
+	// ErrMissingArtifactType is returned by [PackManifest] when
+	// PackManifestOptions.PackManifestType is PackManifestTypeImageV1_1_RC4
+	// and artifactType is not specified and the config media type is set to
 	// "application/vnd.oci.empty.v1+json".
 	ErrMissingArtifactType = errors.New("missing artifact type")
 )

--- a/pack.go
+++ b/pack.go
@@ -34,7 +34,7 @@ const (
 	// MediaTypeUnknownConfig is the default config mediaType used
 	//   - for [Pack] when PackOptions.PackImageManifest is true and
 	//     PackOptions.ConfigDescriptor is not specified.
-	//   - for [PackManifest] when manifestType is PackManifestVersionV1_0
+	//   - for [PackManifest] when manifestType is PackManifestVersion1_0
 	//     and PackManifestOptions.ConfigDescriptor is not specified.
 	MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json"
 
@@ -52,7 +52,7 @@ var (
 	ErrInvalidDateTimeFormat = errors.New("invalid date and time format")
 
 	// ErrMissingArtifactType is returned by [PackManifest] when
-	// packManifestType is PackManifestVersionV1_1_RC4 and artifactType is
+	// packManifestType is PackManifestVersion1_1_RC4 and artifactType is
 	// empty and the config media type is set to
 	// "application/vnd.oci.empty.v1+json".
 	ErrMissingArtifactType = errors.New("missing artifact type")
@@ -62,22 +62,22 @@ var (
 type PackManifestVersion int
 
 const (
-	// PackManifestVersionV1_0 represents the OCI Image Manifest defined in
+	// PackManifestVersion1_0 represents the OCI Image Manifest defined in
 	// image-spec v1.0.2.
 	// Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
-	PackManifestVersionV1_0 PackManifestVersion = 1
+	PackManifestVersion1_0 PackManifestVersion = 1
 
-	// PackManifestVersionV1_1_RC4 represents the OCI Image Manifest defined
+	// PackManifestVersion1_1_RC4 represents the OCI Image Manifest defined
 	// in image-spec v1.1.0-rc4.
 	// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/manifest.md
-	PackManifestVersionV1_1_RC4 PackManifestVersion = 2
+	PackManifestVersion1_1_RC4 PackManifestVersion = 2
 )
 
 // PackManifestOptions contains parameters for [PackManifest].
 type PackManifestOptions struct {
 	// Subject is the subject of the manifest.
 	// This option is only valid when PackManifestType is
-	// NOT PackManifestVersionV1_0.
+	// NOT PackManifestVersion1_0.
 	Subject *ocispec.Descriptor
 
 	// Layers is the layers of the manifest.
@@ -99,20 +99,20 @@ type PackManifestOptions struct {
 // PackManifest generates an OCI Image Manifest based on the given parameters
 // and pushes the packed manifest to a content storage using pusher. The version
 // of the manifest to be packed is determined by manifestVersion (Recommended
-// value: PackManifestVersionV1_1_RC4).
+// value: PackManifestVersion1_1_RC4).
 //
-//   - If manifestVersion is [PackManifestVersionV1_1_RC4],
+//   - If manifestVersion is [PackManifestVersion1_1_RC4],
 //     artifactType must not be empty when opts.ConfigDescriptor is nil.
-//   - If manifestVersion is [PackManifestVersionV1_0],
+//   - If manifestVersion is [PackManifestVersion1_0],
 //     artifactType will be used as the the config media type when
 //     opts.ConfigDescriptor is nil.
 //
 // If succeeded, returns a descriptor of the manifest.
 func PackManifest(ctx context.Context, pusher content.Pusher, manifestVersion PackManifestVersion, artifactType string, opts PackManifestOptions) (ocispec.Descriptor, error) {
 	switch manifestVersion {
-	case PackManifestVersionV1_0:
+	case PackManifestVersion1_0:
 		return packManifestV1_0(ctx, pusher, artifactType, opts)
-	case PackManifestVersionV1_1_RC4:
+	case PackManifestVersion1_1_RC4:
 		return packManifestV1_1_RC4(ctx, pusher, artifactType, opts)
 	default:
 		return ocispec.Descriptor{}, fmt.Errorf("PackManifestType(%v): %w", manifestVersion, errdef.ErrUnsupported)
@@ -124,18 +124,18 @@ func PackManifest(ctx context.Context, pusher content.Pusher, manifestVersion Pa
 // Deprecated: This type is deprecated and not recommended for future use.
 // Use [PackManifestOptions] instead.
 type PackOptions struct {
+	// Subject is the subject of the manifest.
+	Subject *ocispec.Descriptor
+
+	// ManifestAnnotations is the annotation map of the manifest.
+	ManifestAnnotations map[string]string
+
 	// PackImageManifest controls whether to pack an OCI Image Manifest or not.
 	//   - If true, pack an OCI Image Manifest.
 	//   - If false, pack an OCI Artifact Manifest (deprecated).
 	//
 	// Default value: false.
 	PackImageManifest bool
-
-	// Subject is the subject of the manifest.
-	Subject *ocispec.Descriptor
-
-	// ManifestAnnotations is the annotation map of the manifest.
-	ManifestAnnotations map[string]string
 
 	// ConfigDescriptor is a pointer to the descriptor of the config blob.
 	// If not nil, artifactType will be implied by the mediaType of the
@@ -290,7 +290,7 @@ func packManifestV1_1_RC4(ctx context.Context, pusher content.Pusher, artifactTy
 // Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
 func packManifestV1_0(ctx context.Context, pusher content.Pusher, configMediaType string, opts PackManifestOptions) (ocispec.Descriptor, error) {
 	if opts.Subject != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("subject is not supported for manifest version %v: %w", PackManifestVersionV1_0, errdef.ErrUnsupported)
+		return ocispec.Descriptor{}, fmt.Errorf("subject is not supported for manifest version %v: %w", PackManifestVersion1_0, errdef.ErrUnsupported)
 	}
 
 	// manifest v1.0 is equivalent to manifest v1.1.0-rc2 without subject

--- a/pack.go
+++ b/pack.go
@@ -115,7 +115,7 @@ func PackManifest(ctx context.Context, pusher content.Pusher, manifestVersion Pa
 	case PackManifestVersion1_1_RC4:
 		return packManifestV1_1_RC4(ctx, pusher, artifactType, opts)
 	default:
-		return ocispec.Descriptor{}, fmt.Errorf("PackManifestType(%v): %w", manifestVersion, errdef.ErrUnsupported)
+		return ocispec.Descriptor{}, fmt.Errorf("PackManifestVersion(%v): %w", manifestVersion, errdef.ErrUnsupported)
 	}
 }
 

--- a/pack.go
+++ b/pack.go
@@ -77,8 +77,6 @@ const (
 // PackManifestOptions contains parameters for [PackManifest].
 type PackManifestOptions struct {
 	// PackManifestType controls which type of manifest to pack.
-	// This option is valid only when PackImageManifest is true.
-	//
 	// Default value: PackManifestTypeImageV1_1_RC4.
 	PackManifestType PackManifestType
 
@@ -114,7 +112,6 @@ type PackManifestOptions struct {
 func PackManifest(ctx context.Context, pusher content.Pusher, artifactType string, layers []ocispec.Descriptor, opts PackManifestOptions) (ocispec.Descriptor, error) {
 	switch opts.PackManifestType {
 	case PackManifestTypeImageV1_0:
-		// TODO: block subject?
 		return packManifestV1_0(ctx, pusher, artifactType, layers, opts)
 	case PackManifestTypeImageV1_1_RC4:
 		return packManifestV1_1_RC4(ctx, pusher, artifactType, layers, opts)
@@ -125,19 +122,22 @@ func PackManifest(ctx context.Context, pusher content.Pusher, artifactType strin
 }
 
 // PackOptions contains parameters for [Pack].
+//
+// Deprecated: This type is deprecated and not recommended for future use.
+// Use [PackManifestOptions] instead.
 type PackOptions struct {
-	// Subject is the subject of the manifest.
-	Subject *ocispec.Descriptor
-
-	// ManifestAnnotations is the annotation map of the manifest.
-	ManifestAnnotations map[string]string
-
 	// PackImageManifest controls whether to pack an OCI Image Manifest or not.
 	//   - If true, pack an OCI Image Manifest.
 	//   - If false, pack an OCI Artifact Manifest (deprecated).
 	//
 	// Default value: false.
 	PackImageManifest bool
+
+	// Subject is the subject of the manifest.
+	Subject *ocispec.Descriptor
+
+	// ManifestAnnotations is the annotation map of the manifest.
+	ManifestAnnotations map[string]string
 
 	// ConfigDescriptor is a pointer to the descriptor of the config blob.
 	// If not nil, artifactType will be implied by the mediaType of the
@@ -158,9 +158,12 @@ type PackOptions struct {
 // the config descriptor mediaType of the image manifest.
 //
 // If succeeded, returns a descriptor of the manifest.
+//
+// Deprecated: This method is deprecated and not recommended for future use.
+// Use [PackManifest] instead.
 func Pack(ctx context.Context, pusher content.Pusher, artifactType string, blobs []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
 	if opts.PackImageManifest {
-		return packImage(ctx, pusher, artifactType, blobs, opts)
+		return packManifestV1_1_RC2(ctx, pusher, artifactType, blobs, opts)
 	}
 	return packArtifact(ctx, pusher, artifactType, blobs, opts)
 }
@@ -186,9 +189,9 @@ func packArtifact(ctx context.Context, pusher content.Pusher, artifactType strin
 	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.ArtifactType, manifest.Annotations)
 }
 
-// packImage packs an image manifest defined in image-spec v1.1.0-rc2.
+// packManifestV1_1_RC2 packs an image manifest defined in image-spec v1.1.0-rc2.
 // Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md
-func packImage(ctx context.Context, pusher content.Pusher, configMediaType string, layers []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
+func packManifestV1_1_RC2(ctx context.Context, pusher content.Pusher, configMediaType string, layers []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
 	if configMediaType == "" {
 		configMediaType = MediaTypeUnknownConfig
 	}
@@ -287,44 +290,18 @@ func packManifestV1_1_RC4(ctx context.Context, pusher content.Pusher, artifactTy
 // packManifestV1_0 packs an image manifest defined in image-spec v1.0.2.
 // Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
 func packManifestV1_0(ctx context.Context, pusher content.Pusher, configMediaType string, layers []ocispec.Descriptor, opts PackManifestOptions) (ocispec.Descriptor, error) {
-	if configMediaType == "" {
-		configMediaType = MediaTypeUnknownConfig
+	if opts.Subject != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("subject is not supported for manifest type %v: %w", PackManifestTypeImageV1_0, errdef.ErrUnsupported)
 	}
 
-	var configDesc ocispec.Descriptor
-	if opts.ConfigDescriptor != nil {
-		configDesc = *opts.ConfigDescriptor
-	} else {
-		// Use an empty JSON object here, because some registries may not accept
-		// empty config blob.
-		// As of September 2022, GAR is known to return 400 on empty blob upload.
-		// See https://github.com/oras-project/oras-go/issues/294 for details.
-		configBytes := []byte("{}")
-		configDesc = content.NewDescriptorFromBytes(configMediaType, configBytes)
-		configDesc.Annotations = opts.ConfigAnnotations
-		// push config
-		if err := pushIfNotExist(ctx, pusher, configDesc, configBytes); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("failed to push config: %w", err)
-		}
+	// manifest v1.0 is equivalent to manifest v1.1.0-rc2 without subject
+	packOpts := PackOptions{
+		PackImageManifest:   true,
+		ManifestAnnotations: opts.ManifestAnnotations,
+		ConfigDescriptor:    opts.ConfigDescriptor,
+		ConfigAnnotations:   opts.ConfigAnnotations,
 	}
-
-	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, ocispec.AnnotationCreated)
-	if err != nil {
-		return ocispec.Descriptor{}, err
-	}
-	if layers == nil {
-		layers = []ocispec.Descriptor{} // make it an empty array to prevent potential server-side bugs
-	}
-	manifest := ocispec.Manifest{
-		Versioned: specs.Versioned{
-			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
-		},
-		Config:      configDesc,
-		MediaType:   ocispec.MediaTypeImageManifest,
-		Layers:      layers,
-		Annotations: annotations,
-	}
-	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.Config.MediaType, manifest.Annotations)
+	return packManifestV1_1_RC2(ctx, pusher, configMediaType, layers, packOpts)
 }
 
 // pushIfNotExist pushes data described by desc if it does not exist in the

--- a/pack_test.go
+++ b/pack_test.go
@@ -1023,7 +1023,7 @@ func Test_PackManifest_ImageV1_0_InvalidDateTimeFormat(t *testing.T) {
 	}
 }
 
-func Test_PackManifest_UnsupportedPackManifestType(t *testing.T) {
+func Test_PackManifest_UnsupportedPackManifestVersion(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()

--- a/pack_test.go
+++ b/pack_test.go
@@ -521,7 +521,7 @@ func Test_Pack_ImageRC2_InvalidDateTimeFormat(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC4(t *testing.T) {
+func Test_PackManifest_ImageRC4(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
@@ -530,7 +530,7 @@ func Test_Pack_ImageRC4(t *testing.T) {
 		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
 	}
 
-	// verify Pack
+	// verify PackManifest
 	ctx := context.Background()
 	artifactType := "application/vnd.test"
 	opts := PackManifestOptions{
@@ -538,7 +538,7 @@ func Test_Pack_ImageRC4(t *testing.T) {
 	}
 	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
-		t.Fatal("Oras.Pack() error =", err)
+		t.Fatal("Oras.PackManifest() error =", err)
 	}
 
 	// verify manifest
@@ -597,7 +597,7 @@ func Test_Pack_ImageRC4(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
+func Test_PackManifest_ImageRC4_WithOptions(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
@@ -619,7 +619,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 		Size:      int64(len(subjectManifest)),
 	}
 
-	// test Pack with ConfigDescriptor
+	// test PackManifest with ConfigDescriptor
 	ctx := context.Background()
 	opts := PackManifestOptions{
 		PackManifestType:    PackManifestTypeImageV1_1_RC4,
@@ -630,7 +630,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	}
 	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
-		t.Fatal("Oras.Pack() error =", err)
+		t.Fatal("Oras.PackManifest() error =", err)
 	}
 
 	expectedManifest := ocispec.Manifest{
@@ -670,10 +670,10 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	expectedManifestDesc.ArtifactType = expectedManifest.ArtifactType
 	expectedManifestDesc.Annotations = expectedManifest.Annotations
 	if !reflect.DeepEqual(manifestDesc, expectedManifestDesc) {
-		t.Errorf("Pack() = %v, want %v", manifestDesc, expectedManifestDesc)
+		t.Errorf("PackManifest() = %v, want %v", manifestDesc, expectedManifestDesc)
 	}
 
-	// test Pack with ConfigDescriptor, but without artifactType
+	// test PackManifest with ConfigDescriptor, but without artifactType
 	opts = PackManifestOptions{
 		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
@@ -683,7 +683,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	}
 	manifestDesc, err = PackManifest(ctx, s, "", layers, opts)
 	if err != nil {
-		t.Fatal("Oras.Pack() error =", err)
+		t.Fatal("Oras.PackManifest() error =", err)
 	}
 
 	expectedManifest = ocispec.Manifest{
@@ -722,7 +722,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	expectedManifestDesc.ArtifactType = expectedManifest.ArtifactType
 	expectedManifestDesc.Annotations = expectedManifest.Annotations
 	if !reflect.DeepEqual(manifestDesc, expectedManifestDesc) {
-		t.Errorf("Pack() = %v, want %v", manifestDesc, expectedManifestDesc)
+		t.Errorf("PackManifest() = %v, want %v", manifestDesc, expectedManifestDesc)
 	}
 
 	// test Pack without ConfigDescriptor
@@ -734,7 +734,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	}
 	manifestDesc, err = PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
-		t.Fatal("Oras.Pack() error =", err)
+		t.Fatal("Oras.PackManifest() error =", err)
 	}
 
 	expectedConfigDesc := ocispec.DescriptorEmptyJSON
@@ -776,11 +776,11 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	expectedManifestDesc.ArtifactType = expectedManifest.ArtifactType
 	expectedManifestDesc.Annotations = expectedManifest.Annotations
 	if !reflect.DeepEqual(manifestDesc, expectedManifestDesc) {
-		t.Errorf("Pack() = %v, want %v", manifestDesc, expectedManifestDesc)
+		t.Errorf("PackManifest() = %v, want %v", manifestDesc, expectedManifestDesc)
 	}
 }
 
-func Test_Pack_ImageRC4_NoArtifactType(t *testing.T) {
+func Test_PackManifest_ImageRC4_NoArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -790,7 +790,7 @@ func Test_Pack_ImageRC4_NoArtifactType(t *testing.T) {
 	}
 	_, err := PackManifest(ctx, s, "", nil, opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
-		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 
 	// test no artifact type and config with media type empty
@@ -802,21 +802,21 @@ func Test_Pack_ImageRC4_NoArtifactType(t *testing.T) {
 	}
 	_, err = PackManifest(ctx, s, "", nil, opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
-		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 }
 
-func Test_Pack_ImageRC4_NoLayer(t *testing.T) {
+func Test_PackManifest_ImageRC4_NoLayer(t *testing.T) {
 	s := memory.New()
 
-	// test Pack
+	// test PackManifest
 	ctx := context.Background()
 	opts := PackManifestOptions{
 		PackManifestType: PackManifestTypeImageV1_1_RC4,
 	}
 	manifestDesc, err := PackManifest(ctx, s, "test", nil, opts)
 	if err != nil {
-		t.Fatal("Oras.Pack() error =", err)
+		t.Fatal("Oras.PackManifest() error =", err)
 	}
 
 	var manifest ocispec.Manifest
@@ -838,7 +838,7 @@ func Test_Pack_ImageRC4_NoLayer(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
+func Test_PackManifest_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -850,84 +850,11 @@ func Test_Pack_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
 	}
 	_, err := PackManifest(ctx, s, "test", nil, opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
-		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 }
 
-// func Test_Pack_DefaultPackOptions(t *testing.T) {
-// 	s := memory.New()
-
-// 	// prepare test content
-// 	layers := []ocispec.Descriptor{
-// 		content.NewDescriptorFromBytes("test", []byte("hello world")),
-// 		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
-// 	}
-
-// 	// verify Pack
-// 	ctx := context.Background()
-// 	artifactType := "application/vnd.test"
-// 	manifestDesc, err := Pack(ctx, s, artifactType, layers, DefaultPackOptions)
-// 	if err != nil {
-// 		t.Fatal("Oras.Pack() error =", err)
-// 	}
-
-// 	// verify manifest
-// 	var manifest ocispec.Manifest
-// 	rc, err := s.Fetch(ctx, manifestDesc)
-// 	if err != nil {
-// 		t.Fatal("Store.Fetch() error =", err)
-// 	}
-// 	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
-// 		t.Fatal("error decoding manifest, error =", err)
-// 	}
-// 	if err := rc.Close(); err != nil {
-// 		t.Fatal("Store.Fetch().Close() error =", err)
-// 	}
-
-// 	// verify media type
-// 	got := manifest.MediaType
-// 	if got != ocispec.MediaTypeImageManifest {
-// 		t.Fatalf("got media type = %s, want %s", got, ocispec.MediaTypeImageManifest)
-// 	}
-
-// 	// verify config
-// 	expectedConfig := ocispec.DescriptorEmptyJSON
-// 	if !reflect.DeepEqual(manifest.Config, expectedConfig) {
-// 		t.Errorf("got config = %v, want %v", manifest.Config, expectedConfig)
-// 	}
-
-// 	// verify layers
-// 	if !reflect.DeepEqual(manifest.Layers, layers) {
-// 		t.Errorf("got layers = %v, want %v", manifest.Layers, layers)
-// 	}
-
-// 	// verify created time annotation
-// 	createdTime, ok := manifest.Annotations[ocispec.AnnotationCreated]
-// 	if !ok {
-// 		t.Errorf("Annotation %s = %v, want %v", ocispec.AnnotationCreated, ok, true)
-// 	}
-// 	_, err = time.Parse(time.RFC3339, createdTime)
-// 	if err != nil {
-// 		t.Errorf("error parsing created time: %s, error = %v", createdTime, err)
-// 	}
-
-// 	// verify artifact type
-// 	if !reflect.DeepEqual(manifest.ArtifactType, artifactType) {
-// 		t.Errorf("got artifactType = %v, want %v", manifest.ArtifactType, artifactType)
-// 	}
-
-// 	// verify descriptor artifact type
-// 	if want := manifest.ArtifactType; !reflect.DeepEqual(manifestDesc.ArtifactType, want) {
-// 		t.Errorf("got descriptor artifactType = %v, want %v", manifestDesc.ArtifactType, want)
-// 	}
-
-// 	// verify descriptor annotations
-// 	if want := manifest.Annotations; !reflect.DeepEqual(manifestDesc.Annotations, want) {
-// 		t.Errorf("got descriptor annotations = %v, want %v", manifestDesc.Annotations, want)
-// 	}
-// }
-
-func Test_Pack_UnsupportedPackManifestType(t *testing.T) {
+func Test_PackManifest_UnsupportedPackManifestType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -936,6 +863,6 @@ func Test_Pack_UnsupportedPackManifestType(t *testing.T) {
 	}
 	_, err := PackManifest(ctx, s, "", nil, opts)
 	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
-		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 }

--- a/pack_test.go
+++ b/pack_test.go
@@ -534,7 +534,7 @@ func Test_Pack_ImageRC4(t *testing.T) {
 	ctx := context.Background()
 	artifactType := "application/vnd.test"
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType: PackManifestTypeImageV1_1_RC4,
 	}
 	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
@@ -622,7 +622,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	// test Pack with ConfigDescriptor
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
@@ -675,7 +675,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 
 	// test Pack with ConfigDescriptor, but without artifactType
 	opts = PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
@@ -727,7 +727,7 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 
 	// test Pack without ConfigDescriptor
 	opts = PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
@@ -786,7 +786,7 @@ func Test_Pack_ImageRC4_NoArtifactType(t *testing.T) {
 	ctx := context.Background()
 	// test no artifact type and no config
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType: PackManifestTypeImageV1_1_RC4,
 	}
 	_, err := PackManifest(ctx, s, "", nil, opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
@@ -795,7 +795,7 @@ func Test_Pack_ImageRC4_NoArtifactType(t *testing.T) {
 
 	// test no artifact type and config with media type empty
 	opts = PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType: PackManifestTypeImageV1_1_RC4,
 		ConfigDescriptor: &ocispec.Descriptor{
 			MediaType: ocispec.DescriptorEmptyJSON.MediaType,
 		},
@@ -812,7 +812,7 @@ func Test_Pack_ImageRC4_NoLayer(t *testing.T) {
 	// test Pack
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType: PackManifestTypeImageV1_1_RC4,
 	}
 	manifestDesc, err := PackManifest(ctx, s, "test", nil, opts)
 	if err != nil {
@@ -843,7 +843,7 @@ func Test_Pack_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
 
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
+		PackManifestType: PackManifestTypeImageV1_1_RC4,
 		ManifestAnnotations: map[string]string{
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},

--- a/pack_test.go
+++ b/pack_test.go
@@ -528,7 +528,7 @@ func Test_PackManifest_ImageV1_1_RC4(t *testing.T) {
 
 	// test PackManifest
 	ctx := context.Background()
-	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "test", PackManifestOptions{})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersion1_1_RC4, "test", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -584,7 +584,7 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, artifactType, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersion1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -637,7 +637,7 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "", opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestVersion1_1_RC4, "", opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -688,7 +688,7 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, PackManifestVersionV1_1_RC4, artifactType, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestVersion1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -741,7 +741,7 @@ func Test_PackManifest_ImageV1_1_RC4_NoArtifactType(t *testing.T) {
 
 	ctx := context.Background()
 	// test no artifact type and no config
-	_, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "", PackManifestOptions{})
+	_, err := PackManifest(ctx, s, PackManifestVersion1_1_RC4, "", PackManifestOptions{})
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -752,7 +752,7 @@ func Test_PackManifest_ImageV1_1_RC4_NoArtifactType(t *testing.T) {
 			MediaType: ocispec.DescriptorEmptyJSON.MediaType,
 		},
 	}
-	_, err = PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "", opts)
+	_, err = PackManifest(ctx, s, PackManifestVersion1_1_RC4, "", opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -767,7 +767,7 @@ func Test_PackManifest_ImageV1_1_RC4_InvalidDateTimeFormat(t *testing.T) {
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "test", opts)
+	_, err := PackManifest(ctx, s, PackManifestVersion1_1_RC4, "test", opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -779,7 +779,7 @@ func Test_PackManifest_ImageV1_0(t *testing.T) {
 	// test Pack
 	ctx := context.Background()
 	artifactType := "testconfig"
-	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, PackManifestOptions{})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersion1_0, artifactType, PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -860,7 +860,7 @@ func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersion1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -909,7 +909,7 @@ func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestVersion1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -972,7 +972,7 @@ func Test_PackManifest_ImageV1_0_SubjectUnsupported(t *testing.T) {
 	opts := PackManifestOptions{
 		Subject: &subjectDesc,
 	}
-	_, err := PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, opts)
+	_, err := PackManifest(ctx, s, PackManifestVersion1_0, artifactType, opts)
 	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr %v", err, wantErr)
 	}
@@ -982,7 +982,7 @@ func Test_PackManifest_ImageV1_0_NoArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_0, "", PackManifestOptions{})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersion1_0, "", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -1017,7 +1017,7 @@ func Test_PackManifest_ImageV1_0_InvalidDateTimeFormat(t *testing.T) {
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := PackManifest(ctx, s, PackManifestVersionV1_0, "", opts)
+	_, err := PackManifest(ctx, s, PackManifestVersion1_0, "", opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}

--- a/pack_test.go
+++ b/pack_test.go
@@ -110,6 +110,7 @@ func Test_Pack_Artifact_WithOptions(t *testing.T) {
 	artifactType := "application/vnd.test"
 	annotations := map[string]string{
 		spec.AnnotationArtifactCreated: "2000-01-01T00:00:00Z",
+		"foo":                          "bar",
 	}
 	subjectManifest := []byte(`{"layers":[]}`)
 	subjectDesc := ocispec.Descriptor{
@@ -250,7 +251,7 @@ func Test_Pack_Artifact_InvalidDateTimeFormat(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC2(t *testing.T) {
+func Test_Pack_ImageV1_1_RC2(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
@@ -317,7 +318,7 @@ func Test_Pack_ImageRC2(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC2_WithOptions(t *testing.T) {
+func Test_Pack_ImageV1_1_RC2_WithOptions(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
@@ -330,6 +331,7 @@ func Test_Pack_ImageRC2_WithOptions(t *testing.T) {
 	configAnnotations := map[string]string{"foo": "bar"}
 	annotations := map[string]string{
 		ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
+		"foo":                     "bar",
 	}
 	artifactType := "application/vnd.test"
 	subjectManifest := []byte(`{"layers":[]}`)
@@ -446,7 +448,7 @@ func Test_Pack_ImageRC2_WithOptions(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC2_NoArtifactType(t *testing.T) {
+func Test_Pack_ImageV1_1_RC2_NoArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -476,7 +478,7 @@ func Test_Pack_ImageRC2_NoArtifactType(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC2_NoLayer(t *testing.T) {
+func Test_Pack_ImageV1_1_RC2_NoLayer(t *testing.T) {
 	s := memory.New()
 
 	// test Pack
@@ -505,7 +507,7 @@ func Test_Pack_ImageRC2_NoLayer(t *testing.T) {
 	}
 }
 
-func Test_Pack_ImageRC2_InvalidDateTimeFormat(t *testing.T) {
+func Test_Pack_ImageV1_1_RC2_InvalidDateTimeFormat(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -521,7 +523,7 @@ func Test_Pack_ImageRC2_InvalidDateTimeFormat(t *testing.T) {
 	}
 }
 
-func Test_PackManifest_ImageRC4(t *testing.T) {
+func Test_PackManifest_ImageV1_1_RC4(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
@@ -533,10 +535,7 @@ func Test_PackManifest_ImageRC4(t *testing.T) {
 	// verify PackManifest
 	ctx := context.Background()
 	artifactType := "application/vnd.test"
-	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_RC4,
-	}
-	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
+	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -597,7 +596,7 @@ func Test_PackManifest_ImageRC4(t *testing.T) {
 	}
 }
 
-func Test_PackManifest_ImageRC4_WithOptions(t *testing.T) {
+func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
@@ -610,6 +609,7 @@ func Test_PackManifest_ImageRC4_WithOptions(t *testing.T) {
 	configAnnotations := map[string]string{"foo": "bar"}
 	annotations := map[string]string{
 		ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
+		"foo":                     "bar",
 	}
 	artifactType := "application/vnd.test"
 	subjectManifest := []byte(`{"layers":[]}`)
@@ -780,7 +780,7 @@ func Test_PackManifest_ImageRC4_WithOptions(t *testing.T) {
 	}
 }
 
-func Test_PackManifest_ImageRC4_NoArtifactType(t *testing.T) {
+func Test_PackManifest_ImageV1_1_RC4_NoArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -806,7 +806,7 @@ func Test_PackManifest_ImageRC4_NoArtifactType(t *testing.T) {
 	}
 }
 
-func Test_PackManifest_ImageRC4_NoLayer(t *testing.T) {
+func Test_PackManifest_ImageV1_1_RC4_NoLayer(t *testing.T) {
 	s := memory.New()
 
 	// test PackManifest
@@ -838,7 +838,7 @@ func Test_PackManifest_ImageRC4_NoLayer(t *testing.T) {
 	}
 }
 
-func Test_PackManifest_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
+func Test_PackManifest_ImageV1_1_RC4_InvalidDateTimeFormat(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
@@ -849,6 +849,296 @@ func Test_PackManifest_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
 		},
 	}
 	_, err := PackManifest(ctx, s, "test", nil, opts)
+	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
+	}
+}
+
+func Test_PackManifest_ImageV1_0(t *testing.T) {
+	s := memory.New()
+
+	// prepare test content
+	layers := []ocispec.Descriptor{
+		content.NewDescriptorFromBytes("test", []byte("hello world")),
+		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
+	}
+
+	// test Pack
+	ctx := context.Background()
+	artifactType := "testconfig"
+	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, PackManifestOptions{PackManifestType: PackManifestTypeImageV1_0})
+	if err != nil {
+		t.Fatal("Oras.PackManifest() error =", err)
+	}
+
+	var manifest ocispec.Manifest
+	rc, err := s.Fetch(ctx, manifestDesc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		t.Fatal("error decoding manifest, error =", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatal("Store.Fetch().Close() error =", err)
+	}
+
+	// verify media type
+	got := manifest.MediaType
+	if got != ocispec.MediaTypeImageManifest {
+		t.Fatalf("got media type = %s, want %s", got, ocispec.MediaTypeImageManifest)
+	}
+
+	// verify config
+	expectedConfigBytes := []byte("{}")
+	expectedConfig := ocispec.Descriptor{
+		MediaType: artifactType,
+		Digest:    digest.FromBytes(expectedConfigBytes),
+		Size:      int64(len(expectedConfigBytes)),
+	}
+	if !reflect.DeepEqual(manifest.Config, expectedConfig) {
+		t.Errorf("got config = %v, want %v", manifest.Config, expectedConfig)
+	}
+
+	// verify layers
+	if !reflect.DeepEqual(manifest.Layers, layers) {
+		t.Errorf("got layers = %v, want %v", manifest.Layers, layers)
+	}
+
+	// verify created time annotation
+	createdTime, ok := manifest.Annotations[ocispec.AnnotationCreated]
+	if !ok {
+		t.Errorf("Annotation %s = %v, want %v", ocispec.AnnotationCreated, ok, true)
+	}
+	_, err = time.Parse(time.RFC3339, createdTime)
+	if err != nil {
+		t.Errorf("error parsing created time: %s, error = %v", createdTime, err)
+	}
+
+	// verify descriptor annotations
+	if want := manifest.Annotations; !reflect.DeepEqual(manifestDesc.Annotations, want) {
+		t.Errorf("got descriptor annotations = %v, want %v", manifestDesc.Annotations, want)
+	}
+}
+
+func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
+	s := memory.New()
+
+	// prepare test content
+	layers := []ocispec.Descriptor{
+		content.NewDescriptorFromBytes("test", []byte("hello world")),
+		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
+	}
+	configBytes := []byte("{}")
+	configDesc := content.NewDescriptorFromBytes("testconfig", configBytes)
+	configAnnotations := map[string]string{"foo": "bar"}
+	annotations := map[string]string{
+		ocispec.AnnotationCreated: "2000-01-01T00:00:00Z",
+		"foo":                     "bar",
+	}
+	artifactType := "application/vnd.test"
+
+	// test PackManifest with ConfigDescriptor
+	ctx := context.Background()
+	opts := PackManifestOptions{
+		PackManifestType:    PackManifestTypeImageV1_0,
+		ConfigDescriptor:    &configDesc,
+		ConfigAnnotations:   configAnnotations,
+		ManifestAnnotations: annotations,
+	}
+	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
+	if err != nil {
+		t.Fatal("Oras.PackManifest() error =", err)
+	}
+
+	expectedManifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		MediaType:   ocispec.MediaTypeImageManifest,
+		Config:      configDesc,
+		Layers:      layers,
+		Annotations: annotations,
+	}
+	expectedManifestBytes, err := json.Marshal(expectedManifest)
+	if err != nil {
+		t.Fatal("failed to marshal manifest:", err)
+	}
+
+	rc, err := s.Fetch(ctx, manifestDesc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Store.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Store.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, expectedManifestBytes) {
+		t.Errorf("Store.Fetch() = %v, want %v", string(got), string(expectedManifestBytes))
+	}
+
+	// verify descriptor
+	expectedManifestDesc := content.NewDescriptorFromBytes(expectedManifest.MediaType, expectedManifestBytes)
+	expectedManifestDesc.ArtifactType = expectedManifest.Config.MediaType
+	expectedManifestDesc.Annotations = expectedManifest.Annotations
+	if !reflect.DeepEqual(manifestDesc, expectedManifestDesc) {
+		t.Errorf("Pack() = %v, want %v", manifestDesc, expectedManifestDesc)
+	}
+
+	// test PackManifest without ConfigDescriptor
+	opts = PackManifestOptions{
+		PackManifestType:    PackManifestTypeImageV1_0,
+		ConfigAnnotations:   configAnnotations,
+		ManifestAnnotations: annotations,
+	}
+	manifestDesc, err = PackManifest(ctx, s, artifactType, layers, opts)
+	if err != nil {
+		t.Fatal("Oras.PackManifest() error =", err)
+	}
+
+	expectedConfigDesc := content.NewDescriptorFromBytes(artifactType, configBytes)
+	expectedConfigDesc.Annotations = configAnnotations
+	expectedManifest = ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		MediaType:   ocispec.MediaTypeImageManifest,
+		Config:      expectedConfigDesc,
+		Layers:      layers,
+		Annotations: annotations,
+	}
+	expectedManifestBytes, err = json.Marshal(expectedManifest)
+	if err != nil {
+		t.Fatal("failed to marshal manifest:", err)
+	}
+
+	rc, err = s.Fetch(ctx, manifestDesc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	got, err = io.ReadAll(rc)
+	if err != nil {
+		t.Fatal("Store.Fetch().Read() error =", err)
+	}
+	err = rc.Close()
+	if err != nil {
+		t.Error("Store.Fetch().Close() error =", err)
+	}
+	if !bytes.Equal(got, expectedManifestBytes) {
+		t.Errorf("Store.Fetch() = %v, want %v", string(got), string(expectedManifestBytes))
+	}
+
+	// verify descriptor
+	expectedManifestDesc = content.NewDescriptorFromBytes(expectedManifest.MediaType, expectedManifestBytes)
+	expectedManifestDesc.ArtifactType = expectedManifest.Config.MediaType
+	expectedManifestDesc.Annotations = expectedManifest.Annotations
+	if !reflect.DeepEqual(manifestDesc, expectedManifestDesc) {
+		t.Errorf("PackManifest() = %v, want %v", manifestDesc, expectedManifestDesc)
+	}
+}
+
+func Test_PackManifest_ImageV1_0_SubjectUnsupported(t *testing.T) {
+	s := memory.New()
+
+	// prepare test content
+	layers := []ocispec.Descriptor{
+		content.NewDescriptorFromBytes("test", []byte("hello world")),
+		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
+	}
+	artifactType := "application/vnd.test"
+	subjectManifest := []byte(`{"layers":[]}`)
+	subjectDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(subjectManifest),
+		Size:      int64(len(subjectManifest)),
+	}
+
+	// test Pack with ConfigDescriptor
+	ctx := context.Background()
+	opts := PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_0,
+		Subject:          &subjectDesc,
+	}
+	_, err := PackManifest(ctx, s, artifactType, layers, opts)
+	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
+		t.Errorf("Oras.PackManifest() error = %v, wantErr %v", err, wantErr)
+	}
+}
+
+func Test_PackManifest_ImageV1_0_NoArtifactType(t *testing.T) {
+	s := memory.New()
+
+	ctx := context.Background()
+	manifestDesc, err := PackManifest(ctx, s, "", nil, PackManifestOptions{PackManifestType: PackManifestTypeImageV1_0})
+	if err != nil {
+		t.Fatal("Oras.PackManifest() error =", err)
+	}
+
+	var manifest ocispec.Manifest
+	rc, err := s.Fetch(ctx, manifestDesc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		t.Fatal("error decoding manifest, error =", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatal("Store.Fetch().Close() error =", err)
+	}
+
+	// verify artifact type and config media type
+	if manifestDesc.ArtifactType != MediaTypeUnknownConfig {
+		t.Fatalf("got artifact type = %s, want %s", manifestDesc.ArtifactType, MediaTypeUnknownConfig)
+	}
+	if manifest.Config.MediaType != MediaTypeUnknownConfig {
+		t.Fatalf("got artifact type = %s, want %s", manifest.Config.MediaType, MediaTypeUnknownConfig)
+	}
+}
+
+func Test_PackManifest_ImageV1_0_NoLayer(t *testing.T) {
+	s := memory.New()
+
+	// test Pack
+	ctx := context.Background()
+	manifestDesc, err := PackManifest(ctx, s, "", nil, PackManifestOptions{PackManifestType: PackManifestTypeImageV1_0})
+	if err != nil {
+		t.Fatal("Oras.PackManifest() error =", err)
+	}
+
+	var manifest ocispec.Manifest
+	rc, err := s.Fetch(ctx, manifestDesc)
+	if err != nil {
+		t.Fatal("Store.Fetch() error =", err)
+	}
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		t.Fatal("error decoding manifest, error =", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatal("Store.Fetch().Close() error =", err)
+	}
+
+	// verify layers
+	expectedLayers := []ocispec.Descriptor{}
+	if !reflect.DeepEqual(manifest.Layers, expectedLayers) {
+		t.Errorf("got layers = %v, want %v", manifest.Layers, expectedLayers)
+	}
+}
+
+func Test_PackManifest_ImageV1_0_InvalidDateTimeFormat(t *testing.T) {
+	s := memory.New()
+
+	ctx := context.Background()
+	opts := PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_0,
+		ManifestAnnotations: map[string]string{
+			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
+		},
+	}
+	_, err := PackManifest(ctx, s, "", nil, opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}

--- a/pack_test.go
+++ b/pack_test.go
@@ -528,7 +528,7 @@ func Test_PackManifest_ImageV1_1_RC4(t *testing.T) {
 
 	// test PackManifest
 	ctx := context.Background()
-	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "test", PackManifestOptions{})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "test", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -584,7 +584,7 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, artifactType, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -637,7 +637,7 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "", opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "", opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -688,7 +688,7 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, artifactType, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestVersionV1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -741,7 +741,7 @@ func Test_PackManifest_ImageV1_1_RC4_NoArtifactType(t *testing.T) {
 
 	ctx := context.Background()
 	// test no artifact type and no config
-	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "", PackManifestOptions{})
+	_, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "", PackManifestOptions{})
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -752,7 +752,7 @@ func Test_PackManifest_ImageV1_1_RC4_NoArtifactType(t *testing.T) {
 			MediaType: ocispec.DescriptorEmptyJSON.MediaType,
 		},
 	}
-	_, err = PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "", opts)
+	_, err = PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "", opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -767,7 +767,7 @@ func Test_PackManifest_ImageV1_1_RC4_InvalidDateTimeFormat(t *testing.T) {
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "test", opts)
+	_, err := PackManifest(ctx, s, PackManifestVersionV1_1_RC4, "test", opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -779,7 +779,7 @@ func Test_PackManifest_ImageV1_0(t *testing.T) {
 	// test Pack
 	ctx := context.Background()
 	artifactType := "testconfig"
-	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, PackManifestOptions{})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -860,7 +860,7 @@ func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -909,7 +909,7 @@ func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -972,7 +972,7 @@ func Test_PackManifest_ImageV1_0_SubjectUnsupported(t *testing.T) {
 	opts := PackManifestOptions{
 		Subject: &subjectDesc,
 	}
-	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
+	_, err := PackManifest(ctx, s, PackManifestVersionV1_0, artifactType, opts)
 	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr %v", err, wantErr)
 	}
@@ -982,7 +982,7 @@ func Test_PackManifest_ImageV1_0_NoArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, "", PackManifestOptions{})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestVersionV1_0, "", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -1017,7 +1017,7 @@ func Test_PackManifest_ImageV1_0_InvalidDateTimeFormat(t *testing.T) {
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, "", opts)
+	_, err := PackManifest(ctx, s, PackManifestVersionV1_0, "", opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}

--- a/pack_test.go
+++ b/pack_test.go
@@ -535,7 +535,10 @@ func Test_PackManifest_ImageV1_1_RC4(t *testing.T) {
 	// verify PackManifest
 	ctx := context.Background()
 	artifactType := "application/vnd.test"
-	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, PackManifestOptions{})
+	opts := PackManifestOptions{
+		Layers: layers,
+	}
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -622,13 +625,13 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 	// test PackManifest with ConfigDescriptor
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
+		Layers:              layers,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -675,13 +678,13 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 
 	// test PackManifest with ConfigDescriptor, but without artifactType
 	opts = PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
+		Layers:              layers,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, "", layers, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "", opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -727,12 +730,12 @@ func Test_PackManifest_ImageV1_1_RC4_WithOptions(t *testing.T) {
 
 	// test Pack without ConfigDescriptor
 	opts = PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_1_RC4,
 		Subject:             &subjectDesc,
+		Layers:              layers,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, artifactType, layers, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -785,22 +788,18 @@ func Test_PackManifest_ImageV1_1_RC4_NoArtifactType(t *testing.T) {
 
 	ctx := context.Background()
 	// test no artifact type and no config
-	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_RC4,
-	}
-	_, err := PackManifest(ctx, s, "", nil, opts)
+	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "", PackManifestOptions{})
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 
 	// test no artifact type and config with media type empty
-	opts = PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_RC4,
+	opts := PackManifestOptions{
 		ConfigDescriptor: &ocispec.Descriptor{
 			MediaType: ocispec.DescriptorEmptyJSON.MediaType,
 		},
 	}
-	_, err = PackManifest(ctx, s, "", nil, opts)
+	_, err = PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "", opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -811,10 +810,7 @@ func Test_PackManifest_ImageV1_1_RC4_NoLayer(t *testing.T) {
 
 	// test PackManifest
 	ctx := context.Background()
-	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_RC4,
-	}
-	manifestDesc, err := PackManifest(ctx, s, "test", nil, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "test", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -843,12 +839,11 @@ func Test_PackManifest_ImageV1_1_RC4_InvalidDateTimeFormat(t *testing.T) {
 
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_1_RC4,
 		ManifestAnnotations: map[string]string{
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := PackManifest(ctx, s, "test", nil, opts)
+	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_1_RC4, "test", opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -866,7 +861,10 @@ func Test_PackManifest_ImageV1_0(t *testing.T) {
 	// test Pack
 	ctx := context.Background()
 	artifactType := "testconfig"
-	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, PackManifestOptions{PackManifestType: PackManifestTypeImageV1_0})
+	opts := PackManifestOptions{
+		Layers: layers,
+	}
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -941,12 +939,12 @@ func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
 	// test PackManifest with ConfigDescriptor
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_0,
+		Layers:              layers,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -991,11 +989,11 @@ func Test_PackManifest_ImageV1_0_WithOptions(t *testing.T) {
 
 	// test PackManifest without ConfigDescriptor
 	opts = PackManifestOptions{
-		PackManifestType:    PackManifestTypeImageV1_0,
+		Layers:              layers,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = PackManifest(ctx, s, artifactType, layers, opts)
+	manifestDesc, err = PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -1045,10 +1043,6 @@ func Test_PackManifest_ImageV1_0_SubjectUnsupported(t *testing.T) {
 	s := memory.New()
 
 	// prepare test content
-	layers := []ocispec.Descriptor{
-		content.NewDescriptorFromBytes("test", []byte("hello world")),
-		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
-	}
 	artifactType := "application/vnd.test"
 	subjectManifest := []byte(`{"layers":[]}`)
 	subjectDesc := ocispec.Descriptor{
@@ -1060,10 +1054,9 @@ func Test_PackManifest_ImageV1_0_SubjectUnsupported(t *testing.T) {
 	// test Pack with ConfigDescriptor
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_0,
-		Subject:          &subjectDesc,
+		Subject: &subjectDesc,
 	}
-	_, err := PackManifest(ctx, s, artifactType, layers, opts)
+	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, artifactType, opts)
 	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr %v", err, wantErr)
 	}
@@ -1073,7 +1066,7 @@ func Test_PackManifest_ImageV1_0_NoArtifactType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	manifestDesc, err := PackManifest(ctx, s, "", nil, PackManifestOptions{PackManifestType: PackManifestTypeImageV1_0})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, "", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -1104,7 +1097,7 @@ func Test_PackManifest_ImageV1_0_NoLayer(t *testing.T) {
 
 	// test Pack
 	ctx := context.Background()
-	manifestDesc, err := PackManifest(ctx, s, "", nil, PackManifestOptions{PackManifestType: PackManifestTypeImageV1_0})
+	manifestDesc, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, "", PackManifestOptions{})
 	if err != nil {
 		t.Fatal("Oras.PackManifest() error =", err)
 	}
@@ -1133,12 +1126,11 @@ func Test_PackManifest_ImageV1_0_InvalidDateTimeFormat(t *testing.T) {
 
 	ctx := context.Background()
 	opts := PackManifestOptions{
-		PackManifestType: PackManifestTypeImageV1_0,
 		ManifestAnnotations: map[string]string{
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := PackManifest(ctx, s, "", nil, opts)
+	_, err := PackManifest(ctx, s, PackManifestTypeImageV1_0, "", opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -1148,10 +1140,7 @@ func Test_PackManifest_UnsupportedPackManifestType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	opts := PackManifestOptions{
-		PackManifestType: -1,
-	}
-	_, err := PackManifest(ctx, s, "", nil, opts)
+	_, err := PackManifest(ctx, s, -1, "", PackManifestOptions{})
 	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}

--- a/pack_test.go
+++ b/pack_test.go
@@ -128,9 +128,8 @@ func Test_Pack_Artifact_WithOptions(t *testing.T) {
 	opts := PackOptions{
 		Subject:             &subjectDesc,
 		ManifestAnnotations: annotations,
-		ConfigDescriptor:    &configDesc,                     // should not work
-		ConfigAnnotations:   configAnnotations,               // should not work
-		PackManifestType:    PackManifestTypeImageV1_1_0_RC4, // should not work
+		ConfigDescriptor:    &configDesc,       // should not work
+		ConfigAnnotations:   configAnnotations, // should not work
 	}
 	manifestDesc, err := Pack(ctx, s, artifactType, blobs, opts)
 	if err != nil {
@@ -396,7 +395,6 @@ func Test_Pack_ImageRC2_WithOptions(t *testing.T) {
 	// test Pack without ConfigDescriptor
 	opts = PackOptions{
 		PackImageManifest:   true,
-		PackManifestType:    PackManifestTypeImageV1_1_0_RC2,
 		Subject:             &subjectDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
@@ -535,11 +533,10 @@ func Test_Pack_ImageRC4(t *testing.T) {
 	// verify Pack
 	ctx := context.Background()
 	artifactType := "application/vnd.test"
-	opts := PackOptions{
-		PackImageManifest: true,
-		PackManifestType:  PackManifestTypeImageV1_1_0_RC4,
+	opts := PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
 	}
-	manifestDesc, err := Pack(ctx, s, artifactType, layers, opts)
+	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
 		t.Fatal("Oras.Pack() error =", err)
 	}
@@ -624,15 +621,14 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 
 	// test Pack with ConfigDescriptor
 	ctx := context.Background()
-	opts := PackOptions{
-		PackImageManifest:   true,
+	opts := PackManifestOptions{
 		PackManifestType:    PackManifestTypeImageV1_1_0_RC4,
 		Subject:             &subjectDesc,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err := Pack(ctx, s, artifactType, layers, opts)
+	manifestDesc, err := PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
 		t.Fatal("Oras.Pack() error =", err)
 	}
@@ -678,15 +674,14 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	}
 
 	// test Pack with ConfigDescriptor, but without artifactType
-	opts = PackOptions{
-		PackImageManifest:   true,
+	opts = PackManifestOptions{
 		PackManifestType:    PackManifestTypeImageV1_1_0_RC4,
 		Subject:             &subjectDesc,
 		ConfigDescriptor:    &configDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = Pack(ctx, s, "", layers, opts)
+	manifestDesc, err = PackManifest(ctx, s, "", layers, opts)
 	if err != nil {
 		t.Fatal("Oras.Pack() error =", err)
 	}
@@ -731,14 +726,13 @@ func Test_Pack_ImageRC4_WithOptions(t *testing.T) {
 	}
 
 	// test Pack without ConfigDescriptor
-	opts = PackOptions{
-		PackImageManifest:   true,
+	opts = PackManifestOptions{
 		PackManifestType:    PackManifestTypeImageV1_1_0_RC4,
 		Subject:             &subjectDesc,
 		ConfigAnnotations:   configAnnotations,
 		ManifestAnnotations: annotations,
 	}
-	manifestDesc, err = Pack(ctx, s, artifactType, layers, opts)
+	manifestDesc, err = PackManifest(ctx, s, artifactType, layers, opts)
 	if err != nil {
 		t.Fatal("Oras.Pack() error =", err)
 	}
@@ -791,24 +785,22 @@ func Test_Pack_ImageRC4_NoArtifactType(t *testing.T) {
 
 	ctx := context.Background()
 	// test no artifact type and no config
-	opts := PackOptions{
-		PackImageManifest: true,
-		PackManifestType:  PackManifestTypeImageV1_1_0_RC4,
+	opts := PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
 	}
-	_, err := Pack(ctx, s, "", nil, opts)
+	_, err := PackManifest(ctx, s, "", nil, opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
 	}
 
 	// test no artifact type and config with media type empty
-	opts = PackOptions{
-		PackImageManifest: true,
-		PackManifestType:  PackManifestTypeImageV1_1_0_RC4,
+	opts = PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
 		ConfigDescriptor: &ocispec.Descriptor{
 			MediaType: ocispec.DescriptorEmptyJSON.MediaType,
 		},
 	}
-	_, err = Pack(ctx, s, "", nil, opts)
+	_, err = PackManifest(ctx, s, "", nil, opts)
 	if wantErr := ErrMissingArtifactType; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
 	}
@@ -819,11 +811,10 @@ func Test_Pack_ImageRC4_NoLayer(t *testing.T) {
 
 	// test Pack
 	ctx := context.Background()
-	opts := PackOptions{
-		PackImageManifest: true,
-		PackManifestType:  PackManifestTypeImageV1_1_0_RC4,
+	opts := PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
 	}
-	manifestDesc, err := Pack(ctx, s, "test", nil, opts)
+	manifestDesc, err := PackManifest(ctx, s, "test", nil, opts)
 	if err != nil {
 		t.Fatal("Oras.Pack() error =", err)
 	}
@@ -851,101 +842,99 @@ func Test_Pack_ImageRC4_InvalidDateTimeFormat(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	opts := PackOptions{
-		PackImageManifest: true,
-		PackManifestType:  PackManifestTypeImageV1_1_0_RC4,
+	opts := PackManifestOptions{
+		PackManifestType: PackManifestTypeImageV1_1_0_RC4,
 		ManifestAnnotations: map[string]string{
 			ocispec.AnnotationCreated: "2000/01/01 00:00:00",
 		},
 	}
-	_, err := Pack(ctx, s, "test", nil, opts)
+	_, err := PackManifest(ctx, s, "test", nil, opts)
 	if wantErr := ErrInvalidDateTimeFormat; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
 	}
 }
 
-func Test_Pack_DefaultPackOptions(t *testing.T) {
-	s := memory.New()
+// func Test_Pack_DefaultPackOptions(t *testing.T) {
+// 	s := memory.New()
 
-	// prepare test content
-	layers := []ocispec.Descriptor{
-		content.NewDescriptorFromBytes("test", []byte("hello world")),
-		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
-	}
+// 	// prepare test content
+// 	layers := []ocispec.Descriptor{
+// 		content.NewDescriptorFromBytes("test", []byte("hello world")),
+// 		content.NewDescriptorFromBytes("test", []byte("goodbye world")),
+// 	}
 
-	// verify Pack
-	ctx := context.Background()
-	artifactType := "application/vnd.test"
-	manifestDesc, err := Pack(ctx, s, artifactType, layers, DefaultPackOptions)
-	if err != nil {
-		t.Fatal("Oras.Pack() error =", err)
-	}
+// 	// verify Pack
+// 	ctx := context.Background()
+// 	artifactType := "application/vnd.test"
+// 	manifestDesc, err := Pack(ctx, s, artifactType, layers, DefaultPackOptions)
+// 	if err != nil {
+// 		t.Fatal("Oras.Pack() error =", err)
+// 	}
 
-	// verify manifest
-	var manifest ocispec.Manifest
-	rc, err := s.Fetch(ctx, manifestDesc)
-	if err != nil {
-		t.Fatal("Store.Fetch() error =", err)
-	}
-	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
-		t.Fatal("error decoding manifest, error =", err)
-	}
-	if err := rc.Close(); err != nil {
-		t.Fatal("Store.Fetch().Close() error =", err)
-	}
+// 	// verify manifest
+// 	var manifest ocispec.Manifest
+// 	rc, err := s.Fetch(ctx, manifestDesc)
+// 	if err != nil {
+// 		t.Fatal("Store.Fetch() error =", err)
+// 	}
+// 	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+// 		t.Fatal("error decoding manifest, error =", err)
+// 	}
+// 	if err := rc.Close(); err != nil {
+// 		t.Fatal("Store.Fetch().Close() error =", err)
+// 	}
 
-	// verify media type
-	got := manifest.MediaType
-	if got != ocispec.MediaTypeImageManifest {
-		t.Fatalf("got media type = %s, want %s", got, ocispec.MediaTypeImageManifest)
-	}
+// 	// verify media type
+// 	got := manifest.MediaType
+// 	if got != ocispec.MediaTypeImageManifest {
+// 		t.Fatalf("got media type = %s, want %s", got, ocispec.MediaTypeImageManifest)
+// 	}
 
-	// verify config
-	expectedConfig := ocispec.DescriptorEmptyJSON
-	if !reflect.DeepEqual(manifest.Config, expectedConfig) {
-		t.Errorf("got config = %v, want %v", manifest.Config, expectedConfig)
-	}
+// 	// verify config
+// 	expectedConfig := ocispec.DescriptorEmptyJSON
+// 	if !reflect.DeepEqual(manifest.Config, expectedConfig) {
+// 		t.Errorf("got config = %v, want %v", manifest.Config, expectedConfig)
+// 	}
 
-	// verify layers
-	if !reflect.DeepEqual(manifest.Layers, layers) {
-		t.Errorf("got layers = %v, want %v", manifest.Layers, layers)
-	}
+// 	// verify layers
+// 	if !reflect.DeepEqual(manifest.Layers, layers) {
+// 		t.Errorf("got layers = %v, want %v", manifest.Layers, layers)
+// 	}
 
-	// verify created time annotation
-	createdTime, ok := manifest.Annotations[ocispec.AnnotationCreated]
-	if !ok {
-		t.Errorf("Annotation %s = %v, want %v", ocispec.AnnotationCreated, ok, true)
-	}
-	_, err = time.Parse(time.RFC3339, createdTime)
-	if err != nil {
-		t.Errorf("error parsing created time: %s, error = %v", createdTime, err)
-	}
+// 	// verify created time annotation
+// 	createdTime, ok := manifest.Annotations[ocispec.AnnotationCreated]
+// 	if !ok {
+// 		t.Errorf("Annotation %s = %v, want %v", ocispec.AnnotationCreated, ok, true)
+// 	}
+// 	_, err = time.Parse(time.RFC3339, createdTime)
+// 	if err != nil {
+// 		t.Errorf("error parsing created time: %s, error = %v", createdTime, err)
+// 	}
 
-	// verify artifact type
-	if !reflect.DeepEqual(manifest.ArtifactType, artifactType) {
-		t.Errorf("got artifactType = %v, want %v", manifest.ArtifactType, artifactType)
-	}
+// 	// verify artifact type
+// 	if !reflect.DeepEqual(manifest.ArtifactType, artifactType) {
+// 		t.Errorf("got artifactType = %v, want %v", manifest.ArtifactType, artifactType)
+// 	}
 
-	// verify descriptor artifact type
-	if want := manifest.ArtifactType; !reflect.DeepEqual(manifestDesc.ArtifactType, want) {
-		t.Errorf("got descriptor artifactType = %v, want %v", manifestDesc.ArtifactType, want)
-	}
+// 	// verify descriptor artifact type
+// 	if want := manifest.ArtifactType; !reflect.DeepEqual(manifestDesc.ArtifactType, want) {
+// 		t.Errorf("got descriptor artifactType = %v, want %v", manifestDesc.ArtifactType, want)
+// 	}
 
-	// verify descriptor annotations
-	if want := manifest.Annotations; !reflect.DeepEqual(manifestDesc.Annotations, want) {
-		t.Errorf("got descriptor annotations = %v, want %v", manifestDesc.Annotations, want)
-	}
-}
+// 	// verify descriptor annotations
+// 	if want := manifest.Annotations; !reflect.DeepEqual(manifestDesc.Annotations, want) {
+// 		t.Errorf("got descriptor annotations = %v, want %v", manifestDesc.Annotations, want)
+// 	}
+// }
 
 func Test_Pack_UnsupportedPackManifestType(t *testing.T) {
 	s := memory.New()
 
 	ctx := context.Background()
-	opts := PackOptions{
-		PackImageManifest: true,
-		PackManifestType:  -1,
+	opts := PackManifestOptions{
+		PackManifestType: -1,
 	}
-	_, err := Pack(ctx, s, "", nil, opts)
+	_, err := PackManifest(ctx, s, "", nil, opts)
 	if wantErr := errdef.ErrUnsupported; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
 	}


### PR DESCRIPTION
This PR refactors `oras.Pack` that was updated by #532.

1. Move the support of Image Manifest `v1.1.0-rc4` to `PackManifest`
2. Deprecate `Pack`

Resolves: #568