### PR TITLE
build: bump go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version: ['1.20', '1.21']
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: ['1.19', '1.20']
+        go-version: ['1.20', '1.21']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The ORAS Go library follows [Semantic Versioning](https://semver.org/), where br
 
 The version `2` is actively developed in the [`main`](https://github.com/oras-project/oras-go/tree/main) branch with all new features.
 
+> [!Note]
+> The `main` branch follows [Go's Security Policy](https://github.com/golang/go/security/policy) and supports the two latest versions of Go (currently `1.20` and `1.21`).
+
 Examples for common use cases can be found below:
 
 - [Copy examples](https://pkg.go.dev/oras.land/oras-go/v2#pkg-examples)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module oras.land/oras-go/v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/opencontainers/go-digest v1.0.0


### PR DESCRIPTION
1. Update go mod version to `1.20`
2. Update go version matrix in workflow config files
3. Update README

Resolves: #583