### PR TITLE
doc: add example for digest and parseReference

### DIFF
--- a/registry/example_parse_test.go
+++ b/registry/example_parse_test.go
@@ -1,0 +1,32 @@
+package registry_test
+
+import (
+	_ "crypto/sha256"
+	"fmt"
+	"log"
+
+	"oras.land/oras-go/v2/registry"
+)
+
+var img = "ghcr.io/oras-project/oras@sha256:601d05a48832e7946dab8f49b14953549bebf42e42f4d7973b1a5a287d77ab76"
+
+func ExampleParseReference() {
+
+	ref, err := registry.ParseReference(img)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	fmt.Printf("Registry: %s\n", ref.Registry)
+	fmt.Printf("Repository: %s\n", ref.Repository)
+	digest, err := ref.Digest()
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+	fmt.Printf("Digest: %v\n", digest)
+
+	// Output:
+	// Registry: ghcr.io
+	// Repository: oras-project/oras
+	// Digest: sha256:601d05a48832e7946dab8f49b14953549bebf42e42f4d7973b1a5a287d77ab76
+}

--- a/registry/reference.go
+++ b/registry/reference.go
@@ -250,6 +250,8 @@ func (r Reference) ReferenceOrDefault() string {
 }
 
 // Digest returns the reference as a digest.
+// Make sure you import the appropriate hash implementations as described
+// in https://pkg.go.dev/github.com/opencontainers/go-digest#readme-usage
 func (r Reference) Digest() (digest.Digest, error) {
 	return digest.Parse(r.Reference)
 }


### PR DESCRIPTION
Using this PR to discuss the need for importing the hash algorithm. One option is that add this to the examples for digest or parse reference or it possible to have indirect dependencies. I'm leaning towards not having an indirect dependency since this means that if and when a algorithm becomes unacceptable the library has to rev. Instead clients taking the appropriate imports could define the actual hash algorithms that are being used - 
https://cloud-native.slack.com/archives/CJ1KHJM5Z/p1704365828594969

On a side note, how what would be a good pattern to exclude full file examples from license header check? 

Related to - https://github.com/oras-project/oras-go/pull/671