### PR TITLE
ci: fix v1 build workflow go version and pin action digests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: setup go environment
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.23'
+          go-version-file: 'go.mod'
       - name: run unit tests
         run: make test
       - name: run acceptance tests
@@ -21,7 +21,7 @@ jobs:
           export LOCAL_REGISTRY_HOSTNAME="$(hostname -I | awk '{print $1}')"
           make acceptance
       - name: upload coverage report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: oras-coverage-report-${{ github.sha }}
           path: .cover/


### PR DESCRIPTION
Update actions/checkout, actions/setup-go, and actions/upload-artifact to current versions pinned by digest. Switch from go-version '1.23' to go-version-file to pick up the go 1.25.5 requirement from go.mod, which has been causing all v1 builds to fail since April 24.