### PR TITLE
build(deps): bump golang.org/x/sync from 0.11.0 to 0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module oras.land/oras-go/v2
 
-go 1.23.7
+go 1.23.0
+
+toolchain go1.23.3
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module oras.land/oras-go/v2
 
-go 1.23
+go 1.23.7
 
 require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
-	golang.org/x/sync v0.11.0
+	golang.org/x/sync v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,5 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=


### PR DESCRIPTION
Fixing #915 