### PR TITLE
Bump go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.20', '1.21']
+        go-version: ['1.21', '1.22']
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: ['1.20', '1.21']
+        go-version: ['1.21', '1.22']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The ORAS Go library follows [Semantic Versioning](https://semver.org/), where br
 The version `2` is actively developed in the [`main`](https://github.com/oras-project/oras-go/tree/main) branch with all new features.
 
 > [!Note]
-> The `main` branch follows [Go's Security Policy](https://github.com/golang/go/security/policy) and supports the two latest versions of Go (currently `1.20` and `1.21`).
+> The `main` branch follows [Go's Security Policy](https://github.com/golang/go/security/policy) and supports the two latest versions of Go (currently `1.21` and `1.22`).
 
 Examples for common use cases can be found below:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module oras.land/oras-go/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/opencontainers/go-digest v1.0.0


### PR DESCRIPTION

This PR fixes #713
- bumps go version in `README.md`, `go.mod` and `GitHub Actions`.