### PR TITLE
feat: add `Untag()` to `*oci.Store`

### DIFF
--- a/content/resolver.go
+++ b/content/resolver.go
@@ -39,3 +39,9 @@ type TagResolver interface {
 	Tagger
 	Resolver
 }
+
+// Untagger untags reference tags.
+type Untagger interface {
+	// Untag untags the given reference string.
+	Untag(ctx context.Context, reference string) error
+}


### PR DESCRIPTION
Hi!


`oci.Store` offers the possibility to tag images but not to untag them.
This is a problem when you want to remove images because you only want to untag a tag when several point to the same image (_e.g._ `docker rmi` and see https://github.com/inspektor-gadget/inspektor-gadget/pull/2162#pullrequestreview-1740423646).

I will add proper testing if we agree that this addition is useful to the package.


Best regards and thank you in advance.