### PR TITLE
feat(registry)!: add Tag and Digest fields to Reference

### DIFF
--- a/registry/example_reference_test.go
+++ b/registry/example_reference_test.go
@@ -34,7 +34,7 @@ func ExampleParseReference_digest() {
 	fmt.Println("Registry:", ref.Registry)
 	fmt.Println("Repository:", ref.Repository)
 
-	digest, err := ref.Digest()
+	digest, err := ref.GetDigest()
 	if err != nil {
 		panic(err)
 	}

--- a/registry/reference.go
+++ b/registry/reference.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	"github.com/oras-project/oras-go/v3/errdef"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 // regular expressions for components.
@@ -47,6 +48,9 @@ var (
 // Reference references either a resource descriptor (where Reference.Reference
 // is a tag or a digest), or a resource repository (where Reference.Reference
 // is the empty string).
+//
+// Deprecated: Use [github.com/oras-project/oras-go/v3/registry/remote/properties.Reference] instead.
+// This type will be removed in a future version.
 type Reference struct {
 	// Registry is the name of the registry. It is usually the domain name of
 	// the registry optionally with a port.
@@ -60,7 +64,18 @@ type Reference struct {
 	// case where it's the empty string, it necessarily implies valid form D,
 	// and where it is non-empty, then it is either a tag, or a digest
 	// (implying one of valid forms A, B, or C).
+	//
+	// Deprecated: Use GetReference() method instead to retrieve the reference string.
+	// For specific access to tag or digest values, use the Tag or Digest fields.
 	Reference string
+
+	// Tag is the tag of the object in the repository, if a tag was provided.
+	// This field is empty if only a digest was provided (Form A) or if no reference was provided (Form D).
+	Tag string
+
+	// Digest is the digest of the object in the repository, if a digest was provided.
+	// This field is empty if only a tag was provided (Form C) or if no reference was provided (Form D).
+	Digest string
 }
 
 // ParseReference parses a string (artifact) into an `artifact reference`.
@@ -123,84 +138,33 @@ type Reference struct {
 //	<--- path --------------------------------------------> |  - Decode `path`
 //	<=== REPOSITORY ===> <--- reference ------------------> |    - Decode `reference`
 //	<=== REPOSITORY ===> @ <=================== digest ===> |      - Valid Form A
-//	<=== REPOSITORY ===> : <!!! TAG !!!> @ <=== digest ===> |      - Valid Form B (tag is dropped)
+//	<=== REPOSITORY ===> : <=== TAG ===> @ <=== digest ===> |      - Valid Form B
 //	<=== REPOSITORY ===> : <=== TAG ======================> |      - Valid Form C
 //	<=== REPOSITORY ======================================> |    - Valid Form D
 //
-// Note: In the case of Valid Form B, TAG is dropped without any validation or
-// further consideration.
+// Note: In the case of Valid Form B, the digest takes precedence in the Reference
+// field, but the TAG is captured and stored in the Tag field.
+//
+// Deprecated: Use [github.com/oras-project/oras-go/v3/registry/remote/properties.NewReference] instead.
+// This function will be removed in a future version.
 func ParseReference(artifact string) (Reference, error) {
-	// Strip URI schemes if present
-	artifact = strings.TrimPrefix(artifact, "oci://")
-	artifact = strings.TrimPrefix(artifact, "http://")
-	artifact = strings.TrimPrefix(artifact, "https://")
-
-	registry, path := splitRegistry(artifact)
-	if path == "" {
-		return Reference{}, fmt.Errorf("%w: missing registry or repository", errdef.ErrInvalidReference)
+	p, err := properties.NewReference(artifact)
+	if err != nil {
+		return Reference{}, err
 	}
 
-	repository, reference, isTag := splitRepository(path)
-	ref := Reference{
-		Registry:   registry,
-		Repository: repository,
+	reference := p.Digest
+	if reference == "" {
+		reference = p.Tag
+	}
+
+	return Reference{
+		Registry:   p.Registry,
+		Repository: p.Repository,
 		Reference:  reference,
-	}
-
-	if err := ref.ValidateRegistry(); err != nil {
-		return Reference{}, err
-	}
-
-	if err := ref.ValidateRepository(); err != nil {
-		return Reference{}, err
-	}
-
-	if len(ref.Reference) == 0 {
-		return ref, nil
-	}
-
-	validator := ref.ValidateReferenceAsDigest
-	if isTag {
-		validator = ref.ValidateReferenceAsTag
-	}
-	if err := validator(); err != nil {
-		return Reference{}, err
-	}
-
-	return ref, nil
-}
-
-// splitRepository splits the path into repository and reference, indicating
-// whether the reference is a tag or not.
-func splitRepository(path string) (string, string, bool) {
-	if index := strings.Index(path, "@"); index != -1 {
-		// `digest` found; Valid Form A (if not B)
-		repository := path[:index]
-		reference := path[index+1:]
-
-		if index = strings.Index(repository, ":"); index != -1 {
-			// `tag` found (and now dropped without validation) since the
-			// digest is already present; Valid Form B
-			repository = repository[:index]
-		}
-		return repository, reference, false
-	}
-
-	if index := strings.Index(path, ":"); index != -1 {
-		// `tag` found; Valid Form C
-		return path[:index], path[index+1:], true
-	}
-
-	// empty `reference`; Valid Form D
-	return path, "", false
-}
-
-func splitRegistry(artifact string) (string, string) {
-	parts := strings.SplitN(artifact, "/", 2)
-	if len(parts) == 1 {
-		return parts[0], ""
-	}
-	return parts[0], parts[1]
+		Tag:        p.Tag,
+		Digest:     p.Digest,
+	}, nil
 }
 
 // Validate the entire reference object; the registry, the repository, and the
@@ -243,7 +207,7 @@ func (r Reference) ValidateReferenceAsTag() error {
 
 // ValidateReferenceAsDigest validates the reference as a digest.
 func (r Reference) ValidateReferenceAsDigest() error {
-	if _, err := r.Digest(); err != nil {
+	if _, err := r.GetDigest(); err != nil {
 		return fmt.Errorf("%w: invalid digest %q: %v", errdef.ErrInvalidReference, r.Reference, err)
 	}
 	return nil
@@ -279,11 +243,21 @@ func (r Reference) ReferenceOrDefault() string {
 	return r.Reference
 }
 
-// Digest returns the reference as a digest.
+// GetDigest returns the reference as a digest.
 // Corresponding cryptographic hash implementations are required to be imported
 // as specified by https://pkg.go.dev/github.com/opencontainers/go-digest#readme-usage
-func (r Reference) Digest() (digest.Digest, error) {
+func (r Reference) GetDigest() (digest.Digest, error) {
 	return digest.Parse(r.Reference)
+}
+
+// GetReference returns the reference string (either a tag or a digest).
+// This method should be used instead of directly accessing the deprecated Reference field.
+func (r Reference) GetReference() string {
+
+	if r.Digest == "" {
+		return r.Reference
+	}
+	return r.Digest
 }
 
 // String implements `fmt.Stringer` and returns the reference string.
@@ -296,7 +270,7 @@ func (r Reference) String() string {
 	if r.Reference == "" {
 		return ref
 	}
-	if d, err := r.Digest(); err == nil {
+	if d, err := r.GetDigest(); err == nil {
 		return ref + "@" + d.String()
 	}
 	return ref + ":" + r.Reference

--- a/registry/reference_test.go
+++ b/registry/reference_test.go
@@ -38,6 +38,7 @@ func TestParseReferenceGoodies(t *testing.T) {
 			wantTemplate: Reference{
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Digest:     ValidDigest,
 			},
 		},
 		{
@@ -46,6 +47,8 @@ func TestParseReferenceGoodies(t *testing.T) {
 			wantTemplate: Reference{
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Tag:        "v2",
+				Digest:     ValidDigest,
 			},
 		},
 		{
@@ -54,6 +57,7 @@ func TestParseReferenceGoodies(t *testing.T) {
 			wantTemplate: Reference{
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Digest:     ValidDigest,
 			},
 		},
 		{
@@ -62,6 +66,7 @@ func TestParseReferenceGoodies(t *testing.T) {
 			wantTemplate: Reference{
 				Repository: "hello-world",
 				Reference:  "v1",
+				Tag:        "v1",
 			},
 		},
 		{
@@ -351,6 +356,224 @@ func TestReference_String(t *testing.T) {
 	}
 }
 
+func TestParseReference_FormB_TagAndDigest(t *testing.T) {
+	// Test Form B: repository:tag@digest
+	// Validates that both tag and digest are captured correctly
+	tests := []struct {
+		name         string
+		artifact     string
+		wantRegistry string
+		wantRepo     string
+		wantTag      string
+		wantDigest   string
+		wantRef      string
+	}{
+		{
+			name:         "tag with digest",
+			artifact:     fmt.Sprintf("localhost/hello-world:v2@%s", ValidDigest),
+			wantRegistry: "localhost",
+			wantRepo:     "hello-world",
+			wantTag:      "v2",
+			wantDigest:   ValidDigest,
+			wantRef:      ValidDigest,
+		},
+		{
+			name:         "tag with digest - different tag",
+			artifact:     fmt.Sprintf("registry.example.com/myapp:1.0.0@%s", ValidDigest),
+			wantRegistry: "registry.example.com",
+			wantRepo:     "myapp",
+			wantTag:      "1.0.0",
+			wantDigest:   ValidDigest,
+			wantRef:      ValidDigest,
+		},
+		{
+			name:         "tag with digest - complex tag",
+			artifact:     fmt.Sprintf("localhost:5000/org/repo:v1.2.3-alpha@%s", ValidDigest),
+			wantRegistry: "localhost:5000",
+			wantRepo:     "org/repo",
+			wantTag:      "v1.2.3-alpha",
+			wantDigest:   ValidDigest,
+			wantRef:      ValidDigest,
+		},
+		{
+			name:         "empty tag with digest",
+			artifact:     fmt.Sprintf("localhost/hello-world:@%s", ValidDigest),
+			wantRegistry: "localhost",
+			wantRepo:     "hello-world",
+			wantTag:      "",
+			wantDigest:   ValidDigest,
+			wantRef:      ValidDigest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseReference(tt.artifact)
+			if err != nil {
+				t.Fatalf("ParseReference() unexpected error: %v", err)
+			}
+
+			// Validate Registry
+			if got.Registry != tt.wantRegistry {
+				t.Errorf("Registry = %q, want %q", got.Registry, tt.wantRegistry)
+			}
+
+			// Validate Repository
+			if got.Repository != tt.wantRepo {
+				t.Errorf("Repository = %q, want %q", got.Repository, tt.wantRepo)
+			}
+
+			// Validate Tag field
+			if got.Tag != tt.wantTag {
+				t.Errorf("Tag = %q, want %q", got.Tag, tt.wantTag)
+			}
+
+			// Validate Digest field
+			if got.Digest != tt.wantDigest {
+				t.Errorf("Digest = %q, want %q", got.Digest, tt.wantDigest)
+			}
+
+			// Validate Reference field (should be digest for Form B)
+			if got.Reference != tt.wantRef {
+				t.Errorf("Reference = %q, want %q", got.Reference, tt.wantRef)
+			}
+
+			// Validate GetReference() method
+			if got.GetReference() != tt.wantRef {
+				t.Errorf("GetReference() = %q, want %q", got.GetReference(), tt.wantRef)
+			}
+		})
+	}
+}
+
+func TestReference_GetReference(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference Reference
+		want      string
+	}{
+		{
+			name: "Form A: digest only",
+			reference: Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+				Reference:  ValidDigest,
+				Digest:     ValidDigest,
+			},
+			want: ValidDigest,
+		},
+		{
+			name: "Form B: tag with digest",
+			reference: Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+				Reference:  ValidDigest,
+				Tag:        "v1",
+				Digest:     ValidDigest,
+			},
+			want: ValidDigest,
+		},
+		{
+			name: "Form C: tag only",
+			reference: Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+				Reference:  "v1.0.0",
+				Tag:        "v1.0.0",
+			},
+			want: "v1.0.0",
+		},
+		{
+			name: "Form D: no reference",
+			reference: Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+			},
+			want: "",
+		},
+		{
+			name: "empty Digest returns Reference field",
+			reference: Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+				Reference:  "latest",
+				Digest:     "",
+			},
+			want: "latest",
+		},
+		{
+			name: "Digest takes precedence over Reference",
+			reference: Reference{
+				Registry:   "registry.example.com",
+				Repository: "hello-world",
+				Reference:  "some-tag",
+				Digest:     ValidDigest,
+			},
+			want: ValidDigest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reference.GetReference(); got != tt.want {
+				t.Errorf("Reference.GetReference() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReference_GetReference_ParsedReferences(t *testing.T) {
+	// Test GetReference with references created via ParseReference
+	tests := []struct {
+		name     string
+		artifact string
+		want     string
+	}{
+		{
+			name:     "Form A: digest reference",
+			artifact: fmt.Sprintf("localhost/hello-world@%s", ValidDigest),
+			want:     ValidDigest,
+		},
+		{
+			name:     "Form B: tag with digest",
+			artifact: fmt.Sprintf("localhost/hello-world:v2@%s", ValidDigest),
+			want:     ValidDigest,
+		},
+		{
+			name:     "Form C: tag reference",
+			artifact: "localhost/hello-world:v1",
+			want:     "v1",
+		},
+		{
+			name:     "Form D: no reference",
+			artifact: "localhost/hello-world",
+			want:     "",
+		},
+		{
+			name:     "complex tag",
+			artifact: "registry.example.com/org/repo:v1.2.3-alpha.1_build.123",
+			want:     "v1.2.3-alpha.1_build.123",
+		},
+		{
+			name:     "nested repository with digest",
+			artifact: fmt.Sprintf("localhost:5000/org/team/project@%s", ValidDigest),
+			want:     ValidDigest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, err := ParseReference(tt.artifact)
+			if err != nil {
+				t.Fatalf("ParseReference() unexpected error: %v", err)
+			}
+			if got := ref.GetReference(); got != tt.want {
+				t.Errorf("Reference.GetReference() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseReferenceWithSchemes(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -366,6 +589,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "localhost",
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Digest:     ValidDigest,
 			},
 			wantErr: false,
 		},
@@ -376,6 +600,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 				Reference:  "v1",
+				Tag:        "v1",
 			},
 			wantErr: false,
 		},
@@ -386,6 +611,8 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Tag:        "v2",
+				Digest:     ValidDigest,
 			},
 			wantErr: false,
 		},
@@ -405,6 +632,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "[::1]:5000",
 				Repository: "hello-world",
 				Reference:  "latest",
+				Tag:        "latest",
 			},
 			wantErr: false,
 		},
@@ -415,6 +643,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "ghcr.io",
 				Repository: "oras-project/oras-go",
 				Reference:  "v3.0.0",
+				Tag:        "v3.0.0",
 			},
 			wantErr: false,
 		},
@@ -427,6 +656,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "localhost",
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Digest:     ValidDigest,
 			},
 			wantErr: false,
 		},
@@ -437,6 +667,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "registry.example.com:8080",
 				Repository: "hello-world",
 				Reference:  "v1",
+				Tag:        "v1",
 			},
 			wantErr: false,
 		},
@@ -449,6 +680,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "localhost",
 				Repository: "hello-world",
 				Reference:  ValidDigest,
+				Digest:     ValidDigest,
 			},
 			wantErr: false,
 		},
@@ -459,6 +691,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 				Reference:  "v1",
+				Tag:        "v1",
 			},
 			wantErr: false,
 		},
@@ -471,6 +704,7 @@ func TestParseReferenceWithSchemes(t *testing.T) {
 				Registry:   "localhost",
 				Repository: "hello-world",
 				Reference:  "v1",
+				Tag:        "v1",
 			},
 			wantErr: false,
 		},

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1064,7 +1064,7 @@ func (s *blobStore) Resolve(ctx context.Context, reference string) (ocispec.Desc
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	refDigest, err := ref.Digest()
+	refDigest, err := ref.GetDigest()
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
@@ -1101,7 +1101,7 @@ func (s *blobStore) FetchReference(ctx context.Context, reference string) (desc 
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	refDigest, err := ref.Digest()
+	refDigest, err := ref.GetDigest()
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
@@ -1692,7 +1692,7 @@ func (s *manifestStore) generateDescriptor(resp *http.Response, ref registry.Ref
 
 	// 3. Validate Client Reference
 	var refDigest digest.Digest
-	if d, err := ref.Digest(); err == nil {
+	if d, err := ref.GetDigest(); err == nil {
 		refDigest = d
 	}
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3615,7 +3615,7 @@ func Test_generateBlobDescriptorWithVariousDockerContentDigestHeaders(t *testing
 
 			var err error
 			var d digest.Digest
-			if d, err = reference.Digest(); err != nil {
+			if d, err = reference.GetDigest(); err != nil {
 				t.Errorf(
 					"[Blob.%v] %v; got digest from a tag reference unexpectedly",
 					method, testName,
@@ -7230,6 +7230,7 @@ func TestRepository_ParseReference(t *testing.T) {
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 				Reference:  "foobar",
+				Tag:        "foobar",
 			},
 			wantErr: nil,
 		},
@@ -7246,6 +7247,7 @@ func TestRepository_ParseReference(t *testing.T) {
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+				Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: nil,
 		},
@@ -7262,6 +7264,8 @@ func TestRepository_ParseReference(t *testing.T) {
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+				Tag:        "foobar",
+				Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: nil,
 		},


### PR DESCRIPTION
## What

Adds explicit `Tag` and `Digest` string fields to `registry.Reference`, fixes Form B parsing, and routes `ParseReference` through `properties.NewReference`.

- `Reference` gains `Tag` and `Digest` fields, populated by `ParseReference`. The legacy `Reference` string field is preserved (and still holds the digest for Form A/B / the tag for Form C) so existing `String()` output is unchanged.
- **Form B (`registry/repo:tag@digest`)**: the tag is now captured in `Reference.Tag` instead of being silently dropped. The digest still takes precedence in the `Reference` field.
- New `GetReference()` method returns the canonical reference string (digest if present, otherwise tag). Preferred over reading the now-deprecated `Reference` field directly.
- `ParseReference` now delegates to `properties.NewReference` (introduced in #1140).
- **Breaking**: the existing `Digest()` method is renamed to `GetDigest()` because the new `Digest` field would otherwise collide. In-tree callers in `registry/remote/repository.go` (3 call sites) and its tests are updated in the same commit.
- `Reference` (the type) and `Reference.Reference` (the field) are marked `Deprecated:` in favor of `registry/remote/properties.Reference`.

## Why

Part of the v3 PR-by-PR breakdown (**PR 14: `feat/registry-reference-updates`**). Depends on PR 4 — `feat(properties): add remote properties package` (#1140, merged) — for `properties.NewReference`.

The previous attempt at this work (#1042) was closed; this version makes the change minimal and self-contained.

## Test plan

- [x] `go build -mod=mod ./...`
- [x] `go test -mod=mod ./registry/... .` — all packages pass
- [x] `registry/reference_test.go` rewritten to cover Tag/Digest field population and GetReference()
- [x] `Repository.ParseReference` FQDN test cases updated to assert the new Tag/Digest fields