### PR TITLE
fix(content): reject descriptor sizes exceeding 32 MiB in ReadAll

### DIFF
--- a/content/reader.go
+++ b/content/reader.go
@@ -24,6 +24,12 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// maxDescriptorSize is the upper-bound for descriptor sizes accepted by
+// ReadAll. Descriptors sourced from attacker-supplied OCI layouts can carry
+// arbitrarily large Size values; without this cap, make([]byte, desc.Size)
+// triggers a runtime panic before any allocation occurs.
+const maxDescriptorSize = 32 * 1024 * 1024 // 32 MiB
+
 var (
 	// ErrInvalidDescriptorSize is returned by ReadAll() when
 	// the descriptor has an invalid size.
@@ -119,7 +125,7 @@ func NewVerifyReader(r io.Reader, desc ocispec.Descriptor) *VerifyReader {
 // The read content is verified against the size and the digest
 // using a VerifyReader.
 func ReadAll(r io.Reader, desc ocispec.Descriptor) ([]byte, error) {
-	if desc.Size < 0 {
+	if desc.Size < 0 || desc.Size > maxDescriptorSize {
 		return nil, ErrInvalidDescriptorSize
 	}
 	buf := make([]byte, desc.Size)

--- a/content/reader_test.go
+++ b/content/reader_test.go
@@ -260,3 +260,17 @@ func TestReadAll_InvalidDescriptorSize(t *testing.T) {
 		t.Errorf("ReadAll() error = %v, want %v", err, ErrInvalidDescriptorSize)
 	}
 }
+
+func TestReadAll_OversizedDescriptor(t *testing.T) {
+	content := []byte("example content")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(content),
+		Size:      4611686018427387904, // 2^62, triggers makeslice panic without the cap
+	}
+	r := bytes.NewReader(content)
+	_, err := ReadAll(r, desc)
+	if err == nil || !errors.Is(err, ErrInvalidDescriptorSize) {
+		t.Errorf("ReadAll() error = %v, want %v", err, ErrInvalidDescriptorSize)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `maxDescriptorSize` constant (32 MiB) in `content/reader.go`
- Rejects any descriptor whose `Size` exceeds this limit in `ReadAll()` with `ErrInvalidDescriptorSize`, the same error already returned for negative sizes
- Adds `TestReadAll_OversizedDescriptor` to confirm a 2^62 size value is safely rejected without panic

Fixes GHSA-f36w-mj3v-6jqv

### Root cause

`ReadAll()` only checked for negative `Size` values. A crafted OCI layout `index.json` can supply a large positive `Size` (e.g. `4611686018427387904`, or 2^62), causing `make([]byte, desc.Size)` to trigger a Go runtime panic (`makeslice: len out of range`) before any allocation occurs. The `recover()` in `syncutil/once.go` unconditionally re-panics, so the ORAS process terminates unconditionally.

This is reachable via any ORAS CLI command that accepts `--oci-layout`, `--from-oci-layout`, or `--input` flags (`cp`, `pull`, `restore`, `manifest fetch`, `repo tags`, `resolve`, `discover`).

### Fix

```go
const maxDescriptorSize = 32 * 1024 * 1024 // 32 MiB

func ReadAll(r io.Reader, desc ocispec.Descriptor) ([]byte, error) {
    if desc.Size < 0 || desc.Size > maxDescriptorSize {
        return nil, ErrInvalidDescriptorSize
    }
    ...
}
```

## Test plan

- [x] `TestReadAll_OversizedDescriptor` — verifies `Size: 4611686018427387904` returns `ErrInvalidDescriptorSize` without panic
- [x] All existing `TestReadAll_*` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)