### PR TITLE
Handle empty config files

### DIFF
--- a/registry/remote/credentials/internal/config/config_test.go
+++ b/registry/remote/credentials/internal/config/config_test.go
@@ -57,6 +57,20 @@ func TestLoad_badPath(t *testing.T) {
 	}
 }
 
+func TestLoad_emptyFile(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	err := os.WriteFile(configPath, []byte{}, 0666)
+	if err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	_, err = Load(configPath)
+	if err != nil {
+		t.Errorf("Load() error = %v, wantErr nil", err)
+	}
+}
+
 func TestLoad_badFormat(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
ORAS handles config files that do not exist by initializing the cfg object. A similar case is when config files are empty files. ORAS v1 used the docker CLI packages that handled the io.EOF error case gracefully by initializing the configuration.

This change adds in fault tolerance handling by handling the EOF case.

Closes #961
