### PR TITLE
chore: add reference details to errors

### DIFF
--- a/registry/reference.go
+++ b/registry/reference.go
@@ -117,7 +117,7 @@ func ParseReference(artifact string) (Reference, error) {
 	parts := strings.SplitN(artifact, "/", 2)
 	if len(parts) == 1 {
 		// Invalid Form
-		return Reference{}, fmt.Errorf("%w: missing repository", errdef.ErrInvalidReference)
+		return Reference{}, fmt.Errorf("%w: missing registry or repository", errdef.ErrInvalidReference)
 	}
 	registry, path := parts[0], parts[1]
 
@@ -190,7 +190,7 @@ func (r Reference) Validate() error {
 // ValidateRegistry validates the registry.
 func (r Reference) ValidateRegistry() error {
 	if uri, err := url.ParseRequestURI("dummy://" + r.Registry); err != nil || uri.Host != r.Registry {
-		return fmt.Errorf("%w: invalid registry", errdef.ErrInvalidReference)
+		return fmt.Errorf("%w: invalid registry %q", errdef.ErrInvalidReference, r.Registry)
 	}
 	return nil
 }
@@ -198,7 +198,7 @@ func (r Reference) ValidateRegistry() error {
 // ValidateRepository validates the repository.
 func (r Reference) ValidateRepository() error {
 	if !repositoryRegexp.MatchString(r.Repository) {
-		return fmt.Errorf("%w: invalid repository", errdef.ErrInvalidReference)
+		return fmt.Errorf("%w: invalid repository %q", errdef.ErrInvalidReference, r.Repository)
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (r Reference) ValidateRepository() error {
 // ValidateReferenceAsTag validates the reference as a tag.
 func (r Reference) ValidateReferenceAsTag() error {
 	if !tagRegexp.MatchString(r.Reference) {
-		return fmt.Errorf("%w: invalid tag", errdef.ErrInvalidReference)
+		return fmt.Errorf("%w: invalid tag %q", errdef.ErrInvalidReference, r.Reference)
 	}
 	return nil
 }
@@ -214,7 +214,7 @@ func (r Reference) ValidateReferenceAsTag() error {
 // ValidateReferenceAsDigest validates the reference as a digest.
 func (r Reference) ValidateReferenceAsDigest() error {
 	if _, err := r.Digest(); err != nil {
-		return fmt.Errorf("%w: invalid digest; %v", errdef.ErrInvalidReference, err)
+		return fmt.Errorf("%w: invalid digest %q: %v", errdef.ErrInvalidReference, r.Reference, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Include values of the artifact and or related context in the errors - 

This is related to https://github.com/oras-project/oras/pull/1152. See the oras-project/oras#1152 to see the updates to output of errors. 