### PR TITLE
feat: minimal change to support cross-repo blob mounting

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -37,8 +37,9 @@ import (
 // defaultConcurrency is the default value of CopyGraphOptions.Concurrency.
 const defaultConcurrency int = 3 // This value is consistent with dockerd and containerd.
 
-// errSkipDesc signals copyNode() to stop processing a descriptor.
-var errSkipDesc = errors.New("skip descriptor")
+// ErrSkipDesc signals to stop copying a descriptor.  When returned from PreCopy the blob must exist in the target.
+// This can be used to signal that a blob has been made available in the target repository by "Mount()" or some other technique.
+var ErrSkipDesc = errors.New("skip descriptor")
 
 // DefaultCopyOptions provides the default CopyOptions.
 var DefaultCopyOptions CopyOptions = CopyOptions{
@@ -281,7 +282,7 @@ func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.St
 func copyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor, opts CopyGraphOptions) error {
 	if opts.PreCopy != nil {
 		if err := opts.PreCopy(ctx, desc); err != nil {
-			if err == errSkipDesc {
+			if err == ErrSkipDesc {
 				return nil
 			}
 			return err
@@ -373,7 +374,7 @@ func prepareCopy(ctx context.Context, dst Target, dstRef string, proxy *cas.Prox
 				}
 			}
 			// skip the regular copy workflow
-			return errSkipDesc
+			return ErrSkipDesc
 		}
 	} else {
 		postCopy := opts.PostCopy


### PR DESCRIPTION
Export `ErrSkipDesc` as `ErrSkipDesc` allows users of the library to implement `CopyGraphOptions.PreCopy` to call `Mount()` and then return `ErrSkipDesc` from `PreCopy` which bypasses the downstream copy operation.

Closes #580 