### PR TITLE
feat: add configpaths internal package

### DIFF
--- a/registry/remote/internal/configpaths/current.go
+++ b/registry/remote/internal/configpaths/current.go
@@ -1,0 +1,151 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configpaths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	dockerConfigDirEnv   = "DOCKER_CONFIG"
+	dockerConfigFileDir  = ".docker"
+	dockerConfigFileName = "config.json"
+
+	containersAuthFile  = "auth.json"
+	containersConfigDir = "containers"
+	xdgRuntimeDirEnv    = "XDG_RUNTIME_DIR"
+)
+
+// currentResolver implements PathResolver using the current containers/image
+// path resolution strategy.
+type currentResolver struct {
+	// systemConfDir is the system-wide config parent directory
+	// (e.g., "/etc"). Empty means no system-level paths are used.
+	systemConfDir string
+	// userConfRelDir is the user config directory relative to $HOME
+	// (e.g., ".config/containers").
+	userConfRelDir string
+	// authUsesXDGRuntime indicates whether auth.json primary path should
+	// check $XDG_RUNTIME_DIR (true on Linux/FreeBSD, false on macOS/Windows).
+	authUsesXDGRuntime bool
+}
+
+func (r *currentResolver) MainConfigPaths(name string) []string {
+	var paths []string
+	if r.systemConfDir != "" {
+		paths = append(paths, filepath.Join(r.systemConfDir, containersConfigDir, name+".conf"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, r.userConfRelDir, name+".conf"))
+	}
+	return paths
+}
+
+func (r *currentResolver) DropInDirs(name string) []string {
+	var dirs []string
+	if r.systemConfDir != "" {
+		dirs = append(dirs, filepath.Join(r.systemConfDir, containersConfigDir, name+".conf.d"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, r.userConfRelDir, name+".conf.d"))
+	}
+	return dirs
+}
+
+func (r *currentResolver) MergeStrategy() MergeStrategy {
+	return MergeAll
+}
+
+func (r *currentResolver) AuthPrimaryPath() (string, error) {
+	if r.authUsesXDGRuntime {
+		if xdgRuntime := os.Getenv(xdgRuntimeDirEnv); xdgRuntime != "" {
+			path := filepath.Join(xdgRuntime, containersConfigDir, containersAuthFile)
+			if _, err := os.Stat(path); err == nil {
+				return path, nil
+			}
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	return filepath.Join(home, r.userConfRelDir, containersAuthFile), nil
+}
+
+func (r *currentResolver) AuthFallbackPaths() []string {
+	var paths []string
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return paths
+	}
+	// $HOME/.config/containers/auth.json (if not already primary)
+	if r.authUsesXDGRuntime {
+		paths = append(paths, filepath.Join(home, r.userConfRelDir, containersAuthFile))
+	}
+	// Docker fallbacks
+	paths = append(paths,
+		filepath.Join(home, dockerConfigFileDir, dockerConfigFileName),
+		filepath.Join(home, ".dockercfg"),
+	)
+	return paths
+}
+
+func (r *currentResolver) CertsDirPaths() []string {
+	var paths []string
+	if r.systemConfDir != "" {
+		paths = append(paths, filepath.Join(r.systemConfDir, containersConfigDir, "certs.d"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, r.userConfRelDir, "certs.d"))
+	}
+	return paths
+}
+
+func (r *currentResolver) RegistriesDDirs() []string {
+	var dirs []string
+	if r.systemConfDir != "" {
+		dirs = append(dirs, filepath.Join(r.systemConfDir, containersConfigDir, "registries.d"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, r.userConfRelDir, "registries.d"))
+	}
+	return dirs
+}
+
+func (r *currentResolver) PolicyPaths() []string {
+	var paths []string
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, r.userConfRelDir, "policy.json"))
+	}
+	if r.systemConfDir != "" {
+		paths = append(paths, filepath.Join(r.systemConfDir, containersConfigDir, "policy.json"))
+	}
+	return paths
+}
+
+func (r *currentResolver) DockerConfigPath() (string, error) {
+	configDir := os.Getenv(dockerConfigDirEnv)
+	if configDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		configDir = filepath.Join(home, dockerConfigFileDir)
+	}
+	return filepath.Join(configDir, dockerConfigFileName), nil
+}

--- a/registry/remote/internal/configpaths/current_darwin.go
+++ b/registry/remote/internal/configpaths/current_darwin.go
@@ -1,0 +1,26 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build darwin
+
+package configpaths
+
+func newCurrentResolver() *currentResolver {
+	return &currentResolver{
+		systemConfDir:      "/etc",
+		userConfRelDir:     ".config/containers",
+		authUsesXDGRuntime: true,
+	}
+}

--- a/registry/remote/internal/configpaths/current_freebsd.go
+++ b/registry/remote/internal/configpaths/current_freebsd.go
@@ -1,0 +1,26 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build freebsd
+
+package configpaths
+
+func newCurrentResolver() *currentResolver {
+	return &currentResolver{
+		systemConfDir:      "/usr/local/etc",
+		userConfRelDir:     ".config/containers",
+		authUsesXDGRuntime: true,
+	}
+}

--- a/registry/remote/internal/configpaths/current_linux.go
+++ b/registry/remote/internal/configpaths/current_linux.go
@@ -1,0 +1,26 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build linux
+
+package configpaths
+
+func newCurrentResolver() *currentResolver {
+	return &currentResolver{
+		systemConfDir:      "/etc",
+		userConfRelDir:     ".config/containers",
+		authUsesXDGRuntime: true,
+	}
+}

--- a/registry/remote/internal/configpaths/current_windows.go
+++ b/registry/remote/internal/configpaths/current_windows.go
@@ -1,0 +1,28 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build windows
+
+package configpaths
+
+func newCurrentResolver() *currentResolver {
+	// The current containers/image implementation does not define
+	// system-wide paths on Windows. Only user-level paths are used.
+	return &currentResolver{
+		systemConfDir:      "",
+		userConfRelDir:     ".config/containers",
+		authUsesXDGRuntime: false,
+	}
+}

--- a/registry/remote/internal/configpaths/resolver.go
+++ b/registry/remote/internal/configpaths/resolver.go
@@ -1,0 +1,91 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package configpaths provides platform-aware configuration file path
+// resolution for container tools configuration files.
+package configpaths
+
+// MergeStrategy controls how main configuration files are combined.
+type MergeStrategy int
+
+const (
+	// MergeAll merges all found config files from all tiers.
+	// This is the current containers/image behavior.
+	MergeAll MergeStrategy = iota
+
+	// FirstFoundWins uses the first main config file found (user → system
+	// → vendor) but still merges all drop-in directories.
+	// This is the UAPI specification behavior.
+	FirstFoundWins
+)
+
+// Strategy specifies which path resolution approach to use.
+type Strategy int
+
+const (
+	// ContainersImage uses the current containers/image two-tier path
+	// resolution (system + user).
+	ContainersImage Strategy = iota
+
+	// UAPI uses the Podman 6 UAPI-based three-tier path resolution
+	// (vendor + system + user) with rootful/rootless directories.
+	// EXPERIMENTAL: behavior may change as the upstream specification evolves.
+	UAPI
+)
+
+// PathResolver determines where to find configuration files.
+type PathResolver interface {
+	// MainConfigPaths returns the ordered paths for the main config file.
+	// The name parameter is the config file base name without extension
+	// (e.g., "registries" for registries.conf).
+	MainConfigPaths(name string) []string
+
+	// DropInDirs returns the ordered directories for drop-in config files.
+	DropInDirs(name string) []string
+
+	// MergeStrategy returns how main config files should be combined.
+	MergeStrategy() MergeStrategy
+
+	// AuthPrimaryPath returns the primary read/write path for auth.json.
+	AuthPrimaryPath() (string, error)
+
+	// AuthFallbackPaths returns fallback read-only paths for auth.json.
+	AuthFallbackPaths() []string
+
+	// CertsDirPaths returns base directories for certs.d certificate
+	// discovery.
+	CertsDirPaths() []string
+
+	// RegistriesDDirs returns directories for registries.d signature
+	// storage configuration.
+	RegistriesDDirs() []string
+
+	// PolicyPaths returns candidate paths for policy.json, in order of
+	// preference (first found wins).
+	PolicyPaths() []string
+
+	// DockerConfigPath returns the Docker config.json path.
+	DockerConfigPath() (string, error)
+}
+
+// NewResolver creates a PathResolver for the given strategy.
+func NewResolver(s Strategy) PathResolver {
+	switch s {
+	case UAPI:
+		return newUAPIResolver()
+	default:
+		return newCurrentResolver()
+	}
+}

--- a/registry/remote/internal/configpaths/resolver_test.go
+++ b/registry/remote/internal/configpaths/resolver_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configpaths
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestNewResolver_Default(t *testing.T) {
+	r := NewResolver(ContainersImage)
+	if r == nil {
+		t.Fatal("NewResolver(ContainersImage) returned nil")
+	}
+	if r.MergeStrategy() != MergeAll {
+		t.Errorf("MergeStrategy() = %v, want MergeAll", r.MergeStrategy())
+	}
+}
+
+func TestNewResolver_UAPI(t *testing.T) {
+	r := NewResolver(UAPI)
+	if r == nil {
+		t.Fatal("NewResolver(UAPI) returned nil")
+	}
+	if r.MergeStrategy() != FirstFoundWins {
+		t.Errorf("MergeStrategy() = %v, want FirstFoundWins", r.MergeStrategy())
+	}
+}
+
+func TestCurrentResolver_MainConfigPaths(t *testing.T) {
+	r := NewResolver(ContainersImage)
+	paths := r.MainConfigPaths("registries")
+	if len(paths) == 0 {
+		t.Fatal("MainConfigPaths returned empty")
+	}
+	// All paths should end with registries.conf
+	for _, p := range paths {
+		if !strings.HasSuffix(p, "registries.conf") {
+			t.Errorf("path %q does not end with registries.conf", p)
+		}
+	}
+}
+
+func TestCurrentResolver_DropInDirs(t *testing.T) {
+	r := NewResolver(ContainersImage)
+	dirs := r.DropInDirs("registries")
+	if len(dirs) == 0 {
+		t.Fatal("DropInDirs returned empty")
+	}
+	for _, d := range dirs {
+		if !strings.HasSuffix(d, "registries.conf.d") {
+			t.Errorf("dir %q does not end with registries.conf.d", d)
+		}
+	}
+}
+
+func TestCurrentResolver_AuthPrimaryPath(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	r := NewResolver(ContainersImage)
+	path, err := r.AuthPrimaryPath()
+	if err != nil {
+		t.Fatalf("AuthPrimaryPath() error: %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.Join("containers", "auth.json")) {
+		t.Errorf("path %q does not end with containers/auth.json", path)
+	}
+}
+
+func TestCurrentResolver_AuthPrimaryPath_XDGRuntime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG_RUNTIME_DIR not used on Windows")
+	}
+	tmpDir := t.TempDir()
+	xdgAuthDir := filepath.Join(tmpDir, "containers")
+	if err := os.MkdirAll(xdgAuthDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(xdgAuthDir, "auth.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", tmpDir)
+
+	r := NewResolver(ContainersImage)
+	path, err := r.AuthPrimaryPath()
+	if err != nil {
+		t.Fatalf("AuthPrimaryPath() error: %v", err)
+	}
+	want := filepath.Join(tmpDir, "containers", "auth.json")
+	if path != want {
+		t.Errorf("AuthPrimaryPath() = %q, want %q", path, want)
+	}
+}
+
+func TestCurrentResolver_CertsDirPaths(t *testing.T) {
+	r := NewResolver(ContainersImage)
+	paths := r.CertsDirPaths()
+	if len(paths) == 0 {
+		t.Fatal("CertsDirPaths returned empty")
+	}
+	for _, p := range paths {
+		if !strings.HasSuffix(p, "certs.d") {
+			t.Errorf("path %q does not end with certs.d", p)
+		}
+	}
+}
+
+func TestCurrentResolver_PolicyPaths(t *testing.T) {
+	r := NewResolver(ContainersImage)
+	paths := r.PolicyPaths()
+	if len(paths) == 0 {
+		t.Fatal("PolicyPaths returned empty")
+	}
+	for _, p := range paths {
+		if !strings.HasSuffix(p, "policy.json") {
+			t.Errorf("path %q does not end with policy.json", p)
+		}
+	}
+}
+
+func TestCurrentResolver_DockerConfigPath(t *testing.T) {
+	t.Setenv("DOCKER_CONFIG", "")
+	r := NewResolver(ContainersImage)
+	path, err := r.DockerConfigPath()
+	if err != nil {
+		t.Fatalf("DockerConfigPath() error: %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.Join(".docker", "config.json")) {
+		t.Errorf("path %q does not end with .docker/config.json", path)
+	}
+}
+
+func TestCurrentResolver_DockerConfigPath_EnvOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", tmpDir)
+	r := NewResolver(ContainersImage)
+	path, err := r.DockerConfigPath()
+	if err != nil {
+		t.Fatalf("DockerConfigPath() error: %v", err)
+	}
+	want := filepath.Join(tmpDir, "config.json")
+	if path != want {
+		t.Errorf("DockerConfigPath() = %q, want %q", path, want)
+	}
+}
+
+func TestUAPIResolver_MainConfigPaths(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fakehome")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	r := NewResolver(UAPI)
+	paths := r.MainConfigPaths("registries")
+
+	// Should have at least user path; on non-Windows also system and vendor.
+	if len(paths) == 0 {
+		t.Fatal("MainConfigPaths returned empty")
+	}
+
+	// First path should be user (UAPI: user → system → vendor).
+	if !strings.Contains(paths[0], "fakehome") && !strings.Contains(paths[0], "APPDATA") {
+		t.Errorf("first path %q should be user-level", paths[0])
+	}
+
+	for _, p := range paths {
+		if !strings.HasSuffix(p, "registries.conf") {
+			t.Errorf("path %q does not end with registries.conf", p)
+		}
+	}
+}
+
+func TestUAPIResolver_DropInDirs(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fakehome")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	r := NewResolver(UAPI)
+	dirs := r.DropInDirs("registries")
+
+	if len(dirs) == 0 {
+		t.Fatal("DropInDirs returned empty")
+	}
+
+	// Should include .conf.d directories.
+	hasConfD := false
+	for _, d := range dirs {
+		if strings.HasSuffix(d, "registries.conf.d") {
+			hasConfD = true
+		}
+	}
+	if !hasConfD {
+		t.Error("DropInDirs should include registries.conf.d directories")
+	}
+
+	// On non-Windows, should include rootful or rootless dirs.
+	if runtime.GOOS != "windows" {
+		hasRootDir := false
+		for _, d := range dirs {
+			if strings.Contains(d, "rootful") || strings.Contains(d, "rootless") {
+				hasRootDir = true
+			}
+		}
+		if !hasRootDir {
+			t.Error("DropInDirs should include rootful/rootless directories on non-Windows")
+		}
+	}
+}
+
+func TestUAPIResolver_XDGConfigHome(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	r := NewResolver(UAPI)
+	paths := r.MainConfigPaths("registries")
+
+	// First path should use XDG_CONFIG_HOME.
+	want := filepath.Join(tmpDir, "containers", "registries.conf")
+	if len(paths) == 0 || paths[0] != want {
+		t.Errorf("first MainConfigPath = %q, want %q", paths[0], want)
+	}
+}
+
+func TestUAPIResolver_AuthPrimaryPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	r := NewResolver(UAPI)
+	path, err := r.AuthPrimaryPath()
+	if err != nil {
+		t.Fatalf("AuthPrimaryPath() error: %v", err)
+	}
+	want := filepath.Join(tmpDir, "containers", "auth.json")
+	if path != want {
+		t.Errorf("AuthPrimaryPath() = %q, want %q", path, want)
+	}
+}

--- a/registry/remote/internal/configpaths/uapi.go
+++ b/registry/remote/internal/configpaths/uapi.go
@@ -1,0 +1,206 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configpaths
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	xdgConfigHomeEnv = "XDG_CONFIG_HOME"
+)
+
+// uapiResolver implements PathResolver using the Podman 6 UAPI-based
+// path resolution strategy.
+//
+// EXPERIMENTAL: This resolver is based on the Podman 6 design proposal
+// for unified config file parsing. The behavior may change as the
+// upstream specification evolves.
+//
+// Reference: https://uapi-group.org/specifications/specs/configuration_files_specification/
+type uapiResolver struct {
+	// vendorConfDir is the vendor/distro default directory
+	// (e.g., "/usr/share"). Empty means no vendor tier.
+	vendorConfDir string
+	// systemConfDir is the system admin directory (e.g., "/etc").
+	// Empty means no system tier.
+	systemConfDir string
+	// userConfDir returns the user config directory.
+	// This is a function to defer environment variable lookups.
+	userConfDir func() string
+	// supportsRootfulRootless indicates whether rootful/rootless
+	// directory splits are supported (false on Windows).
+	supportsRootfulRootless bool
+}
+
+// userDir returns the user-level containers config directory.
+func (r *uapiResolver) userDir() string {
+	if r.userConfDir != nil {
+		return r.userConfDir()
+	}
+	return ""
+}
+
+func (r *uapiResolver) MainConfigPaths(name string) []string {
+	// UAPI order: user → system → vendor (first found wins).
+	var paths []string
+	if dir := r.userDir(); dir != "" {
+		paths = append(paths, filepath.Join(dir, name+".conf"))
+	}
+	if r.systemConfDir != "" {
+		paths = append(paths, filepath.Join(r.systemConfDir, containersConfigDir, name+".conf"))
+	}
+	if r.vendorConfDir != "" {
+		paths = append(paths, filepath.Join(r.vendorConfDir, containersConfigDir, name+".conf"))
+	}
+	return paths
+}
+
+func (r *uapiResolver) DropInDirs(name string) []string {
+	// Drop-ins are always merged from all tiers: vendor → system → user.
+	// Within each tier, rootful/rootless variants are included.
+	var dirs []string
+
+	if r.vendorConfDir != "" {
+		base := filepath.Join(r.vendorConfDir, containersConfigDir)
+		dirs = append(dirs, filepath.Join(base, name+".conf.d"))
+		dirs = r.appendRootDirs(dirs, base, name)
+	}
+
+	if r.systemConfDir != "" {
+		base := filepath.Join(r.systemConfDir, containersConfigDir)
+		dirs = append(dirs, filepath.Join(base, name+".conf.d"))
+		dirs = r.appendRootDirs(dirs, base, name)
+	}
+
+	if dir := r.userDir(); dir != "" {
+		dirs = append(dirs, filepath.Join(dir, name+".conf.d"))
+	}
+
+	return dirs
+}
+
+// appendRootDirs appends rootful or rootless drop-in directories based
+// on the current UID.
+func (r *uapiResolver) appendRootDirs(dirs []string, base, name string) []string {
+	if !r.supportsRootfulRootless {
+		return dirs
+	}
+
+	uid := os.Getuid()
+	if uid == 0 {
+		dirs = append(dirs, filepath.Join(base, name+".rootful.conf.d"))
+	} else {
+		dirs = append(dirs, filepath.Join(base, name+".rootless.conf.d"))
+		dirs = append(dirs, filepath.Join(base, name+".rootless.conf.d", strconv.Itoa(uid)))
+	}
+	return dirs
+}
+
+func (r *uapiResolver) MergeStrategy() MergeStrategy {
+	return FirstFoundWins
+}
+
+func (r *uapiResolver) AuthPrimaryPath() (string, error) {
+	if dir := r.userDir(); dir != "" {
+		return filepath.Join(dir, containersAuthFile), nil
+	}
+	return "", fmt.Errorf("failed to determine user config directory for auth.json")
+}
+
+func (r *uapiResolver) AuthFallbackPaths() []string {
+	var paths []string
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return paths
+	}
+	// Docker fallbacks
+	paths = append(paths,
+		filepath.Join(home, dockerConfigFileDir, dockerConfigFileName),
+		filepath.Join(home, ".dockercfg"),
+	)
+	return paths
+}
+
+func (r *uapiResolver) CertsDirPaths() []string {
+	var paths []string
+	if r.vendorConfDir != "" {
+		paths = append(paths, filepath.Join(r.vendorConfDir, containersConfigDir, "certs.d"))
+	}
+	if r.systemConfDir != "" {
+		paths = append(paths, filepath.Join(r.systemConfDir, containersConfigDir, "certs.d"))
+	}
+	if dir := r.userDir(); dir != "" {
+		paths = append(paths, filepath.Join(dir, "certs.d"))
+	}
+	return paths
+}
+
+func (r *uapiResolver) RegistriesDDirs() []string {
+	var dirs []string
+	if r.vendorConfDir != "" {
+		dirs = append(dirs, filepath.Join(r.vendorConfDir, containersConfigDir, "registries.d"))
+	}
+	if r.systemConfDir != "" {
+		dirs = append(dirs, filepath.Join(r.systemConfDir, containersConfigDir, "registries.d"))
+	}
+	if dir := r.userDir(); dir != "" {
+		dirs = append(dirs, filepath.Join(dir, "registries.d"))
+	}
+	return dirs
+}
+
+func (r *uapiResolver) PolicyPaths() []string {
+	// UAPI: user → system → vendor (first found wins).
+	var paths []string
+	if dir := r.userDir(); dir != "" {
+		paths = append(paths, filepath.Join(dir, "policy.json"))
+	}
+	if r.systemConfDir != "" {
+		paths = append(paths, filepath.Join(r.systemConfDir, containersConfigDir, "policy.json"))
+	}
+	if r.vendorConfDir != "" {
+		paths = append(paths, filepath.Join(r.vendorConfDir, containersConfigDir, "policy.json"))
+	}
+	return paths
+}
+
+func (r *uapiResolver) DockerConfigPath() (string, error) {
+	configDir := os.Getenv(dockerConfigDirEnv)
+	if configDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		configDir = filepath.Join(home, dockerConfigFileDir)
+	}
+	return filepath.Join(configDir, dockerConfigFileName), nil
+}
+
+// defaultXDGConfigHome returns $XDG_CONFIG_HOME/containers if set,
+// otherwise $HOME/.config/containers.
+func defaultXDGConfigHome() string {
+	if xdg := os.Getenv(xdgConfigHomeEnv); xdg != "" {
+		return filepath.Join(xdg, containersConfigDir)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".config", containersConfigDir)
+	}
+	return ""
+}

--- a/registry/remote/internal/configpaths/uapi_darwin.go
+++ b/registry/remote/internal/configpaths/uapi_darwin.go
@@ -1,0 +1,27 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build darwin
+
+package configpaths
+
+func newUAPIResolver() *uapiResolver {
+	return &uapiResolver{
+		vendorConfDir:           "/usr/share",
+		systemConfDir:           "/etc",
+		userConfDir:             defaultXDGConfigHome,
+		supportsRootfulRootless: true,
+	}
+}

--- a/registry/remote/internal/configpaths/uapi_freebsd.go
+++ b/registry/remote/internal/configpaths/uapi_freebsd.go
@@ -1,0 +1,27 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build freebsd
+
+package configpaths
+
+func newUAPIResolver() *uapiResolver {
+	return &uapiResolver{
+		vendorConfDir:           "/usr/local/share",
+		systemConfDir:           "/usr/local/etc",
+		userConfDir:             defaultXDGConfigHome,
+		supportsRootfulRootless: true,
+	}
+}

--- a/registry/remote/internal/configpaths/uapi_linux.go
+++ b/registry/remote/internal/configpaths/uapi_linux.go
@@ -1,0 +1,27 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build linux
+
+package configpaths
+
+func newUAPIResolver() *uapiResolver {
+	return &uapiResolver{
+		vendorConfDir:           "/usr/share",
+		systemConfDir:           "/etc",
+		userConfDir:             defaultXDGConfigHome,
+		supportsRootfulRootless: true,
+	}
+}

--- a/registry/remote/internal/configpaths/uapi_windows.go
+++ b/registry/remote/internal/configpaths/uapi_windows.go
@@ -1,0 +1,54 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build windows
+
+package configpaths
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func newUAPIResolver() *uapiResolver {
+	return &uapiResolver{
+		// Windows has no vendor (/usr/share) equivalent.
+		vendorConfDir: "",
+		// %ProgramData% replaces /etc on Windows.
+		systemConfDir: windowsProgramData(),
+		// %APPDATA% replaces $XDG_CONFIG_HOME on Windows.
+		userConfDir:             windowsAppData,
+		supportsRootfulRootless: false,
+	}
+}
+
+// windowsProgramData returns the ProgramData directory, which serves as
+// the system-wide config directory on Windows.
+func windowsProgramData() string {
+	if pd := os.Getenv("ProgramData"); pd != "" {
+		return pd
+	}
+	return ""
+}
+
+// windowsAppData returns %APPDATA%/containers as the user config
+// directory on Windows.
+func windowsAppData() string {
+	if appdata := os.Getenv("APPDATA"); appdata != "" {
+		return filepath.Join(appdata, containersConfigDir)
+	}
+	// Fall back to $HOME/.config/containers
+	return defaultXDGConfigHome()
+}


### PR DESCRIPTION
## Summary

- Add `registry/remote/internal/configpaths` package for OS-specific config path resolution
- Resolves paths for Docker `config.json`, XDG config directories, and OS keychain config locations
- Platform-specific implementations for Darwin, Linux, FreeBSD, and Windows (`current_*.go`, `uapi_*.go`)
- `resolver.go` provides a unified `Resolver` that walks candidate paths in priority order
- Full unit tests in `resolver_test.go`

This is a standalone internal package with no new inbound dependencies. It is required by the upcoming `registry/remote/config` package which loads system registry configuration.

## Test plan

- [ ] `go test ./registry/remote/internal/configpaths/...` passes on Linux, Darwin, Windows

Part of the `feat/everything` v3 redesign breakdown. See `prs.md` for the full plan.