### PR TITLE
fix: add missing operation to fs path error

### DIFF
--- a/internal/fs/tarfs/tarfs.go
+++ b/internal/fs/tarfs/tarfs.go
@@ -67,7 +67,7 @@ func New(path string) (*TarFS, error) {
 // ValidPath(name), returning a *PathError with Err set to
 // ErrInvalid or ErrNotExist.
 func (tfs *TarFS) Open(name string) (file fs.File, openErr error) {
-	entry, err := tfs.getEntry(name)
+	entry, err := tfs.getEntry("open", name)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (tfs *TarFS) Open(name string) (file fs.File, openErr error) {
 // Stat returns a FileInfo describing the file.
 // If there is an error, it should be of type *PathError.
 func (tfs *TarFS) Stat(name string) (fs.FileInfo, error) {
-	entry, err := tfs.getEntry(name)
+	entry, err := tfs.getEntry("stat", name)
 	if err != nil {
 		return nil, err
 	}
@@ -106,18 +106,18 @@ func (tfs *TarFS) Stat(name string) (fs.FileInfo, error) {
 }
 
 // getEntry returns the named entry.
-func (tfs *TarFS) getEntry(name string) (*entry, error) {
-	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+func (tfs *TarFS) getEntry(operation string, path string) (*entry, error) {
+	if !fs.ValidPath(path) {
+		return nil, &fs.PathError{Op: operation, Path: path, Err: fs.ErrInvalid}
 	}
-	entry, ok := tfs.entries[name]
+	entry, ok := tfs.entries[path]
 	if !ok {
-		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+		return nil, &fs.PathError{Op: operation, Path: path, Err: fs.ErrNotExist}
 	}
 	if entry.header.Typeflag != tar.TypeReg {
 		// support regular files only
 		return nil, fmt.Errorf("%s: type flag %c is not supported: %w",
-			name, entry.header.Typeflag, errdef.ErrUnsupported)
+			path, entry.header.Typeflag, errdef.ErrUnsupported)
 	}
 	return entry, nil
 }

--- a/internal/fs/tarfs/tarfs.go
+++ b/internal/fs/tarfs/tarfs.go
@@ -108,11 +108,11 @@ func (tfs *TarFS) Stat(name string) (fs.FileInfo, error) {
 // getEntry returns the named entry.
 func (tfs *TarFS) getEntry(name string) (*entry, error) {
 	if !fs.ValidPath(name) {
-		return nil, &fs.PathError{Path: name, Err: fs.ErrInvalid}
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 	entry, ok := tfs.entries[name]
 	if !ok {
-		return nil, &fs.PathError{Path: name, Err: fs.ErrNotExist}
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 	}
 	if entry.header.Typeflag != tar.TypeReg {
 		// support regular files only


### PR DESCRIPTION
When opening a folder as OCI image layout and there is no `oci-layout` file exists, the error would be

> failed to open OCI layout file:  oci-layout: file does not exist

There is a duplicated space in the error string, because the `Op` field is missing in the returned `fs.PathError`. With fix in this PR, the return error would be
> failed to open OCI layout file: open oci-layout: file does not exist

Fixes #640