### PR TITLE
fix(remote): tolerate Content-Length mismatch in manifest fetch

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1237,9 +1237,10 @@ func (s *manifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (r
 	if mediaType != target.MediaType {
 		return nil, fmt.Errorf("%s %q: mismatch response Content-Type %q: expect %q", resp.Request.Method, resp.Request.URL, mediaType, target.MediaType)
 	}
-	if size := resp.ContentLength; size != -1 && size != target.Size {
-		return nil, fmt.Errorf("%s %q: mismatch Content-Length", resp.Request.Method, resp.Request.URL)
-	}
+	// Content-Length is not validated here because some registries (e.g. Harbor)
+	// return different values between HEAD (used by Resolve) and GET responses,
+	// typically due to transparent compression. Integrity is guaranteed by
+	// verifyContentDigest below.
 	if err := verifyContentDigest(resp, target.Digest); err != nil {
 		return nil, err
 	}

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3930,7 +3930,10 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		}
 	})
 
-	t.Run("fail with mismatching Content-Length", func(t *testing.T) {
+	// Content-Length mismatches are tolerated for manifests because some
+	// registries (e.g. Harbor) return different values between HEAD (Resolve)
+	// and GET responses. Integrity is guaranteed by the digest check instead.
+	t.Run("succeed with mismatching Content-Length", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodGet {
 				t.Errorf("unexpected access: %s %s", r.Method, r.URL)
@@ -3946,7 +3949,7 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 				}
 				w.Header().Set("Content-Type", manifestDesc.MediaType)
 				w.Header().Set("Docker-Content-Digest", manifestDesc.Digest.String())
-				if _, err := w.Write([]byte("random")); err != nil {
+				if _, err := w.Write(manifest); err != nil {
 					t.Errorf("failed to write %q: %v", r.URL, err)
 				}
 			default:
@@ -3967,10 +3970,15 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		store := repo.Manifests()
 		ctx := context.Background()
 
-		_, err = store.Fetch(ctx, manifestDesc)
-		if err == nil {
-			t.Error("Manifests.Fetch() error = nil, wantErr = true")
+		// Use a descriptor with a wrong Size to simulate a HEAD/GET Content-Length
+		// divergence as seen with Harbor when copying to a differently-named repo.
+		wrongSizeDesc := manifestDesc
+		wrongSizeDesc.Size = manifestDesc.Size + 100
+		rc, err := store.Fetch(ctx, wrongSizeDesc)
+		if err != nil {
+			t.Fatalf("Manifests.Fetch() error = %v, want nil (Content-Length mismatch should be tolerated)", err)
 		}
+		rc.Close()
 	})
 
 	t.Run("fail with mismatching digest", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Some registries (e.g. Harbor) return different `Content-Length` values between HEAD (used by `Resolve`) and GET (used by `Fetch`) for the same manifest URL — typically due to transparent compression applied only on GET responses.

The existing check in `manifestStore.Fetch`:

```go
if size := resp.ContentLength; size != -1 && size != target.Size {
    return nil, fmt.Errorf("%s %q: mismatch Content-Length", ...)
}
```

was rejecting these valid responses. This causes `oras cp -r` to fail with `mismatch Content-Length` from the source registry when copying to a **differently-named** destination repository on Harbor. (With the same destination name the manifest already exists there, so the fetch is skipped and the error is never triggered.)

The check is redundant for manifests: `verifyContentDigest` immediately below validates the `Docker-Content-Digest` response header against the expected digest, which is the authoritative integrity guarantee.

## Changes

- Remove the two-line `Content-Length` check from `manifestStore.Fetch` in `registry/remote/repository.go`
- Update `Test_ManifestStore_Fetch` to verify the mismatch is now tolerated (renamed subtest from "fail with mismatching Content-Length" → "succeed with mismatching Content-Length")

The analogous check in `blobStore.Fetch` is intentionally kept — for blobs, size matters for range requests and progress tracking.

## Test plan

- [ ] `go test ./registry/remote/ -run Test_ManifestStore_Fetch` passes (all 5 subtests)
- [ ] Manual test: `oras cp -r` to a differently-named destination on a Harbor registry succeeds

Fixes #1176
Related: oras-project/oras#2054