### PR TITLE
feat(auth)!: flip OAuth2 default and rename ForceAttemptOAuth2 to legacyMode

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -99,13 +99,25 @@ type Client struct {
 	// Reference: https://distribution.github.io/distribution/spec/auth/oauth/#getting-a-token
 	ClientID string
 
-	// ForceAttemptOAuth2 controls whether to follow OAuth2 with password grant
-	// instead the distribution spec when authenticating using username and
-	// password.
+	// legacyMode controls whether to use the legacy distribution spec
+	// instead of OAuth2 with password grant when authenticating using
+	// username and password.
+	// Default is false (OAuth2 is used).
+	//
+	// When legacyMode is true, the client uses the legacy distribution spec for
+	// authentication. If the registry says it supports bearer authentication,
+	// basic authentication will be performed unless there are no credentials
+	// or a refresh token is provided. This is the approach used in oras-go
+	// v1 and v2.
+	//
+	// When legacyMode is false (default), the client uses OAuth2 with password
+	// grant.  If the registry says it supports bearer authentication, bearer
+	// authentication will be performed.
+	//
 	// References:
 	// - https://distribution.github.io/distribution/spec/auth/jwt/
 	// - https://distribution.github.io/distribution/spec/auth/oauth/
-	ForceAttemptOAuth2 bool
+	legacyMode bool
 }
 
 // client returns an HTTP client used to access the remote registry.
@@ -148,6 +160,27 @@ func (c *Client) SetUserAgent(userAgent string) {
 		c.Header = http.Header{}
 	}
 	c.Header.Set(headerUserAgent, userAgent)
+}
+
+// SetLegacyMode sets whether to use legacy distribution spec authentication
+// instead of OAuth2 with password grant when authenticating using username
+// and password.
+//
+// When legacy is true, the client uses the legacy distribution spec for
+// authentication. If the registry says it supports bearer authentication,
+// basic authentication will be performed unless there are no credentials
+// or a refresh token is provided. This is the approach used in oras-go
+// v1 and v2.
+//
+// When legacy is false (default), the client uses OAuth2 with password
+// grant.  If the registry says it supports bearer authentication, bearer
+// authentication will be performed.
+//
+// References:
+//   - https://distribution.github.io/distribution/spec/auth/jwt/
+//   - https://distribution.github.io/distribution/spec/auth/oauth/
+func (c *Client) SetLegacyMode(legacy bool) {
+	c.legacyMode = legacy
 }
 
 // Do sends the request to the remote server, attempting to resolve
@@ -288,7 +321,7 @@ func (c *Client) fetchBearerToken(ctx context.Context, registry, realm, service 
 	if cred.AccessToken != "" {
 		return cred.AccessToken, nil
 	}
-	if cred == credentials.EmptyCredential || (cred.RefreshToken == "" && !c.ForceAttemptOAuth2) {
+	if cred == credentials.EmptyCredential || (cred.RefreshToken == "" && c.legacyMode) {
 		return c.fetchDistributionToken(ctx, realm, service, scopes, cred.Username, cred.Password)
 	}
 	return c.fetchOAuth2Token(ctx, realm, service, scopes, cred)

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -726,6 +726,7 @@ func TestClient_Do_Bearer_Auth(t *testing.T) {
 			}, nil
 		},
 	}
+	client.SetLegacyMode(true)
 
 	// first request
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -853,6 +854,7 @@ func TestClient_Do_Bearer_Auth_Cached(t *testing.T) {
 		},
 		Cache: NewCache(),
 	}
+	client.SetLegacyMode(true)
 
 	// first request
 	ctx := WithScopes(context.Background(), scopes...)
@@ -995,6 +997,7 @@ func TestClient_Do_Bearer_Auth_Cached_PerHost(t *testing.T) {
 		}),
 		Cache: NewCache(),
 	}
+	client1.SetLegacyMode(true)
 
 	// set up server 2
 	username2 := "test_user2"
@@ -1065,6 +1068,7 @@ func TestClient_Do_Bearer_Auth_Cached_PerHost(t *testing.T) {
 		}),
 		Cache: NewCache(),
 	}
+	client2.SetLegacyMode(true)
 
 	ctx := context.Background()
 	ctx = WithScopesForHost(ctx, uri1.Host, scopes1...)
@@ -1312,7 +1316,6 @@ func TestClient_Do_Bearer_OAuth2_Password(t *testing.T) {
 				Password: password,
 			}, nil
 		},
-		ForceAttemptOAuth2: true,
 	}
 
 	// first request
@@ -1459,8 +1462,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached(t *testing.T) {
 				Password: password,
 			}, nil
 		},
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	// first request
@@ -1622,8 +1624,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached_PerHost(t *testing.T) {
 			Username: username1,
 			Password: password1,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 	// set up server 2
 	username2 := "test_user2"
@@ -1712,8 +1713,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached_PerHost(t *testing.T) {
 			Username: username2,
 			Password: password2,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	ctx := context.Background()
@@ -2970,8 +2970,7 @@ func TestClient_Do_Scope_Hint_Mismatch(t *testing.T) {
 				Password: password,
 			}, nil
 		},
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	// first request
@@ -3114,8 +3113,7 @@ func TestClient_Do_Scope_Hint_Mismatch_PerHost(t *testing.T) {
 			Username: username1,
 			Password: password1,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	// set up server 1
@@ -3208,8 +3206,7 @@ func TestClient_Do_Scope_Hint_Mismatch_PerHost(t *testing.T) {
 			Username: username2,
 			Password: password2,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	ctx := context.Background()
@@ -3350,6 +3347,7 @@ func TestClient_Do_Invalid_Credential_Basic(t *testing.T) {
 			}, nil
 		},
 	}
+	client.SetLegacyMode(true)
 
 	// request should fail
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -3435,6 +3433,7 @@ func TestClient_Do_Invalid_Credential_Bearer(t *testing.T) {
 			}, nil
 		},
 	}
+	client.SetLegacyMode(true)
 
 	// request should fail
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -3620,6 +3619,7 @@ func TestClient_Do_Scheme_Change(t *testing.T) {
 		},
 		Cache: NewCache(),
 	}
+	client.SetLegacyMode(true)
 
 	// request with bearer auth
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -3975,5 +3975,23 @@ func TestClient_fetchBasicAuth(t *testing.T) {
 	_, err := c.fetchBasicAuth(context.Background(), "")
 	if err != ErrBasicCredentialNotFound {
 		t.Errorf("incorrect error: %v, expected %v", err, ErrBasicCredentialNotFound)
+	}
+}
+
+func TestClient_SetLegacyMode(t *testing.T) {
+	var client Client
+	// Default should be false.
+	if client.legacyMode {
+		t.Error("default legacyMode should be false")
+	}
+
+	client.SetLegacyMode(true)
+	if !client.legacyMode {
+		t.Error("SetLegacyMode(true) should set legacyMode to true")
+	}
+
+	client.SetLegacyMode(false)
+	if client.legacyMode {
+		t.Error("SetLegacyMode(false) should set legacyMode to false")
 	}
 }

--- a/registry/remote/auth/example_test.go
+++ b/registry/remote/auth/example_test.go
@@ -190,8 +190,6 @@ func ExampleClient_Do_clientConfigurations() {
 			Username: username,
 			Password: password,
 		}),
-		// ForceAttemptOAuth2 controls whether to follow OAuth2 with password grant.
-		ForceAttemptOAuth2: true,
 		// Cache caches credentials for accessing the remote registry.
 		Cache: NewCache(),
 	}


### PR DESCRIPTION
## Summary

Part 1 of 3 splitting #1141 into reviewable chunks.

Replace the exported `ForceAttemptOAuth2 bool` field on `auth.Client` with an unexported `legacyMode` field plus a public `SetLegacyMode(bool)` setter, and **flip the default behavior**:

| | Before | After |
|---|---|---|
| Default for username+password | distribution-spec token endpoint | OAuth2 password grant |
| Opt-in toggle | `client.ForceAttemptOAuth2 = true` | `client.SetLegacyMode(true)` |

The selection logic in `fetchBearerToken` is unchanged — only the polarity of the flag and the default are swapped.

## Breaking change

- Callers that relied on the **implicit distribution-spec default** (did not set `ForceAttemptOAuth2`, authenticated via username+password) must now call `client.SetLegacyMode(true)` to keep the old behavior.
- Callers that explicitly set `ForceAttemptOAuth2 = true` should drop that line — OAuth2 is the new default.
- `ForceAttemptOAuth2` is removed (no deprecation period). Happy to add a one-release deprecation shim if reviewers prefer.

## Test changes

- 8 distribution-spec tests (`TestClient_Do_Bearer_Auth*`, `TestClient_Do_Invalid_Credential_*`, `TestClient_Do_Scheme_Change`) gain `client.SetLegacyMode(true)`.
- 7 OAuth2 tests (`TestClient_Do_Bearer_OAuth2_Password*`, `TestClient_Do_Scope_Hint_Mismatch*`) drop `ForceAttemptOAuth2: true`.
- `example_test.go` drops the `ForceAttemptOAuth2` reference.
- Adds `TestClient_SetLegacyMode` for the new setter.

## Test plan

- [x] `go test -mod=mod ./registry/remote/auth/...` — passes
- [ ] CI on this PR

## Follow-ups in the split

- PR B: `feat(auth): add TokenFetcher interface and token abstraction` (based on this branch)
- PR C: `feat(auth): add ForceBasicAuth to override Bearer challenges` (independent, based on main)

Closes nothing on its own; replaces #1141 together with PRs B and C.