### PR TITLE
test: fix file closing issue on windows

### DIFF
--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -690,6 +690,7 @@ func TestStore_Dir_Push_SkipUnpack(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to open internal gz")
 	}
+	defer pushedFile.Close()
 	pushedContent, err := io.ReadAll(pushedFile)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fix file closing issue `The process cannot access the file because it is being used by another process.` on Windows for the test `TestStore_Dir_Push_SkipUnpack`.