### PR TITLE
build(go): shift Go support window to [1.24, 1.25]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24', '1.25']
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24', '1.25']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 `oras-go` is a Go library for managing OCI artifacts, compliant with the [OCI Image Format Specification](https://github.com/opencontainers/image-spec) and the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec). It provides unified APIs for pushing, pulling, and managing artifacts across OCI-compliant registries, local file systems, and in-memory stores.
 
 > [!Note]
-> The `main` branch follows [Go's Security Policy](https://github.com/golang/go/security/policy) and supports the two latest versions of Go (currently `1.23` and `1.24`).
+> The `main` branch follows [Go's Security Policy](https://github.com/golang/go/security/policy) and supports the two latest versions of Go (currently `1.24` and `1.25`).
 
 ## Getting Started
 

--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -237,9 +237,7 @@ func TestStore_RelativeRoot_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal("error calling Getwd(), error=", err)
 	}
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(tempDir)
 	s, err := New(".")
 	if err != nil {
 		t.Fatal("Store.New() error =", err)
@@ -249,9 +247,7 @@ func TestStore_RelativeRoot_Success(t *testing.T) {
 		t.Errorf("Store.workingDir = %s, want %s", s.workingDir, want)
 	}
 	// cd back to allow the temp directory to be removed
-	if err := os.Chdir(currDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(currDir)
 	ctx := context.Background()
 
 	blob := []byte("hello world")

--- a/content/file/file_unix_test.go
+++ b/content/file/file_unix_test.go
@@ -102,9 +102,7 @@ func TestStore_Dir_ExtractSymlinkRel(t *testing.T) {
 
 	// copy to another file store created from a relative root, to trigger extracting directory
 	tempDir = t.TempDir()
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(tempDir)
 	dstRel, err := New(".")
 	if err != nil {
 		t.Fatal("Store.New() error =", err)
@@ -211,9 +209,7 @@ func TestStore_Dir_ExtractSymlinkAbs(t *testing.T) {
 	if err := os.RemoveAll(dirPath); err != nil {
 		t.Fatal("error calling RemoveAll(), error =", err)
 	}
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(tempDir)
 	dstRel, err := New(".")
 	if err != nil {
 		t.Fatal("Store.New() error =", err)

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -226,9 +226,7 @@ func TestStore_RelativeRoot_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal("error calling Getwd(), error=", err)
 	}
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(tempDir)
 	s, err := New(".")
 	if err != nil {
 		t.Fatal("New() error =", err)
@@ -237,9 +235,7 @@ func TestStore_RelativeRoot_Success(t *testing.T) {
 		t.Errorf("Store.root = %s, want %s", s.root, want)
 	}
 	// cd back to allow the temp directory to be removed
-	if err := os.Chdir(currDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(currDir)
 	ctx := context.Background()
 
 	// validate layout

--- a/content/oci/storage_test.go
+++ b/content/oci/storage_test.go
@@ -95,9 +95,7 @@ func TestStorage_RelativeRoot_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal("error calling Getwd(), error=", err)
 	}
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(tempDir)
 	s, err := NewStorage(".")
 	if err != nil {
 		t.Fatal("New() error =", err)
@@ -106,9 +104,7 @@ func TestStorage_RelativeRoot_Success(t *testing.T) {
 		t.Errorf("Storage.root = %s, want %s", s.root, want)
 	}
 	// cd back to allow the temp directory to be removed
-	if err := os.Chdir(currDir); err != nil {
-		t.Fatal("error calling Chdir(), error=", err)
-	}
+	t.Chdir(currDir)
 	ctx := context.Background()
 
 	// test push

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module oras.land/oras-go/v2
 
-go 1.23.0
-
-toolchain go1.23.3
+go 1.24
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/registry/remote/auth/scope.go
+++ b/registry/remote/auth/scope.go
@@ -254,7 +254,7 @@ func CleanScopes(scopes []string) []string {
 			actionSet = make(map[string]struct{})
 			namedActions[resourceName] = actionSet
 		}
-		for _, action := range strings.Split(actions, ",") {
+		for action := range strings.SplitSeq(actions, ",") {
 			if action != "" {
 				actionSet[action] = struct{}{}
 			}

--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -118,8 +118,8 @@ func isReferrersFilterApplied(applied, requested string) bool {
 	if applied == "" || requested == "" {
 		return false
 	}
-	filters := strings.Split(applied, ",")
-	for _, f := range filters {
+	filters := strings.SplitSeq(applied, ",")
+	for f := range filters {
 		if f == requested {
 			return true
 		}


### PR DESCRIPTION
1. Upgrading go.mod to `1.23`
2. Update go version window to `[1.23, 1.24]` for GitHub builds
3. Use `Go 1.24` features in places applicable

We can have another PR to refactor the file store to use [`os.Root`](https://pkg.go.dev/os#Root)