### PR TITLE
feat(remote): add ReferrerCapability state machine and merge pool

### DIFF
--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -60,8 +60,9 @@ type referrerChange struct {
 }
 
 var (
-	// ErrReferrersCapabilityAlreadySet is returned by SetReferrersCapability()
-	// when the Referrers API capability has been already set.
+	// ErrReferrersCapabilityAlreadySet is returned by ReferrerCapability.SetSupported()
+	// and ReferrerCapability.SetUnsupported() when the capability has already been set
+	// to a conflicting value.
 	ErrReferrersCapabilityAlreadySet = errors.New("referrers capability cannot be changed once set")
 
 	// errNoReferrerUpdate is returned by applyReferrerChanges() when there

--- a/registry/remote/referrers_state.go
+++ b/registry/remote/referrers_state.go
@@ -1,0 +1,145 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"sync/atomic"
+
+	"github.com/oras-project/oras-go/v3/internal/syncutil"
+)
+
+// ReferrerCapability tracks a registry's Referrers API support.
+// It provides thread-safe state management for the referrers capability.
+type ReferrerCapability struct {
+	state int32
+}
+
+// NewReferrerCapability creates a new ReferrerCapability with unknown state.
+func NewReferrerCapability() *ReferrerCapability {
+	return &ReferrerCapability{
+		state: referrersStateUnknown,
+	}
+}
+
+// IsSupported returns true if the registry is known to support the Referrers API.
+func (c *ReferrerCapability) IsSupported() bool {
+	return atomic.LoadInt32(&c.state) == referrersStateSupported
+}
+
+// IsUnsupported returns true if the registry is known to NOT support the Referrers API.
+func (c *ReferrerCapability) IsUnsupported() bool {
+	return atomic.LoadInt32(&c.state) == referrersStateUnsupported
+}
+
+// IsUnknown returns true if the registry's Referrers API support is unknown.
+func (c *ReferrerCapability) IsUnknown() bool {
+	return atomic.LoadInt32(&c.state) == referrersStateUnknown
+}
+
+// State returns the current state of the referrers capability.
+func (c *ReferrerCapability) State() referrersState {
+	return atomic.LoadInt32(&c.state)
+}
+
+// SetSupported marks the registry as supporting the Referrers API.
+// Returns ErrReferrersCapabilityAlreadySet if the state was already set
+// to a different value.
+func (c *ReferrerCapability) SetSupported() error {
+	return c.setState(referrersStateSupported)
+}
+
+// SetUnsupported marks the registry as NOT supporting the Referrers API.
+// Returns ErrReferrersCapabilityAlreadySet if the state was already set
+// to a different value.
+func (c *ReferrerCapability) SetUnsupported() error {
+	return c.setState(referrersStateUnsupported)
+}
+
+// TrySetSupported attempts to mark the registry as supporting the Referrers API.
+// Returns true if the state was successfully set, false if it was already set.
+// Unlike SetSupported, this method does not return an error if the state
+// matches the current value.
+func (c *ReferrerCapability) TrySetSupported() bool {
+	return atomic.CompareAndSwapInt32(&c.state, referrersStateUnknown, referrersStateSupported) ||
+		c.IsSupported()
+}
+
+// TrySetUnsupported attempts to mark the registry as NOT supporting the Referrers API.
+// Returns true if the state was successfully set, false if it was already set.
+// Unlike SetUnsupported, this method does not return an error if the state
+// matches the current value.
+func (c *ReferrerCapability) TrySetUnsupported() bool {
+	return atomic.CompareAndSwapInt32(&c.state, referrersStateUnknown, referrersStateUnsupported) ||
+		c.IsUnsupported()
+}
+
+// Reset resets the capability state to unknown.
+// This is primarily useful for testing.
+func (c *ReferrerCapability) Reset() {
+	atomic.StoreInt32(&c.state, referrersStateUnknown)
+}
+
+// setState atomically sets the state, returning an error if the state
+// was already set to a different value.
+func (c *ReferrerCapability) setState(newState referrersState) error {
+	if swapped := atomic.CompareAndSwapInt32(&c.state, referrersStateUnknown, newState); swapped {
+		return nil
+	}
+	// Check if the current state matches what we're trying to set
+	if c.State() == newState {
+		return nil
+	}
+	return ErrReferrersCapabilityAlreadySet
+}
+
+// ReferrerMergePool manages concurrent updates to referrers indices.
+// It provides a way to merge concurrent tag schema updates for the same
+// subject, reducing redundant read-modify-write cycles.
+type ReferrerMergePool struct {
+	pool syncutil.Pool[syncutil.Merge[referrerChange]]
+}
+
+// NewReferrerMergePool creates a new ReferrerMergePool.
+func NewReferrerMergePool() *ReferrerMergePool {
+	return &ReferrerMergePool{}
+}
+
+// Get retrieves or creates a merge operation for the given referrers tag.
+// The caller must invoke the returned done function when finished.
+func (p *ReferrerMergePool) Get(referrersTag string) (*syncutil.Merge[referrerChange], func()) {
+	return p.pool.Get(referrersTag)
+}
+
+// Do executes a referrer change operation with automatic merging of concurrent
+// updates to the same referrers tag.
+//
+// Parameters:
+//   - referrersTag: The tag identifying the referrers index
+//   - change: The referrer change to apply
+//   - prepare: Function to fetch the current referrers index (called once per batch)
+//   - update: Function to apply all batched changes and push the updated index
+//
+// Returns any error from prepare or update functions.
+func (p *ReferrerMergePool) Do(
+	referrersTag string,
+	change referrerChange,
+	prepare func() error,
+	update func(changes []referrerChange) error,
+) error {
+	merge, done := p.pool.Get(referrersTag)
+	defer done()
+	return merge.Do(change, prepare, update)
+}

--- a/registry/remote/referrers_state_test.go
+++ b/registry/remote/referrers_state_test.go
@@ -1,0 +1,397 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestNewReferrerCapability(t *testing.T) {
+	cap := NewReferrerCapability()
+	if !cap.IsUnknown() {
+		t.Error("NewReferrerCapability() should start with unknown state")
+	}
+	if cap.IsSupported() {
+		t.Error("NewReferrerCapability() should not be supported")
+	}
+	if cap.IsUnsupported() {
+		t.Error("NewReferrerCapability() should not be unsupported")
+	}
+}
+
+func TestReferrerCapability_SetSupported(t *testing.T) {
+	cap := NewReferrerCapability()
+
+	err := cap.SetSupported()
+	if err != nil {
+		t.Fatalf("SetSupported() error = %v", err)
+	}
+	if !cap.IsSupported() {
+		t.Error("IsSupported() = false after SetSupported()")
+	}
+	if cap.IsUnknown() {
+		t.Error("IsUnknown() = true after SetSupported()")
+	}
+	if cap.IsUnsupported() {
+		t.Error("IsUnsupported() = true after SetSupported()")
+	}
+
+	// Setting again to same value should succeed
+	err = cap.SetSupported()
+	if err != nil {
+		t.Errorf("SetSupported() again error = %v", err)
+	}
+}
+
+func TestReferrerCapability_SetUnsupported(t *testing.T) {
+	cap := NewReferrerCapability()
+
+	err := cap.SetUnsupported()
+	if err != nil {
+		t.Fatalf("SetUnsupported() error = %v", err)
+	}
+	if cap.IsSupported() {
+		t.Error("IsSupported() = true after SetUnsupported()")
+	}
+	if cap.IsUnknown() {
+		t.Error("IsUnknown() = true after SetUnsupported()")
+	}
+	if !cap.IsUnsupported() {
+		t.Error("IsUnsupported() = false after SetUnsupported()")
+	}
+
+	// Setting again to same value should succeed
+	err = cap.SetUnsupported()
+	if err != nil {
+		t.Errorf("SetUnsupported() again error = %v", err)
+	}
+}
+
+func TestReferrerCapability_CannotChangeAfterSet(t *testing.T) {
+	// Test setting to supported then trying to set to unsupported
+	t.Run("supported then unsupported", func(t *testing.T) {
+		cap := NewReferrerCapability()
+		if err := cap.SetSupported(); err != nil {
+			t.Fatalf("SetSupported() error = %v", err)
+		}
+		err := cap.SetUnsupported()
+		if !errors.Is(err, ErrReferrersCapabilityAlreadySet) {
+			t.Errorf("SetUnsupported() error = %v, want %v", err, ErrReferrersCapabilityAlreadySet)
+		}
+	})
+
+	// Test setting to unsupported then trying to set to supported
+	t.Run("unsupported then supported", func(t *testing.T) {
+		cap := NewReferrerCapability()
+		if err := cap.SetUnsupported(); err != nil {
+			t.Fatalf("SetUnsupported() error = %v", err)
+		}
+		err := cap.SetSupported()
+		if !errors.Is(err, ErrReferrersCapabilityAlreadySet) {
+			t.Errorf("SetSupported() error = %v, want %v", err, ErrReferrersCapabilityAlreadySet)
+		}
+	})
+}
+
+func TestReferrerCapability_TrySetSupported(t *testing.T) {
+	cap := NewReferrerCapability()
+
+	// First try should succeed
+	if !cap.TrySetSupported() {
+		t.Error("TrySetSupported() = false, want true")
+	}
+	if !cap.IsSupported() {
+		t.Error("IsSupported() = false after TrySetSupported()")
+	}
+
+	// Second try with same value should succeed
+	if !cap.TrySetSupported() {
+		t.Error("TrySetSupported() again = false, want true")
+	}
+
+	// Try setting to unsupported should fail
+	if cap.TrySetUnsupported() {
+		t.Error("TrySetUnsupported() = true after TrySetSupported()")
+	}
+}
+
+func TestReferrerCapability_TrySetUnsupported(t *testing.T) {
+	cap := NewReferrerCapability()
+
+	// First try should succeed
+	if !cap.TrySetUnsupported() {
+		t.Error("TrySetUnsupported() = false, want true")
+	}
+	if !cap.IsUnsupported() {
+		t.Error("IsUnsupported() = false after TrySetUnsupported()")
+	}
+
+	// Second try with same value should succeed
+	if !cap.TrySetUnsupported() {
+		t.Error("TrySetUnsupported() again = false, want true")
+	}
+
+	// Try setting to supported should fail
+	if cap.TrySetSupported() {
+		t.Error("TrySetSupported() = true after TrySetUnsupported()")
+	}
+}
+
+func TestReferrerCapability_Reset(t *testing.T) {
+	cap := NewReferrerCapability()
+
+	// Set to supported
+	if err := cap.SetSupported(); err != nil {
+		t.Fatalf("SetSupported() error = %v", err)
+	}
+	if !cap.IsSupported() {
+		t.Error("IsSupported() = false after SetSupported()")
+	}
+
+	// Reset
+	cap.Reset()
+	if !cap.IsUnknown() {
+		t.Error("IsUnknown() = false after Reset()")
+	}
+	if cap.IsSupported() {
+		t.Error("IsSupported() = true after Reset()")
+	}
+
+	// Should be able to set again after reset
+	if err := cap.SetUnsupported(); err != nil {
+		t.Errorf("SetUnsupported() after Reset() error = %v", err)
+	}
+	if !cap.IsUnsupported() {
+		t.Error("IsUnsupported() = false after SetUnsupported()")
+	}
+}
+
+func TestReferrerCapability_State(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(*ReferrerCapability)
+		wantState referrersState
+	}{
+		{
+			name:      "unknown",
+			setup:     func(c *ReferrerCapability) {},
+			wantState: referrersStateUnknown,
+		},
+		{
+			name: "supported",
+			setup: func(c *ReferrerCapability) {
+				c.SetSupported()
+			},
+			wantState: referrersStateSupported,
+		},
+		{
+			name: "unsupported",
+			setup: func(c *ReferrerCapability) {
+				c.SetUnsupported()
+			},
+			wantState: referrersStateUnsupported,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cap := NewReferrerCapability()
+			tt.setup(cap)
+			if got := cap.State(); got != tt.wantState {
+				t.Errorf("State() = %v, want %v", got, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestReferrerCapability_Concurrent(t *testing.T) {
+	cap := NewReferrerCapability()
+
+	var wg sync.WaitGroup
+	// Run multiple goroutines trying to set the state
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cap.TrySetSupported()
+		}()
+		go func() {
+			defer wg.Done()
+			cap.TrySetUnsupported()
+		}()
+	}
+	wg.Wait()
+
+	// After all concurrent attempts, exactly one state should be set
+	if cap.IsUnknown() {
+		t.Error("State should not be unknown after concurrent sets")
+	}
+	if cap.IsSupported() && cap.IsUnsupported() {
+		t.Error("State cannot be both supported and unsupported")
+	}
+	if !cap.IsSupported() && !cap.IsUnsupported() {
+		t.Error("State must be either supported or unsupported")
+	}
+}
+
+func TestNewReferrerMergePool(t *testing.T) {
+	pool := NewReferrerMergePool()
+	if pool == nil {
+		t.Fatal("NewReferrerMergePool() returned nil")
+	}
+}
+
+func TestReferrerMergePool_Get(t *testing.T) {
+	pool := NewReferrerMergePool()
+
+	// Get should return a merge and a done function
+	merge, done := pool.Get("sha256-abc123")
+	if merge == nil {
+		t.Fatal("Get() returned nil merge")
+	}
+	if done == nil {
+		t.Fatal("Get() returned nil done function")
+	}
+
+	// Clean up
+	done()
+}
+
+func TestReferrerMergePool_Do(t *testing.T) {
+	pool := NewReferrerMergePool()
+
+	prepareCalled := false
+	updateCalled := false
+	var receivedChanges []referrerChange
+
+	err := pool.Do(
+		"sha256-abc123",
+		referrerChange{operation: referrerOperationAdd},
+		func() error {
+			prepareCalled = true
+			return nil
+		},
+		func(changes []referrerChange) error {
+			updateCalled = true
+			receivedChanges = changes
+			return nil
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	if !prepareCalled {
+		t.Error("prepare function was not called")
+	}
+	if !updateCalled {
+		t.Error("update function was not called")
+	}
+	if len(receivedChanges) != 1 {
+		t.Errorf("expected 1 change, got %d", len(receivedChanges))
+	}
+}
+
+func TestReferrerMergePool_Do_PrepareError(t *testing.T) {
+	pool := NewReferrerMergePool()
+
+	expectedErr := errors.New("prepare error")
+
+	err := pool.Do(
+		"sha256-abc123",
+		referrerChange{operation: referrerOperationAdd},
+		func() error {
+			return expectedErr
+		},
+		func(changes []referrerChange) error {
+			t.Error("update should not be called when prepare fails")
+			return nil
+		},
+	)
+
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Do() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestReferrerMergePool_Do_UpdateError(t *testing.T) {
+	pool := NewReferrerMergePool()
+
+	expectedErr := errors.New("update error")
+
+	err := pool.Do(
+		"sha256-abc123",
+		referrerChange{operation: referrerOperationAdd},
+		func() error {
+			return nil
+		},
+		func(changes []referrerChange) error {
+			return expectedErr
+		},
+	)
+
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Do() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestReferrerMergePool_Concurrent(t *testing.T) {
+	pool := NewReferrerMergePool()
+
+	var wg sync.WaitGroup
+	var prepareCount, updateCount int
+	var mu sync.Mutex
+
+	// Run multiple goroutines doing updates on the same tag
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := pool.Do(
+				"sha256-same-tag",
+				referrerChange{operation: referrerOperationAdd},
+				func() error {
+					mu.Lock()
+					prepareCount++
+					mu.Unlock()
+					return nil
+				},
+				func(changes []referrerChange) error {
+					mu.Lock()
+					updateCount++
+					mu.Unlock()
+					return nil
+				},
+			)
+			if err != nil {
+				t.Errorf("Do() error = %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Due to merging, prepare and update may be called fewer times than
+	// the total number of concurrent operations
+	if prepareCount == 0 {
+		t.Error("prepare should have been called at least once")
+	}
+	if updateCount == 0 {
+		t.Error("update should have been called at least once")
+	}
+}


### PR DESCRIPTION
## What

Adds a self-contained `ReferrerCapability` type and a `ReferrerMergePool` helper in `registry/remote`, plus a small doc-comment update on `ErrReferrersCapabilityAlreadySet`.

- `ReferrerCapability` — atomic state machine tracking per-registry referrers API support (unknown / supported / unsupported). Provides `IsSupported`/`IsUnsupported`/`IsUnknown`, strict `SetSupported`/`SetUnsupported` (returning `ErrReferrersCapabilityAlreadySet` on conflict), idempotent `TrySetSupported`/`TrySetUnsupported`, plus `State`/`Reset`.
- `ReferrerMergePool` — `syncutil.Pool[syncutil.Merge[referrerChange]]` wrapper that batches concurrent updates targeting the same referrers tag, exposing `Get` and `Do(referrersTag, change, prepare, update)` to coalesce read-modify-write cycles.
- Updates the `ErrReferrersCapabilityAlreadySet` doc comment to reference the new methods.

## Why

Part of the v3 PR-by-PR breakdown (PR 9: `feat/referrers-state`). Self-contained piece of the larger v3 work, reviewable independently before the repository integration PR plugs it in.

## Test plan

- [x] `go build -mod=mod ./registry/remote/...`
- [x] `go test -mod=mod ./registry/remote/` — passes (`ok ... 20.651s`)
- [x] New `referrers_state_test.go` covers state transitions, concurrent Set/TrySet semantics, and merge-pool batching