### PR TITLE
chore: update to `image-spec v1.1.1`

### DIFF
--- a/content/oci/oci.go
+++ b/content/oci/oci.go
@@ -14,7 +14,7 @@ limitations under the License.
 */
 
 // Package oci provides access to an OCI content store.
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md
 package oci
 
 import (
@@ -44,7 +44,7 @@ import (
 
 // Store implements `oras.Target`, and represents a content store
 // based on file system with the OCI-Image layout.
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md
 type Store struct {
 	// AutoSaveIndex controls if the OCI store will automatically save the index
 	// file when needed.
@@ -222,7 +222,7 @@ func (s *Store) delete(ctx context.Context, target ocispec.Descriptor) ([]ocispe
 
 // Tag tags a descriptor with a reference string.
 // reference should be a valid tag (e.g. "latest").
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md#indexjson-file
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md#indexjson-file
 func (s *Store) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
 	s.sync.RLock()
 	defer s.sync.RUnlock()

--- a/content/oci/readonlyoci.go
+++ b/content/oci/readonlyoci.go
@@ -36,7 +36,7 @@ import (
 
 // ReadOnlyStore implements `oras.ReadonlyTarget`, and represents a read-only
 // content store based on file system with the OCI-Image layout.
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md
 type ReadOnlyStore struct {
 	fsys        fs.FS
 	storage     content.ReadOnlyStorage

--- a/content/oci/readonlystorage.go
+++ b/content/oci/readonlystorage.go
@@ -31,7 +31,7 @@ import (
 
 // ReadOnlyStorage is a read-only CAS based on file system with the OCI-Image
 // layout.
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md
 type ReadOnlyStorage struct {
 	fsys fs.FS
 }

--- a/content/oci/storage.go
+++ b/content/oci/storage.go
@@ -43,7 +43,7 @@ var bufPool = sync.Pool{
 }
 
 // Storage is a CAS based on file system with the OCI-Image layout.
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/image-layout.md
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/image-layout.md
 type Storage struct {
 	*ReadOnlyStorage
 	// root is the root directory of the OCI layout.

--- a/example_pack_test.go
+++ b/example_pack_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ExampleImageV11 demonstrates packing an OCI Image Manifest as defined in
-// image-spec v1.1.0.
+// image-spec v1.1.1.
 func ExamplePackManifest_imageV11() {
 	// 0. Create a storage
 	store := memory.New()

--- a/internal/spec/artifact.go
+++ b/internal/spec/artifact.go
@@ -34,7 +34,7 @@ const MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json
 // Artifact describes an artifact manifest.
 // This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
 //
-// This manifest type was introduced in image-spec v1.1.0-rc1 and was removed in
+// This manifest type was introduced in image-spec v1.1.1-rc1 and was removed in
 // image-spec v1.1.0-rc3. It is not part of the current image-spec and is kept
 // here for Go compatibility.
 //

--- a/internal/spec/artifact.go
+++ b/internal/spec/artifact.go
@@ -34,7 +34,7 @@ const MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json
 // Artifact describes an artifact manifest.
 // This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
 //
-// This manifest type was introduced in image-spec v1.1.1-rc1 and was removed in
+// This manifest type was introduced in image-spec v1.1.0-rc1 and was removed in
 // image-spec v1.1.0-rc3. It is not part of the current image-spec and is kept
 // here for Go compatibility.
 //

--- a/pack.go
+++ b/pack.go
@@ -112,7 +112,7 @@ type PackManifestOptions struct {
 // References:
 //   - https://github.com/opencontainers/image-spec/blob/v1.1.1/schema/defs-descriptor.json#L7
 //   - https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
-var mediaTypeRegexp = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}$`)
+var mediaTypeRegexp = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]{0,126}$`)
 
 // PackManifest generates an OCI Image Manifest based on the given parameters
 // and pushes the packed manifest to a content storage using pusher. The version

--- a/pack.go
+++ b/pack.go
@@ -78,8 +78,8 @@ const (
 	PackManifestVersion1_1_RC4 PackManifestVersion = PackManifestVersion1_1
 
 	// PackManifestVersion1_1 represents the OCI Image Manifest defined in
-	// image-spec v1.1.0.
-	// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md
+	// image-spec v1.1.1.
+	// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/manifest.md
 	PackManifestVersion1_1 PackManifestVersion = 2
 )
 
@@ -110,7 +110,7 @@ type PackManifestOptions struct {
 
 // mediaTypeRegexp checks the format of media types.
 // References:
-//   - https://github.com/opencontainers/image-spec/blob/v1.1.0/schema/defs-descriptor.json#L7
+//   - https://github.com/opencontainers/image-spec/blob/v1.1.1/schema/defs-descriptor.json#L7
 //   - https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
 var mediaTypeRegexp = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}$`)
 
@@ -301,8 +301,8 @@ func packManifestV1_1_RC2(ctx context.Context, pusher content.Pusher, configMedi
 	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.Config.MediaType, manifest.Annotations)
 }
 
-// packManifestV1_1 packs an image manifest defined in image-spec v1.1.0.
-// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#guidelines-for-artifact-usage
+// packManifestV1_1 packs an image manifest defined in image-spec v1.1.1.
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.1/manifest.md#guidelines-for-artifact-usage
 func packManifestV1_1(ctx context.Context, pusher content.Pusher, artifactType string, opts PackManifestOptions) (ocispec.Descriptor, error) {
 	if artifactType == "" && (opts.ConfigDescriptor == nil || opts.ConfigDescriptor.MediaType == ocispec.MediaTypeEmptyJSON) {
 		// artifactType MUST be set when config.mediaType is set to the empty value

--- a/registry/reference.go
+++ b/registry/reference.go
@@ -34,13 +34,13 @@ var (
 	//
 	// References:
 	//   - https://github.com/distribution/distribution/blob/v2.7.1/reference/regexp.go#L53
-	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pulling-manifests
+	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pulling-manifests
 	repositoryRegexp = regexp.MustCompile(`^[a-z0-9]+(?:(?:[._]|__|[-]*)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|[-]*)[a-z0-9]+)*)*$`)
 
 	// tagRegexp checks the tag name.
 	// The docker and OCI spec have the same regular expression.
 	//
-	// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pulling-manifests
+	// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pulling-manifests
 	tagRegexp = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
 )
 

--- a/registry/remote/errcode/errors.go
+++ b/registry/remote/errcode/errors.go
@@ -24,7 +24,7 @@ import (
 )
 
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#error-codes
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#error-codes
 //   - https://docs.docker.com/registry/spec/api/#errors-2
 const (
 	ErrorCodeBlobUnknown         = "BLOB_UNKNOWN"
@@ -45,7 +45,7 @@ const (
 // Error represents a response inner error returned by the remote
 // registry.
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#error-codes
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#error-codes
 //   - https://docs.docker.com/registry/spec/api/#errors-2
 type Error struct {
 	Code    string `json:"code"`
@@ -73,7 +73,7 @@ func (e Error) Error() string {
 // Errors represents a list of response inner errors returned by the remote
 // server.
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#error-codes
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#error-codes
 //   - https://docs.docker.com/registry/spec/api/#errors-2
 type Errors []Error
 

--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -102,7 +102,7 @@ func (e *ReferrersError) IsReferrersIndexDelete() bool {
 
 // buildReferrersTag builds the referrers tag for the given manifest descriptor.
 // Format: <algorithm>-<digest>
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#unavailable-referrers-api
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#unavailable-referrers-api
 func buildReferrersTag(desc ocispec.Descriptor) string {
 	alg := desc.Digest.Algorithm().String()
 	encoded := desc.Digest.Encoded()

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -94,7 +94,7 @@ func (r *Registry) do(req *http.Request) (*http.Response, error) {
 //
 // References:
 //   - https://docs.docker.com/registry/spec/api/#base
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#api
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#api
 func (r *Registry) Ping(ctx context.Context) error {
 	url := buildRegistryBaseURL(r.PlainHTTP, r.Reference)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -53,7 +53,7 @@ const (
 	//
 	// References:
 	//   - https://docs.docker.com/registry/spec/api/#digest-header
-	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pull
+	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pull
 	headerDockerContentDigest = "Docker-Content-Digest"
 
 	// headerOCIFiltersApplied is the "OCI-Filters-Applied" header.
@@ -61,7 +61,7 @@ const (
 	// applied filters.
 	//
 	// Reference:
-	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 	headerOCIFiltersApplied = "OCI-Filters-Applied"
 
 	// headerOCISubject is the "OCI-Subject" header.
@@ -74,7 +74,7 @@ const (
 // referrers.
 //
 // References:
-//   - Latest spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+//   - Latest spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - Compatible spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
 const filterTypeArtifactType = "artifactType"
 
@@ -138,16 +138,16 @@ type Repository struct {
 	//    is successfully uploaded.
 	//  - If true, the old referrers index is kept.
 	// By default, it is disabled (set to false). See also:
-	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#referrers-tag-schema
-	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pushing-manifests-with-subject
-	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#deleting-manifests
+	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#referrers-tag-schema
+	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests-with-subject
+	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
 	SkipReferrersGC bool
 
 	// HandleWarning handles the warning returned by the remote server.
 	// Callers SHOULD deduplicate warnings from multiple associated responses.
 	//
 	// References:
-	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#warnings
+	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#warnings
 	//   - https://www.rfc-editor.org/rfc/rfc7234#section-5.5
 	HandleWarning func(warning Warning)
 
@@ -217,9 +217,9 @@ func (r *Repository) clone() *Repository {
 // SetReferrersCapability returns ErrReferrersCapabilityAlreadySet if the
 // Referrers API capability has been already set.
 //   - When the capability is set to true, the Referrers() function will always
-//     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+//     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - When the capability is set to false, the Referrers() function will always
-//     request the Referrers Tag. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#referrers-tag-schema
+//     request the Referrers Tag. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#referrers-tag-schema
 //   - When the capability is not set, the Referrers() function will automatically
 //     determine which API to use.
 func (r *Repository) SetReferrersCapability(capable bool) error {
@@ -393,7 +393,7 @@ func (r *Repository) ParseReference(reference string) (registry.Reference, error
 // of the Tags list.
 //
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#content-discovery
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#content-discovery
 //   - https://docs.docker.com/registry/spec/api/#tags
 func (r *Repository) Tags(ctx context.Context, last string, fn func(tags []string) error) error {
 	ctx = auth.AppendRepositoryScope(ctx, r.Reference, auth.ActionPull)
@@ -452,7 +452,7 @@ func (r *Repository) tags(ctx context.Context, last string, fn func(tags []strin
 // Predecessors returns the descriptors of image or artifact manifests directly
 // referencing the given manifest descriptor.
 // Predecessors internally leverages Referrers.
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 func (r *Repository) Predecessors(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 	var res []ocispec.Descriptor
 	if err := r.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
@@ -471,7 +471,7 @@ func (r *Repository) Predecessors(ctx context.Context, desc ocispec.Descriptor) 
 // If artifactType is not empty, only referrers of the same artifact type are
 // fed to fn.
 //
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 func (r *Repository) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
 	state := r.loadReferrersState()
 	if state == referrersStateUnsupported {
@@ -570,7 +570,7 @@ func (r *Repository) referrersPageByAPI(ctx context.Context, artifactType string
 	referrers := index.Manifests
 	if artifactType != "" {
 		// check both filters header and filters annotations for compatibility
-		// latest spec for filters header: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+		// latest spec for filters header: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 		// older spec for filters annotations: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
 		filtersHeader := resp.Header.Get(headerOCIFiltersApplied)
 		filtersAnnotation := index.Annotations[spec.AnnotationReferrersFiltersApplied]
@@ -592,7 +592,7 @@ func (r *Repository) referrersPageByAPI(ctx context.Context, artifactType string
 // referencing the given manifest descriptor by requesting referrers tag.
 // fn is called for the referrers result. If artifactType is not empty,
 // only referrers of the same artifact type are fed to fn.
-// reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#backwards-compatibility
+// reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#backwards-compatibility
 func (r *Repository) referrersByTagSchema(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
 	referrersTag := buildReferrersTag(desc)
 	_, referrers, err := r.referrersFromIndex(ctx, referrersTag)
@@ -809,7 +809,7 @@ func (s *blobStore) Mount(ctx context.Context, desc ocispec.Descriptor, fromRepo
 	// push it. If the caller has provided a getContent function, we
 	// can use that, otherwise pull the content from the source repository.
 	//
-	// [spec]: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#mounting-a-blob-from-another-repository
+	// [spec]: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#mounting-a-blob-from-another-repository
 
 	var r io.ReadCloser
 	if getContent != nil {
@@ -844,7 +844,7 @@ func (s *blobStore) sibling(otherRepoName string) *blobStore {
 // References:
 //   - https://docs.docker.com/registry/spec/api/#pushing-an-image
 //   - https://docs.docker.com/registry/spec/api/#initiate-blob-upload
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pushing-a-blob-monolithically
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-a-blob-monolithically
 func (s *blobStore) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
 	// start an upload
 	// pushing usually requires both pull and push actions.
@@ -1154,7 +1154,7 @@ func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.D
 // on manifest delete.
 //
 // References:
-//   - Latest spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#deleting-manifests
+//   - Latest spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
 //   - Compatible spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#deleting-manifests
 func (s *manifestStore) indexReferrersForDelete(ctx context.Context, desc ocispec.Descriptor, manifestJSON []byte) error {
 	var manifest struct {
@@ -1340,7 +1340,7 @@ func (s *manifestStore) push(ctx context.Context, expected ocispec.Descriptor, c
 
 // checkOCISubjectHeader checks the "OCI-Subject" header in the response and
 // sets referrers capability accordingly.
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pushing-manifests-with-subject
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests-with-subject
 func (s *manifestStore) checkOCISubjectHeader(resp *http.Response) {
 	// If the "OCI-Subject" header is set, it indicates that the registry
 	// supports the Referrers API and has processed the subject of the manifest.
@@ -1391,7 +1391,7 @@ func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.D
 // on manifest push.
 //
 // References:
-//   - Latest spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pushing-manifests-with-subject
+//   - Latest spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests-with-subject
 //   - Compatible spec: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#pushing-manifests-with-subject
 func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.Descriptor, manifestJSON []byte) error {
 	var subject ocispec.Descriptor
@@ -1448,8 +1448,8 @@ func (s *manifestStore) indexReferrersForPush(ctx context.Context, desc ocispec.
 // updateReferrersIndex updates the referrers index for desc referencing subject
 // on manifest push and manifest delete.
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#pushing-manifests-with-subject
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#deleting-manifests
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests-with-subject
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
 func (s *manifestStore) updateReferrersIndex(ctx context.Context, subject ocispec.Descriptor, change referrerChange) (err error) {
 	referrersTag := buildReferrersTag(subject)
 

--- a/registry/remote/url.go
+++ b/registry/remote/url.go
@@ -101,7 +101,7 @@ func buildRepositoryBlobMountURL(plainHTTP bool, ref registry.Reference, d diges
 
 // buildReferrersURL builds the URL for querying the Referrers API.
 // Format: <scheme>://<registry>/v2/<repository>/referrers/<digest>?artifactType=<artifactType>
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 func buildReferrersURL(plainHTTP bool, ref registry.Reference, artifactType string) string {
 	var query string
 	if artifactType != "" {

--- a/registry/remote/warning.go
+++ b/registry/remote/warning.go
@@ -43,7 +43,7 @@ var errUnexpectedWarningFormat = errors.New("unexpected warning format")
 // WarningValue represents the value of the Warning header.
 //
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#warnings
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#warnings
 //   - https://www.rfc-editor.org/rfc/rfc7234#section-5.5
 type WarningValue struct {
 	// Code is the warn-code.
@@ -58,7 +58,7 @@ type WarningValue struct {
 // other information related to the warning.
 //
 // References:
-//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#warnings
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#warnings
 //   - https://www.rfc-editor.org/rfc/rfc7234#section-5.5
 type Warning struct {
 	// WarningValue is the value of the warning header.

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -87,7 +87,7 @@ type ReferenceFetcher interface {
 }
 
 // ReferrerLister provides the Referrers API.
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 type ReferrerLister interface {
 	Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error
 }
@@ -109,7 +109,7 @@ type TagLister interface {
 	// specification.
 	//
 	// References:
-	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#content-discovery
+	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#content-discovery
 	//   - https://docs.docker.com/registry/spec/api/#tags
 	// See also `Tags()` in this package.
 	Tags(ctx context.Context, last string, fn func(tags []string) error) error
@@ -143,7 +143,7 @@ func Tags(ctx context.Context, repo TagLister) ([]string, error) {
 // Referrers lists the descriptors of image or artifact manifests directly
 // referencing the given manifest descriptor.
 //
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0/spec.md#listing-referrers
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 func Referrers(ctx context.Context, store content.ReadOnlyGraphStorage, desc ocispec.Descriptor, artifactType string) ([]ocispec.Descriptor, error) {
 	if !descriptor.IsManifest(desc) {
 		return nil, fmt.Errorf("the descriptor %v is not a manifest: %w", desc, errdef.ErrUnsupported)


### PR DESCRIPTION
1. Use the media type regex defined in [`image-spec v1.1.1`](https://github.com/opencontainers/image-spec/blob/v1.1.1/schema/defs-descriptor.json#L7) in `pack.go`
2. Update the doc links to reference `image-spec v1.1.1` and `distribution-spec v1.1.1`

Resolves: #910 