### PR TITLE
fix: add media type in the generated index.json file

### DIFF
--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -379,6 +379,7 @@ func (s *Store) loadIndexFile(ctx context.Context) error {
 			Versioned: specs.Versioned{
 				SchemaVersion: 2, // historical value
 			},
+			MediaType: ocispec.MediaTypeImageIndex,
 			Manifests: []ocispec.Descriptor{},
 		}
 		return s.writeIndexFile()

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -125,6 +125,9 @@ func TestStore_Success(t *testing.T) {
 	if want := 2; index.SchemaVersion != want {
 		t.Errorf("index.SchemaVersion = %v, want %v", index.SchemaVersion, want)
 	}
+	if want := "application/vnd.oci.image.index.v1+json"; index.MediaType != want {
+		t.Errorf("index.MediaType = %s, want %s", index.MediaType, want)
+	}
 
 	// test push blob
 	err = s.Push(ctx, blobDesc, bytes.NewReader(blob))


### PR DESCRIPTION
Add a media type field in the `index.json` file generated during the OCI store initialization.

Fixes: #880 