### PR TITLE
chore: sync OWNERS.md with main branch

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,8 +1,13 @@
 # Owners
 
 Owners:
+  - Andrew Block (@sabre1041)
+  - Shiwei Zhang (@shizhMSFT)
+  - Sylvia Lei (@Wwwsylvia)
+  - Terry Howe (@TerryHowe)
+
+Emeritus:
   - Avi Deitcher (@deitch)
   - Josh Dolitsky (@jdolitsky)
   - Sajay Antony (@sajayantony)
-  - Shiwei Zhang (@shizhMSFT)
   - Steve Lasker (@stevelasker)


### PR DESCRIPTION
## Summary

- Sync `OWNERS.md` on the `v1` branch to match the current state of `main`
- Adds Andrew Block, Sylvia Lei, and Terry Howe to the Owners list
- Moves Avi Deitcher, Josh Dolitsky, Sajay Antony, and Steve Lasker to Emeritus

## Test plan

- [ ] Verify `OWNERS.md` matches `main` branch content

🤖 Generated with [Claude Code](https://claude.com/claude-code)