### PR TITLE
fix(remote): guard GetCredentialFunc against nil store

### DIFF
--- a/registry/remote/auth.go
+++ b/registry/remote/auth.go
@@ -68,8 +68,15 @@ func Logout(ctx context.Context, store credentials.Store, registryName string) e
 	return nil
 }
 
-// GetCredentialFunc returns a GetCredentialFunc() function that can be used by auth.Client.
+// GetCredentialFunc returns a CredentialFunc that retrieves credentials from
+// the given store. If store is nil, the returned function always returns
+// EmptyCredential without error.
 func GetCredentialFunc(store credentials.Store) credentials.CredentialFunc {
+	if store == nil {
+		return func(context.Context, string) (credentials.Credential, error) {
+			return credentials.EmptyCredential, nil
+		}
+	}
 	return func(ctx context.Context, hostport string) (credentials.Credential, error) {
 		hostport = ServerAddressFromHostname(hostport)
 		if hostport == "" {

--- a/registry/remote/auth_test.go
+++ b/registry/remote/auth_test.go
@@ -205,6 +205,17 @@ func Test_mapHostname(t *testing.T) {
 	}
 }
 
+func TestGetCredentialFunc_NilStore(t *testing.T) {
+	fn := GetCredentialFunc(nil)
+	got, err := fn(context.Background(), "localhost:5000")
+	if err != nil {
+		t.Fatalf("GetCredentialFunc(nil) returned error: %v", err)
+	}
+	if got != credentials.EmptyCredential {
+		t.Errorf("GetCredentialFunc(nil) = %v, want EmptyCredential", got)
+	}
+}
+
 func TestCredential(t *testing.T) {
 	// create a test store
 	s := &testStore{}

--- a/registry/remote/url.go
+++ b/registry/remote/url.go
@@ -88,7 +88,7 @@ func buildRepositoryBlobUploadURL(plainHTTP bool, ref registry.Reference) string
 	return buildRepositoryBaseURL(plainHTTP, ref) + "/blobs/uploads/"
 }
 
-// buildRepositoryBlobMountURLbuilds the URL for cross-repository mounting.
+// buildRepositoryBlobMountURL builds the URL for cross-repository mounting.
 // Format: <scheme>://<registry>/v2/<repository>/blobs/uploads/?mount=<digest>&from=<other_repository>
 // Reference: https://distribution.github.io/distribution/spec/api/#blob
 func buildRepositoryBlobMountURL(plainHTTP bool, ref registry.Reference, d digest.Digest, fromRepo string) string {


### PR DESCRIPTION
## Summary

A `nil` `credentials.Store` passed to `GetCredentialFunc` would cause a deferred panic inside the returned closure at authentication time, making it hard to diagnose. This PR adds an early nil check that returns a no-op `CredentialFunc` yielding `EmptyCredential` when `store` is `nil`, matching the documented semantics.

Also fixes a small typo in the `buildRepositoryBlobMountURL` doc comment (missing space).

Split out from #1115 — the other half (Ingest temp-file cleanup) is in a separate PR.

## Test plan
- [x] Added `TestGetCredentialFunc_NilStore` to verify nil store returns `EmptyCredential` without error
- [x] Unit tests pass (`make test`)