### PR TITLE
chore: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,62 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bug Report
+description: File a bug report
+labels: [bug, triage]
+body:
+  - type: markdown
+    id: preface
+    attributes:
+      value: |
+        Thank you for reporting bugs to ORAS-GO!
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: What happened in your environment? 
+      description: "Please also attach logs here using `--debug` flag."
+  - type: textarea
+    id: expect
+    attributes:
+      label: "What did you expect to happen?"
+  - type: textarea
+    id: reproduce
+    validations:
+      required: true
+    attributes:
+      label: "How can we reproduce it?"
+      description: "Please tell us your environment information as minimally and precisely as possible."
+  - type: textarea
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: What is the version of your ORAS CLI?
+      description: "You can use the command `oras version` to get it."
+  - type: input
+    id: os
+    validations:
+      required: true
+    attributes:
+      label: What is your OS environment?
+      description: "e.g. Ubuntu 16.04"
+  - type: checkboxes
+    id: idea
+    attributes:
+      label: "Are you willing to submit PRs to fix it?"
+      description: "This is absolutely not required, but we are happy to guide you in the contribution process
+        especially when you already have a good proposal or understanding of how to implement it. Join us at https://slack.cncf.io/ and choose #oras channel."
+      options:
+        - label: Yes, I am willing to fix it.

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -19,7 +19,7 @@ body:
     id: preface
     attributes:
       value: |
-        Thank you for reporting bugs to ORAS-GO!
+        Thank you for reporting bugs to ORAS Go library!
   - type: textarea
     id: environment
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -44,7 +44,6 @@ body:
       required: true
     attributes:
       label: What is the version of your oras-go library ?
-      description: "You can use the command `oras version` to get it."
   - type: input
     id: os
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -43,7 +43,7 @@ body:
     validations:
       required: true
     attributes:
-      label: What is the version of your ORAS CLI?
+      label: What is the version of your oras-go library ?
       description: "You can use the command `oras version` to get it."
   - type: input
     id: os

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question or request support in the community
+    url: https://github.com/oras-project/oras-go/discussions 
+    about: Ask a question or request support for using ORAS

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,4 +15,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Ask a question or request support in the community
     url: https://github.com/oras-project/oras-go/discussions 
-    about: Ask a question or request support for using ORAS
+    about: Ask a question or request support for using ORAS go library

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,47 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Feature Request
+description: File a feature request
+labels: [enhancement, triage]
+body:
+  - type: markdown
+    id: preface
+    attributes:
+      value: "Thank you for submitting new features for ORAS."
+  - type: input
+    id: version
+    attributes:
+      label: "What is the version of your ORAS CLI"
+      description: "You can use the command `oras version` to get it"
+  - type: textarea
+    id: description
+    attributes:
+      label: "What would you like to be added?"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Why is this needed for ORAS?"
+      description: "Please describe your user story or scenario."
+    validations:
+      required: true
+  - type: checkboxes
+    id: idea
+    attributes:
+      label: "Are you willing to submit PRs to contribute to this feature?"
+      description: "This is absolutely not required, but we are happy to guide you in the contribution process
+        especially when you already have a good proposal or understanding of how to implement it. Join us at https://slack.cncf.io/ and choose #oras channel."
+      options:
+        - label: Yes, I am willing to implement it.

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -33,7 +33,7 @@ body:
   - type: textarea
     id: solution
     attributes:
-      label: "Why is this needed for ORAS?"
+      label: "Why is this needed for oras-go?"
       description: "Please describe your user story or scenario."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -18,7 +18,7 @@ body:
   - type: markdown
     id: preface
     attributes:
-      value: "Thank you for submitting new features for ORAS."
+      value: "Thank you for submitting new features for oras-go."
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -22,7 +22,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: "What is the version of your ORAS CLI"
+      label: "What is the version of your oras-go"
       description: "You can use the command `oras version` to get it"
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -23,7 +23,7 @@ body:
     id: version
     attributes:
       label: "What is the version of your oras-go"
-      description: "You can use the command `oras version` to get it"
+   
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION

This PR fixes #641 

- Adds issue templates for: `Bug report`, `feature request` and the config file for the templates.
![Screenshot from 2024-02-28 01-44-18](https://github.com/oras-project/oras-go/assets/131444479/0b7264d3-aecf-4eea-9fe6-6ba30012ea7c)
