### PR TITLE
refactor: split out methods from ParseReference

### DIFF
--- a/registry/reference.go
+++ b/registry/reference.go
@@ -168,7 +168,7 @@ func splitRepository(path string) (string, string, bool) {
 		return repository, reference, false
 	}
 
-	if index = strings.Index(path, ":"); index != -1 {
+	if index := strings.Index(path, ":"); index != -1 {
 		// `tag` found; Valid Form C
 		return path[:index], path[index+1:], true
 	}


### PR DESCRIPTION
The ParseReference method is great for that, but the code in there could be shared to parse registries and repositories aka untagged references.