### PR TITLE
fix: validate Location host before blob upload to prevent credential leak

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -872,6 +873,25 @@ func (s *blobStore) Push(ctx context.Context, expected ocispec.Descriptor, conte
 	return s.completePushAfterInitialPost(ctx, req, resp, expected, content)
 }
 
+// sameUploadHost reports whether location and reqURL refer to the same host,
+// normalizing implicit default ports (80 for http, 443 for https) so that
+// e.g. "example.com" and "example.com:443" compare equal over HTTPS.
+func sameUploadHost(location, reqURL *url.URL) bool {
+	if location.Hostname() != reqURL.Hostname() {
+		return false
+	}
+	canonicalPort := func(u *url.URL) string {
+		if p := u.Port(); p != "" {
+			return p
+		}
+		if u.Scheme == "https" {
+			return "443"
+		}
+		return "80"
+	}
+	return canonicalPort(location) == canonicalPort(reqURL)
+}
+
 // completePushAfterInitialPost implements step 2 of the push protocol. This can be invoked either by
 // Push or by Mount when the receiving repository does not implement the
 // mount endpoint.
@@ -893,6 +913,15 @@ func (s *blobStore) completePushAfterInitialPost(ctx context.Context, req *http.
 	// if location port 443 is missing, add it back
 	if reqPort == "443" && locationHostname == reqHostname && locationPort == "" {
 		location.Host = locationHostname + ":" + reqPort
+	}
+	// Validate the Location stays on the same host to prevent credentials from
+	// being forwarded to an attacker-controlled endpoint.
+	// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-jxpm-75mh-9fp7
+	if !sameUploadHost(location, req.URL) {
+		return fmt.Errorf("blob upload Location %q is on a different host than the registry %q", location.Host, req.URL.Host)
+	}
+	if req.URL.Scheme == "https" && location.Scheme != "https" {
+		return fmt.Errorf("blob upload Location %q downgrades scheme from https", location.Host)
 	}
 	url := location.String()
 	req, err = http.NewRequestWithContext(ctx, http.MethodPut, url, content)

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3111,6 +3111,58 @@ func Test_BlobStore_Push(t *testing.T) {
 	}
 }
 
+func Test_BlobStore_Push_CrossHostRedirect(t *testing.T) {
+	blob := []byte("hello world")
+	blobDesc := ocispec.Descriptor{
+		MediaType: "test",
+		Digest:    digest.FromBytes(blob),
+		Size:      int64(len(blob)),
+	}
+
+	// attacker server: records whether it receives an Authorization header
+	credentialLeaked := false
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			credentialLeaked = true
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer attacker.Close()
+
+	// malicious registry: returns a cross-host Location on POST
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v2/test/blobs/uploads/" {
+			w.Header().Set("Location", attacker.URL+"/v2/test/blobs/uploads/evil-uuid")
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+	}))
+	defer ts.Close()
+
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	store := repo.Blobs()
+	ctx := context.Background()
+
+	err = store.Push(ctx, blobDesc, bytes.NewReader(blob))
+	if err == nil {
+		t.Error("Blobs.Push() expected error on cross-host Location, got nil")
+	}
+	if credentialLeaked {
+		t.Error("Blobs.Push() forwarded Authorization header to attacker-controlled host")
+	}
+}
+
 func Test_BlobStore_Exists(t *testing.T) {
 	blob := []byte("hello world")
 	blobDesc := ocispec.Descriptor{


### PR DESCRIPTION
## Summary

Fixes GHSA-jxpm-75mh-9fp7: credential forwarding via unvalidated `Location` header in blob upload.

During the monolithic blob upload flow, `completePushAfterInitialPost` follows the `Location` header from the registry's `POST` response and reuses the `Authorization` header for the subsequent `PUT`. A malicious registry can return a cross-host `Location`, causing oras-go to forward the caller's credentials to an attacker-controlled endpoint.

### Changes

- **`registry/remote/repository.go`**: After the existing port-443 workaround, validate that `location.Host` resolves to the same server as the original request before issuing the `PUT`. Also reject scheme downgrades (`https` → `http`). Adds `sameUploadHost()` helper that normalises implicit default ports (80/443) so that `example.com` and `example.com:443` compare equal over HTTPS — preserving the existing port-443 workaround behaviour.

- **`registry/remote/repository_test.go`**: Adds `Test_BlobStore_Push_CrossHostRedirect` — a malicious registry returns a cross-host `Location`; a second "attacker" server records whether it received an `Authorization` header. Asserts that `Push` returns an error and no credentials leak.

## Test plan

- [ ] `go test ./registry/remote/ -run Test_BlobStore_Push` — all four push tests pass (including the port-443 workaround tests)
- [ ] `go test ./...` — full suite passes with no regressions
- [ ] `Test_BlobStore_Push_CrossHostRedirect` explicitly verifies the fix

## References

- Advisory: https://github.com/oras-project/oras-go/security/advisories/GHSA-jxpm-75mh-9fp7
- Vulnerable function: `registry/remote/repository.go` → `blobStore.completePushAfterInitialPost`
- CWE-918 (SSRF), CVSS 7.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)