### PR TITLE
feat: dangling node detection for graph.Memory

### DIFF
--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -156,9 +156,7 @@ func (s *Store) Delete(ctx context.Context, target ocispec.Descriptor) error {
 			untagged = true
 		}
 	}
-	if err := s.graph.Remove(ctx, target); err != nil {
-		return err
-	}
+	s.graph.Remove(ctx, target)
 	if untagged && s.AutoSaveIndex {
 		err := s.saveIndex()
 		if err != nil {

--- a/internal/graph/memory.go
+++ b/internal/graph/memory.go
@@ -131,10 +131,13 @@ func (m *Memory) Remove(ctx context.Context, node ocispec.Descriptor) []ocispec.
 		predecessorEntry.Delete(nodeKey)
 
 		// if none of the predecessors of the node still exists, we remove the
-		// predecessors entry. Otherwise, we do not remove the entry.
+		// predecessors entry and return it as a dangling node. Otherwise, we do
+		// not remove the entry.
 		if len(predecessorEntry) == 0 {
 			delete(m.predecessors, successorKey)
-			danglings = append(danglings, m.nodes[successorKey])
+			if _, exists := m.nodes[successorKey]; exists {
+				danglings = append(danglings, m.nodes[successorKey])
+			}
 		}
 	}
 	delete(m.successors, nodeKey)

--- a/internal/graph/memory.go
+++ b/internal/graph/memory.go
@@ -175,7 +175,7 @@ func (m *Memory) index(ctx context.Context, fetcher content.Fetcher, node ocispe
 	return successors, nil
 }
 
-func (m *Memory) isDanglingNode(desc ocispec.Descriptor) bool {
+func (m *Memory) IsDanglingNode(desc ocispec.Descriptor) bool {
 	key := descriptor.FromOCI(desc)
 	_, existsInMemory := m.nodes[key]
 	_, existsInPredecessors := m.predecessors[key]

--- a/internal/graph/memory.go
+++ b/internal/graph/memory.go
@@ -175,6 +175,8 @@ func (m *Memory) index(ctx context.Context, fetcher content.Fetcher, node ocispe
 	return successors, nil
 }
 
+// IsDanglingNode decides whether a node is dangling. A node is considered
+// dangling if it is present and has no predecessors.
 func (m *Memory) IsDanglingNode(desc ocispec.Descriptor) bool {
 	key := descriptor.FromOCI(desc)
 	_, existsInMemory := m.nodes[key]

--- a/internal/graph/memory_test.go
+++ b/internal/graph/memory_test.go
@@ -630,7 +630,7 @@ func TestMemory_IndexAllAndPredecessors(t *testing.T) {
 // |                                               |
 // |                                               |
 // +-----------------------------------------------+
-func TestMemory_isDanglingNode(t *testing.T) {
+func TestMemory_trackDanglingNodes(t *testing.T) {
 	testFetcher := cas.NewMemory()
 	testMemory := NewMemory()
 	ctx := context.Background()

--- a/internal/graph/memory_test.go
+++ b/internal/graph/memory_test.go
@@ -662,7 +662,6 @@ func TestMemory_trackDanglingNodes(t *testing.T) {
 		}
 		return appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
 	}
-
 	descA := generateManifest(descs[1:3]...) // blobs[3], manifest "A"
 
 	// prepare the content in the fetcher, so that it can be used to test Index
@@ -731,7 +730,7 @@ func TestMemory_trackDanglingNodes(t *testing.T) {
 
 	// check that B,C,D are all garbage
 	for i := 1; i < len(nodeKeys); i++ {
-		if isGarbage := testMemory.isDanglingNode(testMemory.nodes[nodeKeys[i]]); !isGarbage {
+		if isGarbage := testMemory.IsDanglingNode(testMemory.nodes[nodeKeys[i]]); !isGarbage {
 			t.Errorf("%v should be considered a dangling node", nodeKeys[i])
 		}
 	}
@@ -752,7 +751,7 @@ func TestMemory_trackDanglingNodes(t *testing.T) {
 		if !reflect.DeepEqual(danglings, expectedDanglings) {
 			t.Errorf("danglings[i] = %v, want %v", danglings[i], expectedDanglings[i])
 		}
-		if isGarbage := testMemory.isDanglingNode(danglings[i]); !isGarbage {
+		if isGarbage := testMemory.IsDanglingNode(danglings[i]); !isGarbage {
 			t.Errorf("%v should be considered a dangling node", danglings[i])
 		}
 	}


### PR DESCRIPTION
Part of #472 

This PR:
1. Adds doc for fields of `graph.Memory`
2. Makes `graph.Memory.Remove()` return dangling successors

This draft PR is followed by #653, which implements recursive GC on `oci.Store`.