### PR TITLE
ci: add v2 to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,14 @@ updates:
     schedule:
       interval: "daily"
 
-# update go dependencies for v1 branch
+  # update go dependencies for v2 branch
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "v2"
+
+  # update go dependencies for v1 branch
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to add automated dependency updates for Go modules on the `v2` branch. This ensures that dependencies for both `v1` and `v2` branches are kept up to date.

Dependabot configuration updates:

* Added a new entry for `gomod` to enable daily dependency updates for the `v2` branch in `.github/dependabot.yml`.