### PR TITLE
feat(auth): add TokenFetcher interface and token abstraction

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -100,6 +100,11 @@ type Client struct {
 	// Reference: https://distribution.github.io/distribution/spec/auth/oauth/#getting-a-token
 	ClientID string
 
+	// TokenFetcher is an optional custom token fetcher for bearer
+	// authentication. If nil, the built-in token-fetching logic is used
+	// (see ForceAttemptOAuth2).
+	TokenFetcher TokenFetcher
+
 	// ForceAttemptOAuth2 controls whether to follow OAuth2 with password grant
 	// instead the distribution spec when authenticating using username and
 	// password.
@@ -385,6 +390,19 @@ func (c *Client) fetchBearerToken(ctx context.Context, registry, realm, service 
 	if err != nil {
 		return "", err
 	}
+
+	// Use custom TokenFetcher if provided
+	if c.TokenFetcher != nil {
+		params := TokenParams{
+			Registry: registry,
+			Realm:    realm,
+			Service:  service,
+			Scopes:   scopes,
+		}
+		return c.TokenFetcher.FetchToken(ctx, params, cred)
+	}
+
+	// Fall back to original implementation
 	if cred.AccessToken != "" {
 		return cred.AccessToken, nil
 	}

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -3978,6 +3978,129 @@ func TestClient_fetchBasicAuth(t *testing.T) {
 	}
 }
 
+func TestClient_Do_Bearer_CustomTokenFetcher(t *testing.T) {
+	wantToken := "custom_fetcher_token"
+	var requestCount, wantRequestCount int64
+	var successCount, wantSuccessCount int64
+	var service string
+	scope := "repository:test:pull"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		if r.Method != http.MethodGet || r.URL.Path != "/" {
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		header := "Bearer " + wantToken
+		if auth := r.Header.Get("Authorization"); auth != header {
+			challenge := fmt.Sprintf("Bearer realm=%q,service=%q,scope=%q", "https://auth.example.com/token", service, scope)
+			w.Header().Set("Www-Authenticate", challenge)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		atomic.AddInt64(&successCount, 1)
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+	service = uri.Host
+
+	// Custom token fetcher that always returns a fixed token.
+	customFetcher := &mockTokenFetcherForClient{token: wantToken}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			return credentials.Credential{
+				Username: "user",
+				Password: "pass",
+			}, nil
+		},
+		TokenFetcher: customFetcher,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if wantRequestCount += 2; requestCount != wantRequestCount {
+		t.Errorf("unexpected number of requests: %d, want %d", requestCount, wantRequestCount)
+	}
+	if wantSuccessCount++; successCount != wantSuccessCount {
+		t.Errorf("unexpected number of successful requests: %d, want %d", successCount, wantSuccessCount)
+	}
+
+	// Verify the custom fetcher was actually called.
+	if !customFetcher.called {
+		t.Error("custom TokenFetcher was not called")
+	}
+}
+
+func TestClient_Do_Bearer_CustomTokenFetcher_Error(t *testing.T) {
+	var service string
+	scope := "repository:test:pull"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		challenge := fmt.Sprintf("Bearer realm=%q,service=%q,scope=%q", "https://auth.example.com/token", service, scope)
+		w.Header().Set("Www-Authenticate", challenge)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+	service = uri.Host
+
+	fetcherErr := errors.New("custom fetcher error")
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			return credentials.Credential{
+				Username: "user",
+				Password: "pass",
+			}, nil
+		},
+		TokenFetcher: &mockTokenFetcherForClient{err: fetcherErr},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	_, err = client.Do(req)
+	if err == nil {
+		t.Fatal("Client.Do() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "custom fetcher error") {
+		t.Errorf("Client.Do() error = %v, want error containing %q", err, "custom fetcher error")
+	}
+}
+
+// mockTokenFetcherForClient is a test helper that returns a fixed token and
+// tracks whether it was called.
+type mockTokenFetcherForClient struct {
+	token  string
+	err    error
+	called bool
+}
+
+func (m *mockTokenFetcherForClient) FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error) {
+	m.called = true
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.token, nil
+}
+
 // TestClient_Do_Basic_Auth_RedirectAfterAuth verifies that the Authorization
 // header is not forwarded when an authenticated request is redirected to a
 // different HTTP origin (here, a different port on the same host).

--- a/registry/remote/auth/token.go
+++ b/registry/remote/auth/token.go
@@ -1,0 +1,253 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
+	"github.com/oras-project/oras-go/v3/registry/remote/internal/errutil"
+)
+
+// TokenParams contains parameters for token acquisition.
+type TokenParams struct {
+	// Registry is the registry hostname (i.e. host:port).
+	Registry string
+	// Realm is the token endpoint URL.
+	Realm string
+	// Service is the service parameter from the WWW-Authenticate header.
+	Service string
+	// Scopes are the requested scopes for the token.
+	Scopes []string
+}
+
+// TokenFetcher abstracts the token acquisition strategy.
+type TokenFetcher interface {
+	// FetchToken fetches an access token for the given parameters and credential.
+	FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error)
+}
+
+// DistributionTokenFetcher implements distribution spec token endpoint (GET).
+// This fetches tokens using the legacy distribution specification.
+//
+// References:
+//   - https://distribution.github.io/distribution/spec/auth/jwt/
+//   - https://distribution.github.io/distribution/spec/auth/token/
+type DistributionTokenFetcher struct {
+	// Client is the underlying HTTP client used to send requests.
+	// If nil, http.DefaultClient is used.
+	Client *http.Client
+	// Header contains custom headers to be added to each request.
+	Header http.Header
+}
+
+// FetchToken fetches an access token using the distribution spec token endpoint.
+// It fetches anonymous tokens if no credential is provided.
+func (f *DistributionTokenFetcher) FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, params.Realm, nil)
+	if err != nil {
+		return "", err
+	}
+	if cred.Username != "" || cred.Password != "" {
+		req.SetBasicAuth(cred.Username, cred.Password)
+	}
+	q := req.URL.Query()
+	if params.Service != "" {
+		q.Set("service", params.Service)
+	}
+	for _, scope := range params.Scopes {
+		q.Add("scope", scope)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := f.send(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", errutil.ParseErrorResponse(resp)
+	}
+
+	// As specified in https://distribution.github.io/distribution/spec/auth/token/ section
+	// "Token Response Fields", the token is either in `token` or
+	// `access_token`. If both present, they are identical.
+	var result struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	lr := io.LimitReader(resp.Body, maxResponseBytes)
+	if err := json.NewDecoder(lr).Decode(&result); err != nil {
+		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
+	}
+	if result.AccessToken != "" {
+		return result.AccessToken, nil
+	}
+	if result.Token != "" {
+		return result.Token, nil
+	}
+	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
+}
+
+// send adds custom headers and sends the request.
+func (f *DistributionTokenFetcher) send(req *http.Request) (*http.Response, error) {
+	for key, values := range f.Header {
+		req.Header[key] = append(req.Header[key], values...)
+	}
+	client := f.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return client.Do(req)
+}
+
+// OAuth2TokenFetcher implements OAuth2 password/refresh_token grants (POST).
+// This fetches tokens using the OAuth2 specification.
+//
+// Reference: https://distribution.github.io/distribution/spec/auth/oauth/
+type OAuth2TokenFetcher struct {
+	// Client is the underlying HTTP client used to send requests.
+	// If nil, http.DefaultClient is used.
+	Client *http.Client
+	// Header contains custom headers to be added to each request.
+	Header http.Header
+	// ClientID is used in fetching OAuth2 token as a required field.
+	// If empty, a default client ID is used.
+	ClientID string
+}
+
+// FetchToken fetches an OAuth2 access token.
+func (f *OAuth2TokenFetcher) FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error) {
+	form := url.Values{}
+	if cred.RefreshToken != "" {
+		form.Set("grant_type", "refresh_token")
+		form.Set("refresh_token", cred.RefreshToken)
+	} else if cred.Username != "" && cred.Password != "" {
+		form.Set("grant_type", "password")
+		form.Set("username", cred.Username)
+		form.Set("password", cred.Password)
+	} else {
+		return "", errors.New("missing username or password for bearer auth")
+	}
+	form.Set("service", params.Service)
+	clientID := f.ClientID
+	if clientID == "" {
+		clientID = defaultClientID
+	}
+	form.Set("client_id", clientID)
+	if len(params.Scopes) != 0 {
+		form.Set("scope", strings.Join(params.Scopes, " "))
+	}
+	body := strings.NewReader(form.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, params.Realm, body)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set(headerContentType, "application/x-www-form-urlencoded")
+
+	resp, err := f.send(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", errutil.ParseErrorResponse(resp)
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	lr := io.LimitReader(resp.Body, maxResponseBytes)
+	if err := json.NewDecoder(lr).Decode(&result); err != nil {
+		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
+	}
+	if result.AccessToken != "" {
+		return result.AccessToken, nil
+	}
+	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
+}
+
+// send adds custom headers and sends the request.
+func (f *OAuth2TokenFetcher) send(req *http.Request) (*http.Response, error) {
+	for key, values := range f.Header {
+		req.Header[key] = append(req.Header[key], values...)
+	}
+	client := f.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return client.Do(req)
+}
+
+// CompositeTokenFetcher selects strategy based on credential type and legacy mode.
+// It delegates to either DistributionTokenFetcher or OAuth2TokenFetcher based
+// on the credential and configuration.
+type CompositeTokenFetcher struct {
+	// Distribution is the fetcher for distribution spec tokens.
+	Distribution TokenFetcher
+	// OAuth2 is the fetcher for OAuth2 tokens.
+	OAuth2 TokenFetcher
+	// LegacyMode controls whether to use the legacy distribution spec
+	// instead of OAuth2 with password grant when authenticating using
+	// username and password.
+	LegacyMode bool
+}
+
+// FetchToken selects the appropriate fetcher and delegates the token acquisition.
+// The selection logic is:
+//   - If credential has an access token, return it directly.
+//   - If credential is empty or (has no refresh token and legacy mode is enabled),
+//     use the distribution fetcher.
+//   - Otherwise, use the OAuth2 fetcher.
+func (f *CompositeTokenFetcher) FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error) {
+	// Return access token directly if provided
+	if cred.AccessToken != "" {
+		return cred.AccessToken, nil
+	}
+
+	// Use distribution fetcher for empty credentials or legacy mode without refresh token
+	if cred == credentials.EmptyCredential || (cred.RefreshToken == "" && f.LegacyMode) {
+		return f.Distribution.FetchToken(ctx, params, cred)
+	}
+
+	// Use OAuth2 fetcher otherwise
+	return f.OAuth2.FetchToken(ctx, params, cred)
+}
+
+// NewCompositeTokenFetcher creates a new CompositeTokenFetcher with default
+// Distribution and OAuth2 fetchers using the provided client and header.
+func NewCompositeTokenFetcher(client *http.Client, header http.Header, clientID string, legacyMode bool) *CompositeTokenFetcher {
+	return &CompositeTokenFetcher{
+		Distribution: &DistributionTokenFetcher{
+			Client: client,
+			Header: header,
+		},
+		OAuth2: &OAuth2TokenFetcher{
+			Client:   client,
+			Header:   header,
+			ClientID: clientID,
+		},
+		LegacyMode: legacyMode,
+	}
+}

--- a/registry/remote/auth/token.go
+++ b/registry/remote/auth/token.go
@@ -47,6 +47,44 @@ type TokenFetcher interface {
 	FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error)
 }
 
+// sendRequest adds the custom headers to the request and sends it using the
+// given client. If client is nil, http.DefaultClient is used.
+func sendRequest(client *http.Client, header http.Header, req *http.Request) (*http.Response, error) {
+	for key, values := range header {
+		req.Header[key] = append(req.Header[key], values...)
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return client.Do(req)
+}
+
+// decodeTokenResponse decodes a token endpoint response body and returns the
+// access token.
+//
+// As specified in https://distribution.github.io/distribution/spec/auth/token/
+// section "Token Response Fields", the token is carried in either the `token`
+// or `access_token` field; if both are present they are identical. OAuth2
+// responses use `access_token` (see
+// https://distribution.github.io/distribution/spec/auth/oauth/).
+func decodeTokenResponse(resp *http.Response) (string, error) {
+	var result struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	lr := io.LimitReader(resp.Body, maxResponseBytes)
+	if err := json.NewDecoder(lr).Decode(&result); err != nil {
+		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
+	}
+	if result.AccessToken != "" {
+		return result.AccessToken, nil
+	}
+	if result.Token != "" {
+		return result.Token, nil
+	}
+	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
+}
+
 // DistributionTokenFetcher implements distribution spec token endpoint (GET).
 // This fetches tokens using the legacy distribution specification.
 //
@@ -80,7 +118,7 @@ func (f *DistributionTokenFetcher) FetchToken(ctx context.Context, params TokenP
 	}
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := f.send(req)
+	resp, err := sendRequest(f.Client, f.Header, req)
 	if err != nil {
 		return "", err
 	}
@@ -88,37 +126,7 @@ func (f *DistributionTokenFetcher) FetchToken(ctx context.Context, params TokenP
 	if resp.StatusCode != http.StatusOK {
 		return "", errutil.ParseErrorResponse(resp)
 	}
-
-	// As specified in https://distribution.github.io/distribution/spec/auth/token/ section
-	// "Token Response Fields", the token is either in `token` or
-	// `access_token`. If both present, they are identical.
-	var result struct {
-		Token       string `json:"token"`
-		AccessToken string `json:"access_token"`
-	}
-	lr := io.LimitReader(resp.Body, maxResponseBytes)
-	if err := json.NewDecoder(lr).Decode(&result); err != nil {
-		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
-	}
-	if result.AccessToken != "" {
-		return result.AccessToken, nil
-	}
-	if result.Token != "" {
-		return result.Token, nil
-	}
-	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
-}
-
-// send adds custom headers and sends the request.
-func (f *DistributionTokenFetcher) send(req *http.Request) (*http.Response, error) {
-	for key, values := range f.Header {
-		req.Header[key] = append(req.Header[key], values...)
-	}
-	client := f.Client
-	if client == nil {
-		client = http.DefaultClient
-	}
-	return client.Do(req)
+	return decodeTokenResponse(resp)
 }
 
 // OAuth2TokenFetcher implements OAuth2 password/refresh_token grants (POST).
@@ -166,7 +174,7 @@ func (f *OAuth2TokenFetcher) FetchToken(ctx context.Context, params TokenParams,
 	}
 	req.Header.Set(headerContentType, "application/x-www-form-urlencoded")
 
-	resp, err := f.send(req)
+	resp, err := sendRequest(f.Client, f.Header, req)
 	if err != nil {
 		return "", err
 	}
@@ -174,30 +182,7 @@ func (f *OAuth2TokenFetcher) FetchToken(ctx context.Context, params TokenParams,
 	if resp.StatusCode != http.StatusOK {
 		return "", errutil.ParseErrorResponse(resp)
 	}
-
-	var result struct {
-		AccessToken string `json:"access_token"`
-	}
-	lr := io.LimitReader(resp.Body, maxResponseBytes)
-	if err := json.NewDecoder(lr).Decode(&result); err != nil {
-		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
-	}
-	if result.AccessToken != "" {
-		return result.AccessToken, nil
-	}
-	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
-}
-
-// send adds custom headers and sends the request.
-func (f *OAuth2TokenFetcher) send(req *http.Request) (*http.Response, error) {
-	for key, values := range f.Header {
-		req.Header[key] = append(req.Header[key], values...)
-	}
-	client := f.Client
-	if client == nil {
-		client = http.DefaultClient
-	}
-	return client.Do(req)
+	return decodeTokenResponse(resp)
 }
 
 // CompositeTokenFetcher selects strategy based on credential type and legacy mode.

--- a/registry/remote/auth/token_test.go
+++ b/registry/remote/auth/token_test.go
@@ -1,0 +1,805 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
+)
+
+func TestDistributionTokenFetcher_FetchToken(t *testing.T) {
+	wantToken := "test_token"
+	wantService := "test_service"
+	wantScope := "repository:test:pull"
+	username := "test_user"
+	password := "test_password"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s, want GET", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		// Verify query parameters
+		if got := r.URL.Query().Get("service"); got != wantService {
+			t.Errorf("unexpected service: %s, want %s", got, wantService)
+		}
+		if got := r.URL.Query().Get("scope"); got != wantScope {
+			t.Errorf("unexpected scope: %s, want %s", got, wantScope)
+		}
+		// Verify basic auth
+		u, p, ok := r.BasicAuth()
+		if !ok {
+			t.Error("expected basic auth")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if u != username || p != password {
+			t.Errorf("unexpected credentials: %s:%s, want %s:%s", u, p, username, password)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		// Return token response
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &DistributionTokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+		Realm:    ts.URL,
+		Service:  wantService,
+		Scopes:   []string{wantScope},
+	}
+	cred := credentials.Credential{
+		Username: username,
+		Password: password,
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestDistributionTokenFetcher_FetchToken_Anonymous(t *testing.T) {
+	wantToken := "anonymous_token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s, want GET", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		// Verify no auth header
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("unexpected Authorization header: %s", auth)
+		}
+
+		// Return token response using 'token' field
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &DistributionTokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+		Realm:    ts.URL,
+		Service:  "test_service",
+		Scopes:   []string{"repository:test:pull"},
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestDistributionTokenFetcher_FetchToken_EmptyToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &DistributionTokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+
+	_, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err == nil {
+		t.Error("expected error for empty token")
+	}
+	if !strings.Contains(err.Error(), "empty token returned") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDistributionTokenFetcher_FetchToken_CustomHeaders(t *testing.T) {
+	wantToken := "test_token"
+	wantHeader := "test-value"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Custom-Header"); got != wantHeader {
+			t.Errorf("unexpected custom header: %s, want %s", got, wantHeader)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &DistributionTokenFetcher{
+		Client: ts.Client(),
+		Header: http.Header{
+			"X-Custom-Header": {wantHeader},
+		},
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_Password(t *testing.T) {
+	wantToken := "oauth2_token"
+	wantService := "test_service"
+	wantScope := "repository:test:pull"
+	wantClientID := "test_client"
+	username := "test_user"
+	password := "test_password"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s, want POST", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/x-www-form-urlencoded" {
+			t.Errorf("unexpected Content-Type: %s", ct)
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "password" {
+			t.Errorf("unexpected grant_type: %s, want password", got)
+		}
+		if got := r.Form.Get("username"); got != username {
+			t.Errorf("unexpected username: %s, want %s", got, username)
+		}
+		if got := r.Form.Get("password"); got != password {
+			t.Errorf("unexpected password: %s, want %s", got, password)
+		}
+		if got := r.Form.Get("service"); got != wantService {
+			t.Errorf("unexpected service: %s, want %s", got, wantService)
+		}
+		if got := r.Form.Get("scope"); got != wantScope {
+			t.Errorf("unexpected scope: %s, want %s", got, wantScope)
+		}
+		if got := r.Form.Get("client_id"); got != wantClientID {
+			t.Errorf("unexpected client_id: %s, want %s", got, wantClientID)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client:   ts.Client(),
+		ClientID: wantClientID,
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+		Realm:    ts.URL,
+		Service:  wantService,
+		Scopes:   []string{wantScope},
+	}
+	cred := credentials.Credential{
+		Username: username,
+		Password: password,
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_RefreshToken(t *testing.T) {
+	wantToken := "oauth2_token"
+	wantRefreshToken := "test_refresh_token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s, want POST", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Errorf("unexpected grant_type: %s, want refresh_token", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != wantRefreshToken {
+			t.Errorf("unexpected refresh_token: %s, want %s", got, wantRefreshToken)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+		Realm:    ts.URL,
+		Service:  "test_service",
+	}
+	cred := credentials.Credential{
+		RefreshToken: wantRefreshToken,
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_DefaultClientID(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+		if got := r.Form.Get("client_id"); got != defaultClientID {
+			t.Errorf("unexpected client_id: %s, want %s", got, defaultClientID)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": "token"}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client: ts.Client(),
+		// No ClientID set, should use default
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	_, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_NoCredentials(t *testing.T) {
+	fetcher := &OAuth2TokenFetcher{}
+
+	params := TokenParams{
+		Realm: "http://example.com/token",
+	}
+
+	_, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err == nil {
+		t.Error("expected error for empty credentials")
+	}
+	if !strings.Contains(err.Error(), "missing username or password") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_EmptyToken(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	_, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err == nil {
+		t.Error("expected error for empty token")
+	}
+	if !strings.Contains(err.Error(), "empty token returned") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCompositeTokenFetcher_FetchToken_AccessToken(t *testing.T) {
+	wantToken := "direct_access_token"
+
+	fetcher := &CompositeTokenFetcher{
+		Distribution: &mockTokenFetcher{token: "distribution_token"},
+		OAuth2:       &mockTokenFetcher{token: "oauth2_token"},
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+	}
+	cred := credentials.Credential{
+		AccessToken: wantToken,
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestCompositeTokenFetcher_FetchToken_EmptyCredential(t *testing.T) {
+	wantToken := "distribution_token"
+
+	fetcher := &CompositeTokenFetcher{
+		Distribution: &mockTokenFetcher{token: wantToken},
+		OAuth2:       &mockTokenFetcher{token: "oauth2_token"},
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s (should use distribution fetcher)", token, wantToken)
+	}
+}
+
+func TestCompositeTokenFetcher_FetchToken_LegacyMode(t *testing.T) {
+	wantToken := "distribution_token"
+
+	fetcher := &CompositeTokenFetcher{
+		Distribution: &mockTokenFetcher{token: wantToken},
+		OAuth2:       &mockTokenFetcher{token: "oauth2_token"},
+		LegacyMode:   true,
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+	}
+	// Credential with username/password but no refresh token
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s (should use distribution fetcher in legacy mode)", token, wantToken)
+	}
+}
+
+func TestCompositeTokenFetcher_FetchToken_OAuth2(t *testing.T) {
+	wantToken := "oauth2_token"
+
+	fetcher := &CompositeTokenFetcher{
+		Distribution: &mockTokenFetcher{token: "distribution_token"},
+		OAuth2:       &mockTokenFetcher{token: wantToken},
+		LegacyMode:   false, // Not legacy mode
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+	}
+	// Credential with username/password and no refresh token
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s (should use OAuth2 fetcher when not in legacy mode)", token, wantToken)
+	}
+}
+
+func TestCompositeTokenFetcher_FetchToken_RefreshToken(t *testing.T) {
+	wantToken := "oauth2_token"
+
+	fetcher := &CompositeTokenFetcher{
+		Distribution: &mockTokenFetcher{token: "distribution_token"},
+		OAuth2:       &mockTokenFetcher{token: wantToken},
+		LegacyMode:   true, // Even in legacy mode, refresh token uses OAuth2
+	}
+
+	params := TokenParams{
+		Registry: "test-registry",
+	}
+	cred := credentials.Credential{
+		RefreshToken: "refresh_token",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s (should use OAuth2 fetcher for refresh token)", token, wantToken)
+	}
+}
+
+func TestNewCompositeTokenFetcher(t *testing.T) {
+	client := &http.Client{}
+	header := http.Header{"X-Test": {"value"}}
+	clientID := "test-client"
+
+	fetcher := NewCompositeTokenFetcher(client, header, clientID, true)
+
+	if fetcher.LegacyMode != true {
+		t.Error("LegacyMode should be true")
+	}
+
+	distFetcher, ok := fetcher.Distribution.(*DistributionTokenFetcher)
+	if !ok {
+		t.Fatal("Distribution should be *DistributionTokenFetcher")
+	}
+	if distFetcher.Client != client {
+		t.Error("Distribution fetcher client mismatch")
+	}
+	if distFetcher.Header.Get("X-Test") != "value" {
+		t.Error("Distribution fetcher header mismatch")
+	}
+
+	oauth2Fetcher, ok := fetcher.OAuth2.(*OAuth2TokenFetcher)
+	if !ok {
+		t.Fatal("OAuth2 should be *OAuth2TokenFetcher")
+	}
+	if oauth2Fetcher.Client != client {
+		t.Error("OAuth2 fetcher client mismatch")
+	}
+	if oauth2Fetcher.Header.Get("X-Test") != "value" {
+		t.Error("OAuth2 fetcher header mismatch")
+	}
+	if oauth2Fetcher.ClientID != clientID {
+		t.Errorf("OAuth2 fetcher ClientID = %s, want %s", oauth2Fetcher.ClientID, clientID)
+	}
+}
+
+// mockTokenFetcher is a test helper that returns a fixed token.
+type mockTokenFetcher struct {
+	token string
+	err   error
+}
+
+func (m *mockTokenFetcher) FetchToken(ctx context.Context, params TokenParams, cred credentials.Credential) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.token, nil
+}
+
+func TestDistributionTokenFetcher_FetchToken_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"errors":[{"code":"UNKNOWN","message":"server error"}]}`))
+	}))
+	defer ts.Close()
+
+	fetcher := &DistributionTokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+
+	_, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err == nil {
+		t.Error("expected error for server error response")
+	}
+}
+
+func TestDistributionTokenFetcher_FetchToken_NilClient(t *testing.T) {
+	wantToken := "nil_client_token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	// No custom Client set, should use http.DefaultClient.
+	fetcher := &DistributionTokenFetcher{}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"errors":[{"code":"UNKNOWN","message":"server error"}]}`))
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	_, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err == nil {
+		t.Error("expected error for server error response")
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_NilClient(t *testing.T) {
+	wantToken := "nil_client_oauth2_token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	// No custom Client set, should use http.DefaultClient.
+	fetcher := &OAuth2TokenFetcher{}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_CustomHeaders(t *testing.T) {
+	wantToken := "header_token"
+	wantHeader := "custom-value"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Custom"); got != wantHeader {
+			t.Errorf("custom header = %q, want %q", got, wantHeader)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client: ts.Client(),
+		Header: http.Header{
+			"X-Custom": {wantHeader},
+		},
+	}
+
+	params := TokenParams{
+		Realm: ts.URL,
+	}
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestOAuth2TokenFetcher_FetchToken_NoScopes(t *testing.T) {
+	wantToken := "no_scope_token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse form: %v", err)
+		}
+		// Scope should not be set when no scopes provided.
+		if got := r.Form.Get("scope"); got != "" {
+			t.Errorf("scope = %q, want empty", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &OAuth2TokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Realm:  ts.URL,
+		Scopes: nil, // No scopes
+	}
+	cred := credentials.Credential{
+		Username: "user",
+		Password: "pass",
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, cred)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+func TestDistributionTokenFetcher_FetchToken_MultipleScopes(t *testing.T) {
+	wantToken := "multi_scope_token"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scopes := r.URL.Query()["scope"]
+		if len(scopes) != 2 {
+			t.Errorf("expected 2 scope params, got %d", len(scopes))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]string{"access_token": wantToken}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fetcher := &DistributionTokenFetcher{
+		Client: ts.Client(),
+	}
+
+	params := TokenParams{
+		Realm:  ts.URL,
+		Scopes: []string{"repository:test:pull", "repository:test:push"},
+	}
+
+	token, err := fetcher.FetchToken(context.Background(), params, credentials.EmptyCredential)
+	if err != nil {
+		t.Fatalf("FetchToken() error = %v", err)
+	}
+	if token != wantToken {
+		t.Errorf("FetchToken() = %s, want %s", token, wantToken)
+	}
+}
+
+// Verify url is imported but potentially unused warning fix
+var _ = url.Parse


### PR DESCRIPTION
## Summary

Part 2 of 3 splitting #1141 into reviewable chunks.

Extract bearer-token acquisition from `auth.Client` into a pluggable `TokenFetcher` interface:

```go
FetchToken(ctx, TokenParams, Credential) (string, error)
```

Three concrete implementations land in the same file:

| Type | Purpose |
|---|---|
| `DistributionTokenFetcher` | GET against the distribution-spec token endpoint with optional basic auth |
| `OAuth2TokenFetcher` | POST OAuth2 password / refresh_token grant |
| `CompositeTokenFetcher` | Selects between the above based on credential shape and a `LegacyMode` toggle — mirrors the existing in-client logic |

A new optional `Client.TokenFetcher` field lets callers inject a custom strategy (e.g. ECR/GCR-specific token exchange) without forking the client. When nil, the built-in fallback in `fetchBearerToken` preserves the existing behavior, so this is a **purely additive** change to the public API. `ForceAttemptOAuth2` is unchanged.

## Why split it out

Today the bearer-token strategy is hardcoded inside `Client.fetchBearerToken`. Callers who need a custom strategy have to fork or wrap the whole client. With `TokenFetcher`, they swap in one field.

The composite implementation is also easier to test in isolation than the inline logic — see `token_test.go` (805 lines) which exercises the strategies without spinning up an HTTP client at all.

This will replace https://github.com/oras-project/oras-go/blob/main/registry/remote/auth/client.go#L266:L400

## Test plan

- [x] `go test -mod=mod ./registry/remote/auth/...` — passes (existing tests + new TokenFetcher coverage)
- [x] `token_test.go` covers all three fetcher implementations independently
- [x] `client_test.go` adds `TestClient_Do_Bearer_CustomTokenFetcher` and `_Error` to verify wiring
- [ ] CI on this PR

## Follow-ups in the split

- PR A (#1180): `feat(auth)!: flip OAuth2 default and rename ForceAttemptOAuth2 to legacyMode` — separate breaking change, independent of this PR
- PR C (#1182): `feat(auth): add ForceBasicAuth to override Bearer challenges` — independent

Replaces #1141 together with PRs A and C.
