### PR TITLE
fix: package `credentials` to support legacy auth keys in docker config

### DIFF
--- a/registry/remote/credentials/internal/config/config_test.go
+++ b/registry/remote/credentials/internal/config/config_test.go
@@ -180,6 +180,72 @@ func TestConfig_GetCredential_validConfig(t *testing.T) {
 	}
 }
 
+func TestConfig_GetCredential_legacyConfig(t *testing.T) {
+	cfg, err := Load("../../testdata/legacy_auths_config.json")
+	if err != nil {
+		t.Fatal("Load() error =", err)
+	}
+
+	tests := []struct {
+		name          string
+		serverAddress string
+		want          auth.Credential
+		wantErr       bool
+	}{
+		{
+			serverAddress: "registry1.example.com",
+			want: auth.Credential{
+				Username: "username1",
+				Password: "password1",
+			},
+		},
+		{
+			serverAddress: "registry2.example.com",
+			want: auth.Credential{
+				Username: "username2",
+				Password: "password2",
+			},
+		},
+		{
+			serverAddress: "registry3.example.com",
+			want: auth.Credential{
+				Username: "username3",
+				Password: "password3",
+			},
+		},
+		{
+			serverAddress: "registry4.example.com",
+			want: auth.Credential{
+				Username: "username4",
+				Password: "password4",
+			},
+		},
+		{
+			serverAddress: "registry5.example.com",
+			want: auth.Credential{
+				Username: "username5",
+				Password: "password5",
+			},
+		},
+		{
+			serverAddress: "registry6.example.com",
+			want:          auth.EmptyCredential,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cfg.GetCredential(tt.serverAddress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.GetCredential() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Config.GetCredential() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfig_GetCredential_invalidConfig(t *testing.T) {
 	cfg, err := Load("../../testdata/invalid_auths_entry_config.json")
 	if err != nil {

--- a/registry/remote/credentials/internal/config/config_test.go
+++ b/registry/remote/credentials/internal/config/config_test.go
@@ -201,6 +201,19 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:          "Another entry for the same address matched",
+			serverAddress: "https://registry1.example.com/",
+			want: auth.Credential{
+				Username: "foo",
+				Password: "bar",
+			},
+		},
+		{
+			name:          "Address with different scheme unmached",
+			serverAddress: "http://registry1.example.com/",
+			want:          auth.EmptyCredential,
+		},
+		{
 			name:          "Address with http prefix matched",
 			serverAddress: "registry2.example.com",
 			want: auth.Credential{
@@ -239,11 +252,6 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 				Username: "username6",
 				Password: "password6",
 			},
-		},
-		{
-			name:          "Reverse won't work",
-			serverAddress: "https://registry1.example.com/",
-			want:          auth.EmptyCredential,
 		},
 	}
 	for _, tt := range tests {

--- a/registry/remote/credentials/internal/config/config_test.go
+++ b/registry/remote/credentials/internal/config/config_test.go
@@ -193,6 +193,7 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 		wantErr       bool
 	}{
 		{
+			name:          "Regular address matched",
 			serverAddress: "registry1.example.com",
 			want: auth.Credential{
 				Username: "username1",
@@ -200,6 +201,7 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:          "Address with http prefix matched",
 			serverAddress: "registry2.example.com",
 			want: auth.Credential{
 				Username: "username2",
@@ -207,6 +209,7 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:          "Address with https prefix matched",
 			serverAddress: "registry3.example.com",
 			want: auth.Credential{
 				Username: "username3",
@@ -214,6 +217,7 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:          "Address with http prefix and / suffix matched",
 			serverAddress: "registry4.example.com",
 			want: auth.Credential{
 				Username: "username4",
@@ -221,6 +225,7 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:          "Address with https prefix and / suffix matched",
 			serverAddress: "registry5.example.com",
 			want: auth.Credential{
 				Username: "username5",
@@ -228,7 +233,16 @@ func TestConfig_GetCredential_legacyConfig(t *testing.T) {
 			},
 		},
 		{
+			name:          "Address with https prefix and path suffix matched",
 			serverAddress: "registry6.example.com",
+			want: auth.Credential{
+				Username: "username6",
+				Password: "password6",
+			},
+		},
+		{
+			name:          "Reverse won't work",
+			serverAddress: "https://registry1.example.com/",
 			want:          auth.EmptyCredential,
 		},
 	}
@@ -1376,6 +1390,54 @@ func Test_decodeAuth(t *testing.T) {
 			}
 			if gotPassword != tt.password {
 				t.Errorf("decodeAuth() got1 = %v, want %v", gotPassword, tt.password)
+			}
+		})
+	}
+}
+
+func Test_toHostname(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{
+			addr: "http://test.example.com",
+			want: "test.example.com",
+		},
+		{
+			addr: "http://test.example.com/",
+			want: "test.example.com",
+		},
+		{
+			addr: "http://test.example.com/foo/bar",
+			want: "test.example.com",
+		},
+		{
+			addr: "https://test.example.com",
+			want: "test.example.com",
+		},
+		{
+			addr: "https://test.example.com/",
+			want: "test.example.com",
+		},
+		{
+			addr: "http://test.example.com/foo/bar",
+			want: "test.example.com",
+		},
+		{
+			addr: "test.example.com",
+			want: "test.example.com",
+		},
+		{
+			addr: "test.example.com/foo/bar/",
+			want: "test.example.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toHostname(tt.addr); got != tt.want {
+				t.Errorf("toHostname() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/registry/remote/credentials/testdata/legacy_auths_config.json
+++ b/registry/remote/credentials/testdata/legacy_auths_config.json
@@ -14,6 +14,9 @@
         },
         "https://registry5.example.com/": {
             "auth": "dXNlcm5hbWU1OnBhc3N3b3JkNQ=="
+        },
+        "https://registry6.example.com/path/": {
+            "auth": "dXNlcm5hbWU2OnBhc3N3b3JkNg=="
         }
     }
 }

--- a/registry/remote/credentials/testdata/legacy_auths_config.json
+++ b/registry/remote/credentials/testdata/legacy_auths_config.json
@@ -1,0 +1,19 @@
+{
+    "auths": {
+        "registry1.example.com": {
+            "auth": "dXNlcm5hbWUxOnBhc3N3b3JkMQ=="
+        },
+        "http://registry2.example.com": {
+            "auth": "dXNlcm5hbWUyOnBhc3N3b3JkMg=="
+        },
+        "https://registry3.example.com": {
+            "auth": "dXNlcm5hbWUzOnBhc3N3b3JkMw=="
+        },
+        "http://registry4.example.com/": {
+            "auth": "dXNlcm5hbWU0OnBhc3N3b3JkNA=="
+        },
+        "https://registry5.example.com/": {
+            "auth": "dXNlcm5hbWU1OnBhc3N3b3JkNQ=="
+        }
+    }
+}

--- a/registry/remote/credentials/testdata/legacy_auths_config.json
+++ b/registry/remote/credentials/testdata/legacy_auths_config.json
@@ -17,6 +17,9 @@
         },
         "https://registry6.example.com/path/": {
             "auth": "dXNlcm5hbWU2OnBhc3N3b3JkNg=="
+        },
+        "https://registry1.example.com/": {
+            "auth": "Zm9vOmJhcg=="
         }
     }
 }


### PR DESCRIPTION
Fix: #616 