### PR TITLE
perf: reduce auth request count for manifest delete

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1121,6 +1121,7 @@ func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.D
 		if err := limitSize(target, s.repo.MaxMetadataBytes); err != nil {
 			return err
 		}
+		ctx = registryutil.WithScopeHint(ctx, s.repo.Reference, auth.ActionPull, auth.ActionDelete)
 		manifestJSON, err := content.FetchAll(ctx, s, target)
 		if err != nil {
 			return err


### PR DESCRIPTION
Backporting 0f1dc30a0fd713f3bafcf3bd52693b2e8a8a6fa5 to the release branch.
This change does the same thing as the original commit (#618) did but using the old `registryutil.WithScopeHint` instead of `auth.AppendRepositoryScope`, which is introduced by #604 and is not available in `v2.3.x`.

---
Add `pull` and `delete` scope hints before attempting client-side indexing on manifest delete.

Before this change, the requests produced during deleting a manifest when Referrers API is not known to be available:

- Request `#0`: GET manifest - 401
- Request `#1`: POST token (scope: pull) - 200
- Request `#2`: GET manifest - 200
- **[optional]** Request `#3`: GET referrers index - 200
- **[optional]** Request `#4`: PUT referrers index - 401
- **[optional]** Request `#5`: POST token (scope: pull, push) - 200
- **[optional]** Request `#6`: PUT referrers index - 201
- <ins> Request `#7`: DELETE manifest - 401  </ins>
- <ins> Request `#8`: POST token (scope: delete)  </ins>
- Request `#9`: DELETE manifest - 202

After this change, the requests should become:

- Request `#0`: GET manifest - 401
- Request `#1`: POST token (scope: pull, delete) - 200
- Request `#2`: GET manifest - 200
- **[optional]** Request `#3`: GET referrers index - 200
- **[optional]** Request `#4`: PUT referrers index - 401
- **[optional]** Request `#5`: POST token (scope: pull, push) - 200
- **[optional]** Request `#6`: PUT referrers index - 201
- Request `#7`: DELETE manifest - 202