### PR TITLE
docs: update example tests

### DIFF
--- a/content/example_test.go
+++ b/content/example_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 
+	_ "crypto/sha256"
+
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 )

--- a/content/file/example_test.go
+++ b/content/file/example_test.go
@@ -92,7 +92,10 @@ func Example_packFiles() {
 
 	// 2. Generate a manifest referencing the files
 	artifactType := "example/test"
-	manifestDescriptor, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, artifactType, oras.PackManifestOptions{Layers: fileDescriptors})
+	opts := oras.PackManifestOptions{
+		Layers: fileDescriptors,
+	}
+	manifestDescriptor, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, artifactType, opts)
 	if err != nil {
 		panic(err)
 	}

--- a/content/file/example_test.go
+++ b/content/file/example_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 )
@@ -78,18 +79,20 @@ func Example_packFiles() {
 	// 1. Add files into the file store
 	mediaType := "example/file"
 	fileNames := []string{"foo.txt", "bar.txt"}
+	fileDescriptors := make([]ocispec.Descriptor, 0, len(fileNames))
 	for _, name := range fileNames {
 		fileDescriptor, err := store.Add(ctx, name, mediaType, "")
 		if err != nil {
 			panic(err)
 		}
+		fileDescriptors = append(fileDescriptors, fileDescriptor)
 
 		fmt.Printf("file descriptor for %s: %v\n", name, fileDescriptor)
 	}
 
 	// 2. Generate a manifest referencing the files
 	artifactType := "example/test"
-	manifestDescriptor, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, artifactType, oras.PackManifestOptions{})
+	manifestDescriptor, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, artifactType, oras.PackManifestOptions{Layers: fileDescriptors})
 	if err != nil {
 		panic(err)
 	}

--- a/content/file/example_test.go
+++ b/content/file/example_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/file"
 )
@@ -67,7 +66,7 @@ func TestMain(m *testing.M) {
 }
 
 // Example_packFiles gives an example of adding files and generating a manifest
-// referencing the files.
+// referencing the files as defined in image-spec v1.1.1.
 func Example_packFiles() {
 	store, err := file.New(workingDir)
 	if err != nil {
@@ -79,20 +78,18 @@ func Example_packFiles() {
 	// 1. Add files into the file store
 	mediaType := "example/file"
 	fileNames := []string{"foo.txt", "bar.txt"}
-	fileDescriptors := make([]ocispec.Descriptor, 0, len(fileNames))
 	for _, name := range fileNames {
 		fileDescriptor, err := store.Add(ctx, name, mediaType, "")
 		if err != nil {
 			panic(err)
 		}
-		fileDescriptors = append(fileDescriptors, fileDescriptor)
 
 		fmt.Printf("file descriptor for %s: %v\n", name, fileDescriptor)
 	}
 
 	// 2. Generate a manifest referencing the files
 	artifactType := "example/test"
-	manifestDescriptor, err := oras.Pack(ctx, store, artifactType, fileDescriptors, oras.PackOptions{})
+	manifestDescriptor, err := oras.PackManifest(ctx, store, oras.PackManifestVersion1_1, artifactType, oras.PackManifestOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -101,5 +98,5 @@ func Example_packFiles() {
 	// Output:
 	// file descriptor for foo.txt: {example/file sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae 3 [] map[org.opencontainers.image.title:foo.txt] [] <nil> }
 	// file descriptor for bar.txt: {example/file sha256:fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9 3 [] map[org.opencontainers.image.title:bar.txt] [] <nil> }
-	// manifest media type: application/vnd.oci.artifact.manifest.v1+json
+	// manifest media type: application/vnd.oci.image.manifest.v1+json
 }

--- a/example_copy_test.go
+++ b/example_copy_test.go
@@ -199,7 +199,7 @@ func ExampleCopy_remoteToRemote() {
 	if err != nil {
 		panic(err) // Handle error
 	}
-	dst, err := reg.Repository(ctx, "target")
+	dst, err := reg.Repository(ctx, "destination")
 	if err != nil {
 		panic(err) // Handle error
 	}
@@ -225,7 +225,7 @@ func ExampleCopy_remoteToRemoteWithMount() {
 	if err != nil {
 		panic(err) // Handle error
 	}
-	dst, err := reg.Repository(ctx, "target")
+	dst, err := reg.Repository(ctx, "destination")
 	if err != nil {
 		panic(err) // Handle error
 	}
@@ -241,7 +241,7 @@ func ExampleCopy_remoteToRemoteWithMount() {
 
 	// Enable cross-repository blob mounting
 	opts.MountFrom = func(ctx context.Context, desc ocispec.Descriptor) ([]string, error) {
-		// the slice of source repositores may also come from a database of known locations of blobs
+		// the slice of source repositories may also come from a database of known locations of blobs
 		return []string{"source/repository/name"}, nil
 	}
 
@@ -326,7 +326,7 @@ func ExampleCopy_localToRemote() {
 		panic(err) // Handle error
 	}
 	ctx := context.Background()
-	dst, err := reg.Repository(ctx, "target")
+	dst, err := reg.Repository(ctx, "destination")
 	if err != nil {
 		panic(err) // Handle error
 	}
@@ -345,24 +345,30 @@ func ExampleCopy_localToRemote() {
 // ExampleCopyArtifactManifestRemoteToLocal gives an example of copying
 // an artifact manifest from a remote repository into memory.
 func Example_copyArtifactManifestRemoteToLocal() {
+	// 0. Connect to a remote repository
 	src, err := remote.NewRepository(fmt.Sprintf("%s/source", remoteHost))
 	if err != nil {
 		panic(err)
 	}
+
+	// 1. Create a memory store
 	dst := memory.New()
 	ctx := context.Background()
 
+	// 2. Resolve the descriptor of the artifact from the digest
 	exampleDigest := "sha256:70c29a81e235dda5c2cebb8ec06eafd3cca346cbd91f15ac74cefd98681c5b3d"
 	descriptor, err := src.Resolve(ctx, exampleDigest)
 	if err != nil {
 		panic(err)
 	}
+
+	// 3. Copy the artifact from the remote repository
 	err = oras.CopyGraph(ctx, src, dst, descriptor, oras.DefaultCopyGraphOptions)
 	if err != nil {
 		panic(err)
 	}
 
-	// verify that the artifact manifest described by the descriptor exists in dst
+	// 4. Verify that the artifact manifest described by the descriptor exists in dst
 	contentExists, err := dst.Exists(ctx, descriptor)
 	if err != nil {
 		panic(err)
@@ -377,13 +383,17 @@ func Example_copyArtifactManifestRemoteToLocal() {
 // copying an artifact along with its referrers from a remote repository into
 // memory.
 func Example_extendedCopyArtifactAndReferrersRemoteToLocal() {
+	// 0. Connect to a remote repository
 	src, err := remote.NewRepository(fmt.Sprintf("%s/source", remoteHost))
 	if err != nil {
 		panic(err)
 	}
+
+	// 1. Create a memory store
 	dst := memory.New()
 	ctx := context.Background()
 
+	// 2. Copy the artifact and its referrers from the remote repository
 	tagName := "latest"
 	// ExtendedCopy will copy the artifact tagged by "latest" along with all of its
 	// referrers from src to dst.

--- a/example_copy_test.go
+++ b/example_copy_test.go
@@ -189,7 +189,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func ExampleCopy_remoteToRemote() {
+func ExampleCopy_repositoryToRepository() {
 	reg, err := remote.NewRegistry(remoteHost)
 	if err != nil {
 		panic(err) // Handle error
@@ -215,7 +215,7 @@ func ExampleCopy_remoteToRemote() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-func ExampleCopy_remoteToRemoteWithMount() {
+func ExampleCopy_repositoryToRepositoryWithMount() {
 	reg, err := remote.NewRegistry(remoteHost)
 	if err != nil {
 		panic(err) // Handle error
@@ -255,7 +255,7 @@ func ExampleCopy_remoteToRemoteWithMount() {
 	// Final sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-func ExampleCopy_remoteToLocal() {
+func ExampleCopy_repositoryToMemory() {
 	reg, err := remote.NewRegistry(remoteHost)
 	if err != nil {
 		panic(err) // Handle error
@@ -279,7 +279,7 @@ func ExampleCopy_remoteToLocal() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-func ExampleCopy_localToLocal() {
+func ExampleCopy_memoryToMemory() {
 	src := exampleMemoryStore
 	dst := memory.New()
 
@@ -295,7 +295,7 @@ func ExampleCopy_localToLocal() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-func ExampleCopy_localToOciFile() {
+func ExampleCopy_memoryToOciFile() {
 	src := exampleMemoryStore
 	tempDir, err := os.MkdirTemp("", "oras_oci_example_*")
 	if err != nil {
@@ -319,7 +319,7 @@ func ExampleCopy_localToOciFile() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-func ExampleCopy_localToRemote() {
+func ExampleCopy_memoryToRepository() {
 	src := exampleMemoryStore
 	reg, err := remote.NewRegistry(remoteHost)
 	if err != nil {
@@ -342,9 +342,9 @@ func ExampleCopy_localToRemote() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-// ExampleCopyArtifactManifestRemoteToLocal gives an example of copying
+// ExampleCopyArtifactFromRepositoryToMemory gives an example of copying
 // an artifact manifest from a remote repository into memory.
-func Example_copyArtifactManifestRemoteToLocal() {
+func Example_copyArtifactFromRepositoryToMemory() {
 	// 0. Connect to a remote repository
 	repositoryName := "source"
 	src, err := remote.NewRepository(fmt.Sprintf("%s/%s", remoteHost, repositoryName))
@@ -380,10 +380,10 @@ func Example_copyArtifactManifestRemoteToLocal() {
 	// true
 }
 
-// ExampleExtendedCopyArtifactAndReferrersRemoteToLocal gives an example of
+// ExampleExtendedCopyArtifactAndReferrersFromRepository gives an example of
 // copying an artifact along with its referrers from a remote repository into
 // memory.
-func Example_extendedCopyArtifactAndReferrersRemoteToLocal() {
+func Example_extendedCopyArtifactAndReferrersFromRepository() {
 	// 0. Connect to a remote repository
 	repositoryName := "source"
 	src, err := remote.NewRepository(fmt.Sprintf("%s/%s", remoteHost, repositoryName))

--- a/example_copy_test.go
+++ b/example_copy_test.go
@@ -346,7 +346,8 @@ func ExampleCopy_localToRemote() {
 // an artifact manifest from a remote repository into memory.
 func Example_copyArtifactManifestRemoteToLocal() {
 	// 0. Connect to a remote repository
-	src, err := remote.NewRepository(fmt.Sprintf("%s/source", remoteHost))
+	repositoryName := "source"
+	src, err := remote.NewRepository(fmt.Sprintf("%s/%s", remoteHost, repositoryName))
 	if err != nil {
 		panic(err)
 	}
@@ -384,7 +385,8 @@ func Example_copyArtifactManifestRemoteToLocal() {
 // memory.
 func Example_extendedCopyArtifactAndReferrersRemoteToLocal() {
 	// 0. Connect to a remote repository
-	src, err := remote.NewRepository(fmt.Sprintf("%s/source", remoteHost))
+	repositoryName := "source"
+	src, err := remote.NewRepository(fmt.Sprintf("%s/%s", remoteHost, repositoryName))
 	if err != nil {
 		panic(err)
 	}

--- a/example_copy_test.go
+++ b/example_copy_test.go
@@ -295,7 +295,7 @@ func ExampleCopy_memoryToMemory() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-func ExampleCopy_memoryToOciFile() {
+func ExampleCopy_memoryToOCIStore() {
 	src := exampleMemoryStore
 	tempDir, err := os.MkdirTemp("", "oras_oci_example_*")
 	if err != nil {
@@ -342,9 +342,9 @@ func ExampleCopy_memoryToRepository() {
 	// sha256:7cbb44b44e8ede5a89cf193db3f5f2fd019d89697e6b87e8ed2589e60649b0d1
 }
 
-// ExampleCopyArtifactFromRepositoryToMemory gives an example of copying
-// an artifact manifest from a remote repository into memory.
-func Example_copyArtifactFromRepositoryToMemory() {
+// ExampleCopyArtifactFromRepository gives an example of copying
+// an artifact from a remote repository into memory.
+func Example_copyArtifactFromRepository() {
 	// 0. Connect to a remote repository
 	repositoryName := "source"
 	src, err := remote.NewRepository(fmt.Sprintf("%s/%s", remoteHost, repositoryName))

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -324,8 +324,8 @@ func ExampleRepository_Push() {
 	// Push finished
 }
 
-// ExampleRepository_Push_artifactReferenceManifest gives an example snippet for pushing a reference manifest.
-func ExampleRepository_Push_artifactReferenceManifest() {
+// ExampleRepository_Push_referrerManifest gives an example snippet for pushing a manifest as a referrer to another manifest.
+func ExampleRepository_Push_referrerManifest() {
 	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, exampleRepositoryName))
 	if err != nil {
 		panic(err)
@@ -483,9 +483,9 @@ func ExampleRepository_Fetch_manifestByDigest() {
 	// {"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:569224ae188c06e97b9fcadaeb2358fb0fb7c4eb105d49aee2620b2719abea43","size":22},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"sha256:ef79e47691ad1bc702d7a256da6323ec369a8fc3159b4f1798a47136f3b38c10","size":21}]}
 }
 
-// ExampleRepository_Fetch_artifactReferenceManifest gives an example of fetching
+// ExampleRepository_Fetch_referrerManifest gives an example of fetching
 // the referrers of a given manifest by using the Referrers API.
-func ExampleRepository_Fetch_artifactReferenceManifest() {
+func ExampleRepository_Fetch_referrerManifest() {
 	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, exampleRepositoryName))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
(hopefully) fixes #818 

This PR:
1. Update the outdated examples involving `Pack` and `ArtifactManifest`.
2. Add numbered step documentation to the two package level examples of copy, so that there is a consistency with the other four package level examples.
3. Minor fixes such as renaming examples.