### PR TITLE
fix: fix concurrency bugs causing panics and race conditions in `internal/syncutil`

### DIFF
--- a/internal/syncutil/limit.go
+++ b/internal/syncutil/limit.go
@@ -90,6 +90,8 @@ func Go[T any](ctx context.Context, limiter *semaphore.Weighted, fn GoFunc[T], i
 			return func() error {
 				defer region.End()
 				err := fn(egCtx, region, t)
+				// TODO: remove egErr
+				// TODO: need to cancel egCtx before releasing (region.End)
 				if err != nil {
 					firstErr.CompareAndSwap(nil, goErr{error: err})
 					return err

--- a/internal/syncutil/limit.go
+++ b/internal/syncutil/limit.go
@@ -82,30 +82,30 @@ func Go[T any](ctx context.Context, limiter *semaphore.Weighted, fn GoFunc[T], i
 				// record the first error occurred
 				firstErr = err
 			})
-			// when error occurs, cancel other tasks
+			// when an error occurs, cancel other tasks
 			cancel()
 			// continue loop instead of returning to allow already scheduled
-			// goroutines to finish their deferred reg.End() calls
+			// goroutines to finish their deferred region.End() calls
 			continue
 		}
 
-		eg.Go(func(t T, reg *LimitedRegion) func() error {
+		eg.Go(func(t T, lr *LimitedRegion) func() error {
 			return func() error {
-				defer reg.End()
+				defer lr.End()
 
 				select {
 				case <-egCtx.Done():
-					// skip the task if the context is already canceled
+					// skip the task if the context is already cancelled
 					return nil
 				default:
 				}
 
-				if err := fn(egCtx, reg, t); err != nil {
+				if err := fn(egCtx, lr, t); err != nil {
 					once.Do(func() {
 						// record the first error occurred
 						firstErr = err
 					})
-					// when error occurs, cancel other tasks
+					// when an error occurs, cancel other tasks
 					cancel()
 					return err
 				}

--- a/internal/syncutil/limit.go
+++ b/internal/syncutil/limit.go
@@ -84,9 +84,9 @@ func Go[T any](ctx context.Context, limiter *semaphore.Weighted, fn GoFunc[T], i
 			})
 			// when an error occurs, cancel other tasks
 			cancel()
-			// continue loop instead of returning to allow already scheduled
+			// break loop instead of returning to allow already scheduled
 			// goroutines to finish their deferred region.End() calls
-			continue
+			break
 		}
 
 		eg.Go(func(t T, lr *LimitedRegion) func() error {

--- a/internal/syncutil/limit.go
+++ b/internal/syncutil/limit.go
@@ -100,9 +100,8 @@ func Go[T any](ctx context.Context, limiter *semaphore.Weighted, fn GoFunc[T], i
 		}(item, region))
 	}
 
-	egErr := eg.Wait()
-	if causeErr := context.Cause(ctx); causeErr != nil {
-		return causeErr
+	if err := eg.Wait(); err != nil {
+		cancel(err)
 	}
-	return egErr
+	return context.Cause(ctx)
 }

--- a/internal/syncutil/limit.go
+++ b/internal/syncutil/limit.go
@@ -67,11 +67,8 @@ func (lr *LimitedRegion) End() {
 type GoFunc[T any] func(ctx context.Context, region *LimitedRegion, t T) error
 
 // Go concurrently invokes fn on items.
-// It records the first “real” error (via sync.Once) and cancels the context.
-// Tasks that see cancellation before running f() return nil, so that Wait()
-// eventually returns your recorded error (if any).
 func Go[T any](ctx context.Context, limiter *semaphore.Weighted, fn GoFunc[T], items ...T) error {
-	// Create an explicit cancelable context.
+	// create an explicit cancelable context.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/syncutil/limit_test.go
+++ b/internal/syncutil/limit_test.go
@@ -1,0 +1,82 @@
+package syncutil
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// TestLimitedRegionAllSuccess verifies that when no errors occur, all goroutines run to completion
+// and the semaphore is properly released.
+func TestLimitedRegionAllSuccess(t *testing.T) {
+	// Create a semaphore with capacity 2.
+	sem := semaphore.NewWeighted(2)
+	ctx := context.Background()
+	var counter int32
+
+	// Use numbers 1..5; our dummy function just sleeps a little and increments counter.
+	err := Go(ctx, sem, func(ctx context.Context, region *LimitedRegion, i int) error {
+		// Simulate work.
+		time.Sleep(10 * time.Millisecond)
+		atomic.AddInt32(&counter, 1)
+		return nil
+	}, 1, 2, 3, 4, 5)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// After everything finishes, we expect counter to be 5.
+	if atomic.LoadInt32(&counter) != 5 {
+		t.Errorf("expected counter==5, got %d", counter)
+	}
+
+	// When all work is done the semaphore should have all permits available.
+	// Try acquiring the full weight—if the permits weren't all released,
+	// TryAcquire would return false.
+	if !sem.TryAcquire(2) {
+		t.Error("semaphore permits were not fully released at the end")
+	}
+	// Release the permits we just acquired.
+	sem.Release(2)
+}
+
+// TestLimitedRegionCancellation verifies that if an early error occurs,
+// (a) the overall Go call returns the error and (b) semaphore permits are released.
+func TestLimitedRegionCancellation(t *testing.T) {
+	sem := semaphore.NewWeighted(2)
+	ctx := context.Background()
+	var counter int32
+
+	// We choose a special item (e.g. value 42) to trigger error.
+	errTest := errors.New("intentional error")
+	err := Go(ctx, sem, func(ctx context.Context, region *LimitedRegion, i int) error {
+		// If we see the trigger value, return an error immediately.
+		if i == 42 {
+			return errTest
+		}
+		// Otherwise, simulate some work that takes time.
+		time.Sleep(50 * time.Millisecond)
+		atomic.AddInt32(&counter, 1)
+		return nil
+	}, 1, 42, 3, 4)
+
+	// In our design the first error should cancel work and be returned.
+	if err == nil {
+		t.Fatal("expected an error, but got nil")
+	}
+	if !errors.Is(err, errTest) {
+		t.Fatalf("expected error %v; got %v", errTest, err)
+	}
+
+	// Some of the non-error tasks may have been short-circuited.
+	// Regardless, once Go returns the semaphore should be fully released.
+	if !sem.TryAcquire(2) {
+		t.Error("semaphore permit was not released after error cancellation")
+	}
+	sem.Release(2)
+}

--- a/internal/syncutil/limit_test.go
+++ b/internal/syncutil/limit_test.go
@@ -70,7 +70,7 @@ func TestLimitedRegion_Cancellation(t *testing.T) {
 		return nil
 	}, 1, -1, 2, 0, -2)
 
-	// we expect the first error to be errTest.
+	// we expect the returned error to be errTest.
 	if !errors.Is(err, errTest) {
 		t.Fatalf("expected error %v; got %v", errTest, err)
 	}

--- a/internal/syncutil/limit_test.go
+++ b/internal/syncutil/limit_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package syncutil
 
 import (

--- a/internal/syncutil/limitgroup.go
+++ b/internal/syncutil/limitgroup.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// A LimitedGroup is a collection of goroutines working on subtasks that are part of
+// LimitedGroup is a collection of goroutines working on subtasks that are part of
 // the same overall task.
 type LimitedGroup struct {
 	grp *errgroup.Group
@@ -38,7 +38,9 @@ type LimitedGroup struct {
 // first.
 func LimitGroup(ctx context.Context, limit int) (*LimitedGroup, context.Context) {
 	grp, ctx := errgroup.WithContext(ctx)
-	grp.SetLimit(limit)
+	if limit > 0 {
+		grp.SetLimit(limit)
+	}
 	return &LimitedGroup{grp: grp, ctx: ctx}, ctx
 }
 
@@ -55,6 +57,7 @@ func (g *LimitedGroup) Go(f func() error) {
 		case <-g.ctx.Done():
 			return g.ctx.Err()
 		default:
+			// f() needs to check if the context is cancelled by itself?
 			return f()
 		}
 	})

--- a/internal/syncutil/limitgroup.go
+++ b/internal/syncutil/limitgroup.go
@@ -38,9 +38,7 @@ type LimitedGroup struct {
 // first.
 func LimitGroup(ctx context.Context, limit int) (*LimitedGroup, context.Context) {
 	grp, ctx := errgroup.WithContext(ctx)
-	if limit > 0 {
-		grp.SetLimit(limit)
-	}
+	grp.SetLimit(limit)
 	return &LimitedGroup{grp: grp, ctx: ctx}, ctx
 }
 
@@ -57,7 +55,6 @@ func (g *LimitedGroup) Go(f func() error) {
 		case <-g.ctx.Done():
 			return g.ctx.Err()
 		default:
-			// f() needs to check if the context is cancelled by itself?
 			return f()
 		}
 	})

--- a/internal/syncutil/limitgroup_test.go
+++ b/internal/syncutil/limitgroup_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package syncutil
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestLimitedGroupSuccess verifies that all functions complete without error.
+func TestLimitedGroupSuccess(t *testing.T) {
+	ctx := context.Background()
+	numTasks := 5
+
+	// Create a limited group with a concurrency limit of 2.
+	lg, _ := LimitGroup(ctx, 2)
+	var counter int32
+
+	for i := 0; i < numTasks; i++ {
+		// Capture i if needed.
+		lg.Go(func() error {
+			// Simulate some work.
+			time.Sleep(10 * time.Millisecond)
+			atomic.AddInt32(&counter, 1)
+			return nil
+		})
+	}
+
+	if err := lg.Wait(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&counter); got != int32(numTasks) {
+		t.Errorf("expected counter %d, got %d", numTasks, got)
+	}
+}
+
+// TestLimitedGroupError confirms that if one task returns an error,
+// the act of canceling prevents further work and that Wait returns the original error.
+func TestLimitedGroupError(t *testing.T) {
+	ctx := context.Background()
+	lg, _ := LimitGroup(ctx, 2)
+	errTest := errors.New("intentional error")
+	var executed int32
+
+	// This task will eventually return an error.
+	lg.Go(func() error {
+		// Delay a bit so that other tasks are scheduled.
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&executed, 1)
+		return errTest
+	})
+
+	// This task simulates a slower, normal task.
+	lg.Go(func() error {
+		// Wait until cancellation is (hopefully) in effect.
+		time.Sleep(50 * time.Millisecond)
+		atomic.AddInt32(&executed, 1)
+		return nil
+	})
+
+	err := lg.Wait()
+	if !errors.Is(err, errTest) {
+		t.Fatalf("expected error %v, got %v", errTest, err)
+	}
+
+	// Since execution stops as soon as an error is encountered,
+	// it's possible that the second task never does its work.
+	if atomic.LoadInt32(&executed) < 1 {
+		t.Errorf("expected at least one task executed, got %d", executed)
+	}
+}
+
+// TestLimitedGroupLimit verifies that the concurrency limit is respected.
+func TestLimitedGroupLimit(t *testing.T) {
+	ctx := context.Background()
+	limit := 2
+	lg, _ := LimitGroup(ctx, limit)
+	var concurrent, maxConcurrent int32
+	numTasks := 10
+
+	for i := 0; i < numTasks; i++ {
+		lg.Go(func() error {
+			// Increment the count of concurrently active tasks.
+			cur := atomic.AddInt32(&concurrent, 1)
+			// Update the max concurrent tasks if needed.
+			for {
+				prevMax := atomic.LoadInt32(&maxConcurrent)
+				if cur > prevMax {
+					if atomic.CompareAndSwapInt32(&maxConcurrent, prevMax, cur) {
+						break
+					}
+				} else {
+					break
+				}
+			}
+
+			// Simulate a short task.
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt32(&concurrent, -1)
+			return nil
+		})
+	}
+
+	if err := lg.Wait(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if maxConcurrent > int32(limit) {
+		t.Errorf("expected max concurrent tasks <= %d, got %d", limit, maxConcurrent)
+	}
+}


### PR DESCRIPTION
1. Remove the use of `atomic.Value`
2. Cancel all go-routines before releasing semaphore permits
3. Wait for schedule go-routines to release the semaphore permits before returning
4. Add unit tests

Fixes #916, fixes #908