### PR TITLE
[RFC] Add Delete() to oci.Store.

### DIFF
--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -103,6 +103,11 @@ func (s *Store) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCl
 	return s.storage.Fetch(ctx, target)
 }
 
+// Delete deletes the content identified by the descriptor.
+func (s *Store) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return s.storage.(*Storage).Delete(ctx, target)
+}
+
 // Push pushes the content, matching the expected descriptor.
 func (s *Store) Push(ctx context.Context, expected ocispec.Descriptor, reader io.Reader) error {
 	if err := s.storage.Push(ctx, expected, reader); err != nil {


### PR DESCRIPTION
Hi.


First, I would like to thank you for the work done in #470.
I tried to use this function but had troubles as the `content.Storage` in `oci.Store` does not implement the `Delete` function.
I thought to add `Deleter` to `oci.Storage` but then I got troubles during compilation with `cas.Memory`.
So, I casted the `content.Storage` to `oci.Storage` which is not really good but at least it works.

As a consequence, I would like to get your feedback on how to permit `oci.Store` to `Delete()` descriptor in a proper way regarding the layers of abstraction you have.


Best regards and thank you in advance.