### PR TITLE
perf: reduce auth request count for manifest delete

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1120,6 +1120,9 @@ func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.D
 		if err := limitSize(target, s.repo.MaxMetadataBytes); err != nil {
 			return err
 		}
+		// "pull" and "delete" scopes are required, "push" is potentially needed
+		// for pushing referrers index if client-side indexing is performed
+		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionPush, auth.ActionDelete)
 		manifestJSON, err := content.FetchAll(ctx, s, target)
 		if err != nil {
 			return err

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1121,7 +1121,7 @@ func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.D
 			return err
 		}
 		// "pull" and "delete" scopes are required, "push" is potentially needed
-		// for pushing referrers index if client-side indexing is performed
+		// for client-side indexing
 		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionPush, auth.ActionDelete)
 		manifestJSON, err := content.FetchAll(ctx, s, target)
 		if err != nil {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1120,9 +1120,7 @@ func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.D
 		if err := limitSize(target, s.repo.MaxMetadataBytes); err != nil {
 			return err
 		}
-		// "pull" and "delete" scopes are required, "push" is potentially needed
-		// for client-side indexing
-		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionPush, auth.ActionDelete)
+		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionDelete)
 		manifestJSON, err := content.FetchAll(ctx, s, target)
 		if err != nil {
 			return err


### PR DESCRIPTION
Add `pull` and `delete` scope hints before attempting client-side indexing on manifest delete.
Resolve: #594 

Before this change, the requests produced during deleting a manifest when Referrers API is not known to be available:

- Request `#0`: GET manifest - 401
- Request `#1`: POST token (scope: pull) - 200
- Request `#2`: GET manifest - 200
- **[optional]** Request `#3`: GET referrers index - 200
- **[optional]** Request `#4`: PUT referrers index - 401
- **[optional]** Request `#5`: POST token (scope: pull, push) - 200
- **[optional]** Request `#6`: PUT referrers index - 201
- <ins> Request `#7`: DELETE manifest - 401  </ins>
- <ins> Request `#8`: POST token (scope: delete)  </ins>
- Request `#9`: DELETE manifest - 202

After this change, the requests should become:

- Request `#0`: GET manifest - 401
- Request `#1`: POST token (scope: pull, delete) - 200
- Request `#2`: GET manifest - 200
- **[optional]** Request `#3`: GET referrers index - 200
- **[optional]** Request `#4`: PUT referrers index - 401
- **[optional]** Request `#5`: POST token (scope: pull, push) - 200
- **[optional]** Request `#6`: PUT referrers index - 201
- Request `#7`: DELETE manifest - 202
