### PR TITLE
chore: upgrade actions/stale to v10.2.0 for Node 24 support

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v10.2.0
         with:
           stale-issue-message: "This issue is stale because it has been open for 60 days with no activity. Remove the stale label or comment to prevent it from being closed in 30 days."
           stale-pr-message: "This PR is stale because it has been open for 45 days with no activity. Remove the stale label or comment to prevent it from being closed in 30 days."


### PR DESCRIPTION
## Summary

- Upgrades `actions/stale` from `v10` to `v10.2.0` which uses Node 24

## Background

GitHub deprecated Node 20 in GitHub Actions runners with a hard deadline of **June 2, 2026**, after which runners will switch to Node 24 by default. The `actions/stale@v10` tag was pointing to an older release using Node 20; v10.2.0 (released Feb 2026) includes Node 24 support.

The other workflows (`build.yml`, `codeql-analysis.yml`, `license-checker.yml`) already use Node 24-compatible action versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)