### PR TITLE
fix: credentials key for docker registry-1

### DIFF
--- a/registry/remote/credentials/registry.go
+++ b/registry/remote/credentials/registry.go
@@ -81,10 +81,12 @@ func Credential(store Store) auth.CredentialFunc {
 
 // ServerAddressFromRegistry maps a registry to a server address, which is used as
 // a key for credentials store. The Docker CLI expects that the credentials of
-// the registry 'docker.io' will be added under the key "https://index.docker.io/v1/".
+// the registry 'registry-1.docker.io' or the alias 'docker.io' will be added
+// under the key "https://index.docker.io/v1/".
 // See: https://github.com/moby/moby/blob/v24.0.2/registry/config.go#L25-L48
 func ServerAddressFromRegistry(registry string) string {
-	if registry == "docker.io" {
+	if registry == "docker.io" ||
+		registry == "registry-1.docker.io" {
 		return "https://index.docker.io/v1/"
 	}
 	return registry

--- a/registry/remote/credentials/registry_test.go
+++ b/registry/remote/credentials/registry_test.go
@@ -183,6 +183,11 @@ func Test_mapHostname(t *testing.T) {
 			want: "https://index.docker.io/v1/",
 		},
 		{
+			name: "map registry-1.docker.io to https://index.docker.io/v1/",
+			host: "registry-1.docker.io",
+			want: "https://index.docker.io/v1/",
+		},
+		{
 			name: "do not map other host names",
 			host: "localhost:2333",
 			want: "localhost:2333",


### PR DESCRIPTION
Login and logout should be supported for the OCI registry server `registry-1.docker.io` as well as the alias `docker.io` The key used is the legacy server for backward compatibility.

Related: https://github.com/helm/helm/issues/30929