### PR TITLE
feat(auth): add ForceBasicAuth to override Bearer challenges

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -106,6 +106,12 @@ type Client struct {
 	// - https://distribution.github.io/distribution/spec/auth/jwt/
 	// - https://distribution.github.io/distribution/spec/auth/oauth/
 	ForceAttemptOAuth2 bool
+
+	// ForceBasicAuth forces the use of HTTP Basic authentication regardless
+	// of what authentication scheme the registry advertises. When true, if
+	// the registry challenges with Bearer auth, Basic auth is used instead.
+	// This requires the registry to also accept Basic auth credentials.
+	ForceBasicAuth bool
 }
 
 // client returns an HTTP client used to access the remote registry.
@@ -197,6 +203,9 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 	// attempt again with credentials for recognized schemes
 	challenge := resp.Header.Get(headerWWWAuthenticate)
 	scheme, params := parseChallenge(challenge)
+	if c.ForceBasicAuth && scheme == SchemeBearer {
+		scheme = SchemeBasic
+	}
 	switch scheme {
 	case SchemeBasic:
 		resp.Body.Close()

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -3977,3 +3977,61 @@ func TestClient_fetchBasicAuth(t *testing.T) {
 		t.Errorf("incorrect error: %v, expected %v", err, ErrBasicCredentialNotFound)
 	}
 }
+
+func TestClient_Do_ForceBasicAuth_OverridesBearer(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+	var requestCount, wantRequestCount int64
+	var successCount, wantSuccessCount int64
+
+	// Server challenges with Bearer but accepts Basic.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		authHeader := r.Header.Get("Authorization")
+		expectedBasic := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+		if authHeader == expectedBasic {
+			atomic.AddInt64(&successCount, 1)
+			return
+		}
+		// Challenge with Bearer to test ForceBasicAuth override.
+		w.Header().Set("Www-Authenticate", `Bearer realm="https://auth.example.com/token",service="test"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	client := &Client{
+		ForceBasicAuth: true,
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != uri.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, uri.Host)
+			}
+			return credentials.Credential{
+				Username: username,
+				Password: password,
+			}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if wantRequestCount += 2; requestCount != wantRequestCount {
+		t.Errorf("unexpected number of requests: %d, want %d", requestCount, wantRequestCount)
+	}
+	if wantSuccessCount++; successCount != wantSuccessCount {
+		t.Errorf("unexpected number of successful requests: %d, want %d", successCount, wantSuccessCount)
+	}
+}


### PR DESCRIPTION
## Summary

Part 3 of 3 splitting #1141 into reviewable chunks.

Add a `ForceBasicAuth bool` field to `auth.Client`. When true, a Bearer challenge from the registry is rewritten to a Basic challenge before credential handling. Useful for registries that advertise Bearer but also accept HTTP Basic for the same credential pair.

## Implementation

Three lines in `Client.Do()`, right after `parseChallenge()` and before the existing scheme switch:

\`\`\`go
if c.ForceBasicAuth && scheme == SchemeBearer {
    scheme = SchemeBasic
}
\`\`\`

The rest of the basic-auth path runs unchanged. The override bypasses the bearer flow entirely, so it does not interact with the token-fetching logic.

## Independence

Independent of PRs A (#1180) and B (#1181). Based directly on \`main\`. Can land in any order relative to the other two.

## Test plan

- [x] \`go test -mod=mod ./registry/remote/auth/...\` — passes
- [x] New \`TestClient_Do_ForceBasicAuth_OverridesBearer\` verifies: registry sends Bearer challenge → client retries with Basic header → 200
- [ ] CI on this PR

Replaces #1141 together with PRs A and B.