### PR TITLE
fix: check content-type when using referrers API

### DIFF
--- a/example_copy_test.go
+++ b/example_copy_test.go
@@ -144,6 +144,7 @@ func TestMain(m *testing.M) {
 				MediaType: ocispec.MediaTypeImageIndex,
 				Manifests: referrers,
 			}
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
 			if err := json.NewEncoder(w).Encode(result); err != nil {
 				panic(err)
 			}

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -1031,15 +1031,20 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex_Referrers(t *testin
 	// set up test server
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Path
+		var manifests []ocispec.Descriptor
 		switch {
 		case p == "/v2/test/referrers/"+descs[0].Digest.String():
+			manifests = descs[1:]
+			fallthrough
+		case strings.HasPrefix(p, "/v2/test/referrers/"):
 			result := ocispec.Index{
 				Versioned: specs.Versioned{
 					SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 				},
 				MediaType: ocispec.MediaTypeImageIndex,
-				Manifests: descs[1:],
+				Manifests: manifests,
 			}
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
 			if err := json.NewEncoder(w).Encode(result); err != nil {
 				t.Errorf("failed to write response: %v", err)
 			}
@@ -1076,7 +1081,6 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex_Referrers(t *testin
 		default:
 			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
 			w.WriteHeader(http.StatusNotFound)
-			return
 		}
 	}))
 	defer ts.Close()
@@ -1454,15 +1458,20 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex_Referrers(t *test
 	// set up test server
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Path
+		var manifests []ocispec.Descriptor
 		switch {
 		case p == "/v2/test/referrers/"+descs[0].Digest.String():
+			manifests = descs[1:]
+			fallthrough
+		case strings.HasPrefix(p, "/v2/test/referrers/"):
 			result := ocispec.Index{
 				Versioned: specs.Versioned{
 					SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 				},
 				MediaType: ocispec.MediaTypeImageIndex,
-				Manifests: descs[1:],
+				Manifests: manifests,
 			}
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
 			if err := json.NewEncoder(w).Encode(result); err != nil {
 				t.Errorf("failed to write response: %v", err)
 			}
@@ -1695,15 +1704,20 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex_Refe
 	// set up test server
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := r.URL.Path
+		var manifests []ocispec.Descriptor
 		switch {
 		case p == "/v2/test/referrers/"+descs[0].Digest.String():
+			manifests = descs[1:]
+			fallthrough
+		case strings.HasPrefix(p, "/v2/test/referrers/"):
 			result := ocispec.Index{
 				Versioned: specs.Versioned{
 					SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
 				},
 				MediaType: ocispec.MediaTypeImageIndex,
-				Manifests: descs[1:],
+				Manifests: manifests,
 			}
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
 			if err := json.NewEncoder(w).Encode(result); err != nil {
 				t.Errorf("failed to write response: %v", err)
 			}

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -174,6 +174,17 @@ func TestMain(m *testing.M) {
 			w.Header().Set("Content-Digest", string(blobDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobContent)))
 			w.Write([]byte(blobContent))
+		case p == fmt.Sprintf("/v2/%s/referrers/%s", exampleRepositoryName, "sha256:0000000000000000000000000000000000000000000000000000000000000000"):
+			result := ocispec.Index{
+				Versioned: specs.Versioned{
+					SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+				},
+				MediaType: ocispec.MediaTypeImageIndex,
+			}
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
+			if err := json.NewEncoder(w).Encode(result); err != nil {
+				panic(err)
+			}
 		case p == fmt.Sprintf("/v2/%s/referrers/%s", exampleRepositoryName, exampleManifestDescriptor.Digest.String()):
 			q := r.URL.Query()
 			var referrers []ocispec.Descriptor
@@ -191,6 +202,7 @@ func TestMain(m *testing.M) {
 				MediaType: ocispec.MediaTypeImageIndex,
 				Manifests: referrers,
 			}
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
 			if err := json.NewEncoder(w).Encode(result); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
When accessing the referrer's API, this adds a check to make sure the content-type is an OCI index.

Also fixes the tests to properly set the content-type header in the response.

Closes #633 