### PR TITLE
refactor(remote): make SetReferrersCapability not return an error

### DIFF
--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -60,8 +60,8 @@ type referrerChange struct {
 }
 
 var (
-	// ErrReferrersCapabilityAlreadySet is returned by SetReferrersCapability()
-	// when the Referrers API capability has been already set.
+	// ErrReferrersCapabilityAlreadySet is returned when the referrers API
+	// capability has already been set to a conflicting value.
 	ErrReferrersCapabilityAlreadySet = errors.New("referrers capability cannot be changed once set")
 
 	// errNoReferrerUpdate is returned by applyReferrerChanges() when there

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -213,31 +213,23 @@ func (r *Repository) clone() *Repository {
 // SetReferrersCapability indicates the Referrers API capability of the remote
 // repository. true: capable; false: not capable.
 //
-// SetReferrersCapability is valid only when it is called for the first time.
-// SetReferrersCapability returns ErrReferrersCapabilityAlreadySet if the
-// Referrers API capability has been already set.
+// SetReferrersCapability has no effect if the capability has already been set
+// to the same value. If the capability has been set to a conflicting value it
+// is silently ignored; the first value set wins.
 //   - When the capability is set to true, the Referrers() function will always
 //     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - When the capability is set to false, the Referrers() function will always
 //     request the Referrers Tag. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#referrers-tag-schema
 //   - When the capability is not set, the Referrers() function will automatically
 //     determine which API to use.
-func (r *Repository) SetReferrersCapability(capable bool) error {
+func (r *Repository) SetReferrersCapability(capable bool) {
 	var state referrersState
 	if capable {
 		state = referrersStateSupported
 	} else {
 		state = referrersStateUnsupported
 	}
-	if swapped := atomic.CompareAndSwapInt32(&r.referrersState, referrersStateUnknown, state); !swapped {
-		if fact := r.loadReferrersState(); fact != state {
-			return fmt.Errorf("%w: current capability = %v, new capability = %v",
-				ErrReferrersCapabilityAlreadySet,
-				fact == referrersStateSupported,
-				capable)
-		}
-	}
-	return nil
+	atomic.CompareAndSwapInt32(&r.referrersState, referrersStateUnknown, state)
 }
 
 // setReferrersState atomically loads r.referrersState.

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -7415,20 +7415,16 @@ func TestRepository_SetReferrersCapability(t *testing.T) {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
 	}
 
-	// valid first time set
-	if err := repo.SetReferrersCapability(true); err != nil {
-		t.Errorf("Repository.SetReferrersCapability() error = %v", err)
-	}
+	// first set
+	repo.SetReferrersCapability(true)
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
 		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
 	}
 
-	// invalid second time set, state should be no changed
-	if err := repo.SetReferrersCapability(false); !errors.Is(err, ErrReferrersCapabilityAlreadySet) {
-		t.Errorf("Repository.SetReferrersCapability() error = %v, wantErr %v", err, ErrReferrersCapabilityAlreadySet)
-	}
+	// conflicting second set is silently ignored; state should be unchanged
+	repo.SetReferrersCapability(false)
 	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+		t.Errorf("Repository.loadReferrersState() = %v, want %v (conflicting set should be ignored)", state, referrersStateSupported)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Simplifies the `SetReferrersCapability` API by removing the error return value; the operation sets internal state and has no failure mode that warrants an error return

## Test plan
- [ ] Unit tests pass (`make test`)