### PR TITLE
feat: add gitops release workflow with goreleaser

### DIFF
--- a/.github/act/release-event.json
+++ b/.github/act/release-event.json
@@ -1,0 +1,23 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "merged": true,
+    "number": 999,
+    "title": "chore: prepare release v2.7.0",
+    "body": "## New Features\n\n* Test feature\n\n## Bug Fixes\n\n* Test fix",
+    "head": {
+      "ref": "release/v2.7.0",
+      "sha": "abc123def456"
+    },
+    "base": {
+      "ref": "v2"
+    }
+  },
+  "repository": {
+    "full_name": "oras-project/oras-go",
+    "name": "oras-go",
+    "owner": {
+      "login": "oras-project"
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,15 @@ jobs:
           VERSION="${BRANCH#release/}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Validate semantic version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! [[ "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+            echo "Error: '$VERSION' does not follow semantic versioning"
+            echo "Expected: vX.Y.Z or vX.Y.Z-(alpha|beta|rc).N"
+            exit 1
+          fi
+
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -57,13 +58,13 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.version.outputs.version }}
+          git tag ${{ steps.version.outputs.version }} ${{ github.event.pull_request.merge_commit_sha }}
           git push origin ${{ steps.version.outputs.version }}
 
       - name: Write release notes from PR body
         env:
           NOTES: ${{ github.event.pull_request.body }}
-        run: echo "$NOTES" > /tmp/release-notes.md
+        run: printf '%s\n' "$NOTES" > /tmp/release-notes.md
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - v2
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}
+
+      - name: Write release notes from PR body
+        env:
+          NOTES: ${{ github.event.pull_request.body }}
+        run: echo "$NOTES" > /tmp/release-notes.md
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean --release-notes /tmp/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "$NOTES" > /tmp/release-notes.md
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: release --clean --release-notes /tmp/release-notes.md

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,9 +17,6 @@ version: 2
 builds:
   - skip: true
 
-archives:
-  - skip: true
-
 checksum:
   disable: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+# oras-go is a library — no binary builds or archives needed.
+builds:
+  - skip: true
+
+archives:
+  - skip: true
+
+checksum:
+  disable: true
+
+release:
+  # Tags containing -alpha, -beta, or -rc are automatically marked pre-release.
+  prerelease: auto
+  draft: false

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -67,6 +67,39 @@ Tags containing `-alpha`, `-beta`, or `-rc` (e.g., `v2.7.0-rc.1`) are
 automatically marked as pre-release on GitHub. Use the same branch naming
 convention: `release/v2.7.0-rc.1`.
 
+## Testing the workflow locally
+
+Three levels of local validation are available without triggering a real release:
+
+**1. Validate the goreleaser config:**
+```bash
+goreleaser check
+```
+
+**2. Validate workflow structure and job matching (dry run):**
+```bash
+act pull_request \
+  -e .github/act/release-event.json \
+  -W .github/workflows/release.yml \
+  -n
+```
+
+**3. Run the workflow end-to-end with a fake token (Colima + cached actions required):**
+```bash
+act pull_request \
+  -e .github/act/release-event.json \
+  -W .github/workflows/release.yml \
+  -s GITHUB_TOKEN=fake \
+  --pull=false \
+  --action-offline-mode \
+  --container-daemon-socket -
+```
+
+This runs all steps up to and including version extraction (`version=vX.Y.Z` will
+appear in the output). The `git push` step then fails with a permission error —
+that is expected and confirms no tag was pushed. The mock event payload is at
+`.github/act/release-event.json`.
+
 ## Updating the documentation site
 
 After a release, update [oras-www](https://github.com/oras-project/oras-www)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,8 +18,9 @@ git push origin release/v2.7.0
 ```
 
 The release does not need to contain the changes being released — those are
-already on `v2`. The PR is a trigger: when it merges, the workflow tags
-whatever commit `v2` is at, which includes all prior work on the branch.
+already on `v2`. The PR is a trigger: when it merges, the workflow tags the
+PR's `merge_commit_sha` (the exact commit that landed on `v2`), which includes
+all prior work on the branch.
 
 ### 2. Open a pull request
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,66 @@
+# Releasing oras-go
+
+Releases are created via a GitOps workflow. Merging a `release/vX.Y.Z` branch
+into `v2` automatically tags the commit and publishes the GitHub Release.
+
+## Steps
+
+### 1. Create a release branch
+
+```bash
+git fetch upstream
+git checkout -b release/v2.7.0 upstream/v2
+git push origin release/v2.7.0
+```
+
+### 2. Open a pull request
+
+Open a PR from `release/v2.7.0` targeting the `v2` branch. Write the release
+notes directly in the PR description using the format from prior releases:
+
+```markdown
+## New Features
+...
+
+## Bug Fixes
+...
+
+## Documentation
+...
+
+## Other Changes
+...
+```
+
+The PR description becomes the GitHub Release body verbatim, so write it in
+its final form.
+
+### 3. Get approvals
+
+Branch protection on `v2` requires approval from at least 3 of the 4 owners
+listed in [OWNERS.md](OWNERS.md). Reviewers should verify:
+
+- The target commit is correct
+- The release notes are accurate and complete
+- All CI checks pass
+
+### 4. Merge
+
+Merge the PR. The [release workflow](.github/workflows/release.yml)
+automatically:
+
+1. Extracts the version from the branch name (`release/v2.7.0` → `v2.7.0`)
+2. Creates and pushes the git tag
+3. Publishes the GitHub Release with the PR body as release notes
+
+## Pre-releases
+
+Tags containing `-alpha`, `-beta`, or `-rc` (e.g., `v2.7.0-rc.1`) are
+automatically marked as pre-release on GitHub. Use the same branch naming
+convention: `release/v2.7.0-rc.1`.
+
+## Updating the documentation site
+
+After a release, update [oras-www](https://github.com/oras-project/oras-www)
+to reflect the new version. See the `CLAUDE.md` in that repository for the
+exact steps.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,11 +7,19 @@ into `v2` automatically tags the commit and publishes the GitHub Release.
 
 ### 1. Create a release branch
 
+The release branch needs at least one commit so GitHub will allow a PR to be
+opened. Use an empty commit as a lightweight marker:
+
 ```bash
 git fetch upstream
 git checkout -b release/v2.7.0 upstream/v2
+git commit --allow-empty -s -m "chore: prepare release v2.7.0"
 git push origin release/v2.7.0
 ```
+
+The release does not need to contain the changes being released — those are
+already on `v2`. The PR is a trigger: when it merges, the workflow tags
+whatever commit `v2` is at, which includes all prior work on the branch.
 
 ### 2. Open a pull request
 


### PR DESCRIPTION
## Summary

Replaces the manual issue-vote → tag → release process with a PR-based GitOps workflow.

## Changes

- **`.goreleaser.yaml`** — Minimal config for a Go library (no binary builds, archives, or checksums). `prerelease: auto` marks tags containing `-alpha`, `-beta`, or `-rc` as pre-release on GitHub.
- **`.github/workflows/release.yml`** — Triggers on merge of a `release/vX.Y.Z` branch into `v2`. Extracts the version from the branch name, tags the merge commit, and publishes the GitHub Release using the PR body as release notes. The `goreleaser/goreleaser-action` is pinned to `e435ccd` (v6.4.0).
- **`RELEASES.md`** — Documents the full release process, the `--allow-empty` branch convention, and three levels of local testing with `act`.
- **`.github/act/release-event.json`** — Mock PR event payload for local workflow testing.

## How a release works

1. Create a branch named `release/vX.Y.Z` from `v2` with an empty commit (required for GitHub to allow a PR with no code diff):
   ```bash
   git fetch upstream
   git checkout -b release/v2.7.0 upstream/v2
   git commit --allow-empty -s -m "chore: prepare release v2.7.0"
   git push origin release/v2.7.0
   ```
2. Open a PR to `v2` — write the release notes in the PR description (same format as today's release issues)
3. Get the required approvals via branch protection (replaces the issue vote)
4. Merge — the workflow automatically tags the commit and publishes the GitHub Release using the PR body as release notes

The release PR does not need to contain the changes being released — those are already on `v2`. The PR is purely a trigger.

## Local testing

Three levels of validation are available without triggering a real release:

```bash
# 1. Validate goreleaser config
goreleaser check

# 2. Validate workflow structure and job matching (dry run)
act pull_request -e .github/act/release-event.json -W .github/workflows/release.yml -n

# 3. Full end-to-end run (Colima + cached actions required)
act pull_request \
  -e .github/act/release-event.json \
  -W .github/workflows/release.yml \
  -s GITHUB_TOKEN=fake \
  --pull=false \
  --action-offline-mode \
  --container-daemon-socket -
```

The end-to-end run executes through checkout → Go setup → version extraction (printing `version=vX.Y.Z`) → then fails at `git push` with a permission error. That is the expected safe stopping point — no tag is pushed and no release is created.

## Notes

- Branch protection on `v2` should require the same approval quorum currently used in release issues (3 of 4 owners)
- Pre-release tags (`-alpha`, `-beta`, `-rc`) are automatically marked as pre-release on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)