### PR TITLE
feat(remote): add MaxPageCount to bound list pagination

### DIFF
--- a/errdef/errors.go
+++ b/errdef/errors.go
@@ -25,6 +25,7 @@ var (
 	ErrInvalidMediaType   = errors.New("invalid media type")
 	ErrMissingReference   = errors.New("missing reference")
 	ErrNotFound           = errors.New("not found")
+	ErrPageCountExceeded  = errors.New("page count exceeds limit")
 	ErrSizeExceedsLimit   = errors.New("size exceeds limit")
 	ErrUnsupported        = errors.New("unsupported")
 	ErrUnsupportedVersion = errors.New("unsupported version")

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -130,7 +130,10 @@ func (r *Registry) Repositories(ctx context.Context, last string, fn func(repos 
 	ctx = auth.AppendScopesForHost(ctx, r.Reference.Host(), auth.ScopeRegistryCatalog)
 	url := buildRegistryCatalogURL(r.PlainHTTP, r.Reference)
 	var err error
-	for err == nil {
+	for pages := 0; err == nil; pages++ {
+		if r.MaxPageCount > 0 && pages >= r.MaxPageCount {
+			return fmt.Errorf("%w: %d", errdef.ErrPageCountExceeded, r.MaxPageCount)
+		}
 		url, err = r.repositories(ctx, last, fn, url)
 		// clear `last` for subsequent pages
 		last = ""

--- a/registry/remote/registry_test.go
+++ b/registry/remote/registry_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -216,6 +217,52 @@ func TestRegistry_Repositories(t *testing.T) {
 	}
 }
 
+func TestRegistry_Repositories_MaxPageCount(t *testing.T) {
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/_catalog" {
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// always advertise a next page to simulate an endless response
+		w.Header().Set("Link", fmt.Sprintf(`<%s/v2/_catalog>; rel="next"`, ts.URL))
+		result := struct {
+			Repositories []string `json:"repositories"`
+		}{
+			Repositories: []string{"repo"},
+		}
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	reg, err := NewRegistry(uri.Host)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	reg.PlainHTTP = true
+	reg.MaxPageCount = 3
+
+	ctx := context.Background()
+	pages := 0
+	err = reg.Repositories(ctx, "", func(got []string) error {
+		pages++
+		return nil
+	})
+	if !errors.Is(err, errdef.ErrPageCountExceeded) {
+		t.Errorf("Registry.Repositories() error = %v, want %v", err, errdef.ErrPageCountExceeded)
+	}
+	if pages != reg.MaxPageCount {
+		t.Errorf("Registry.Repositories() fetched %d pages, want %d", pages, reg.MaxPageCount)
+	}
+}
+
 func TestRegistry_Repository(t *testing.T) {
 	reg, err := NewRegistry("localhost:5000")
 	if err != nil {
@@ -227,6 +274,7 @@ func TestRegistry_Repository(t *testing.T) {
 	reg.TagListPageSize = 100
 	reg.ReferrerListPageSize = 10
 	reg.MaxMetadataBytes = 8 * 1024 * 1024
+	reg.MaxPageCount = 5
 
 	ctx := context.Background()
 	got, err := reg.Repository(ctx, "hello-world")

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -133,6 +133,14 @@ type Repository struct {
 	// If less than or equal to zero, a default (currently 4MiB) is used.
 	MaxMetadataBytes int64
 
+	// MaxPageCount specifies a limit on the number of pages that are fetched
+	// when listing tags, repositories, or referrers via the paginated metadata
+	// APIs.
+	// If less than or equal to zero, no limit is applied and all pages are
+	// fetched. When the limit is exceeded, the listing returns
+	// errdef.ErrPageCountExceeded.
+	MaxPageCount int
+
 	// SkipReferrersGC specifies whether to delete the dangling referrers
 	// index when referrers tag schema is utilized.
 	//  - If false, the old referrers index will be deleted after the new one
@@ -215,6 +223,7 @@ func (r *Repository) clone() *Repository {
 		TagListPageSize:      r.TagListPageSize,
 		ReferrerListPageSize: r.ReferrerListPageSize,
 		MaxMetadataBytes:     r.MaxMetadataBytes,
+		MaxPageCount:         r.MaxPageCount,
 		SkipReferrersGC:      r.SkipReferrersGC,
 		HandleWarning:        r.HandleWarning,
 		Policy:               r.Policy,
@@ -490,7 +499,10 @@ func (r *Repository) Tags(ctx context.Context, last string, fn func(tags []strin
 	ctx = auth.AppendRepositoryScope(ctx, r.Reference, auth.ActionPull)
 	url := buildRepositoryTagListURL(r.PlainHTTP, r.Reference)
 	var err error
-	for err == nil {
+	for pages := 0; err == nil; pages++ {
+		if r.MaxPageCount > 0 && pages >= r.MaxPageCount {
+			return fmt.Errorf("%w: %d", errdef.ErrPageCountExceeded, r.MaxPageCount)
+		}
 		url, err = r.tags(ctx, last, fn, url)
 		// clear `last` for subsequent pages
 		last = ""
@@ -608,7 +620,10 @@ func (r *Repository) referrersByAPI(ctx context.Context, desc ocispec.Descriptor
 
 	url := buildReferrersURL(r.PlainHTTP, ref, artifactType)
 	var err error
-	for err == nil {
+	for pages := 0; err == nil; pages++ {
+		if r.MaxPageCount > 0 && pages >= r.MaxPageCount {
+			return fmt.Errorf("%w: %d", errdef.ErrPageCountExceeded, r.MaxPageCount)
+		}
 		url, err = r.referrersPageByAPI(ctx, artifactType, fn, url)
 	}
 	if err == errNoLink {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1265,6 +1265,113 @@ func TestRepository_Tags(t *testing.T) {
 	}
 }
 
+func TestRepository_Tags_MaxPageCount(t *testing.T) {
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/test/tags/list" {
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// always advertise a next page to simulate an endless response
+		w.Header().Set("Link", fmt.Sprintf(`<%s/v2/test/tags/list>; rel="next"`, ts.URL))
+		result := struct {
+			Tags []string `json:"tags"`
+		}{
+			Tags: []string{"tag"},
+		}
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	repo.MaxPageCount = 3
+
+	ctx := context.Background()
+	pages := 0
+	err = repo.Tags(ctx, "", func(got []string) error {
+		pages++
+		return nil
+	})
+	if !errors.Is(err, errdef.ErrPageCountExceeded) {
+		t.Errorf("Repository.Tags() error = %v, want %v", err, errdef.ErrPageCountExceeded)
+	}
+	if pages != repo.MaxPageCount {
+		t.Errorf("Repository.Tags() fetched %d pages, want %d", pages, repo.MaxPageCount)
+	}
+}
+
+func TestRepository_Referrers_MaxPageCount(t *testing.T) {
+	manifest := []byte(`{"layers":[]}`)
+	manifestDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+	referrer := ocispec.Descriptor{
+		MediaType: spec.MediaTypeArtifactManifest,
+		Size:      1,
+		Digest:    digest.FromString("1"),
+	}
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := "/v2/test/referrers/" + manifestDesc.Digest.String()
+		if r.Method != http.MethodGet || r.URL.Path != path {
+			t.Errorf("unexpected access: %s %q", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// always advertise a next page to simulate an endless response
+		w.Header().Set("Link", fmt.Sprintf(`<%s%s>; rel="next"`, ts.URL, path))
+		result := ocispec.Index{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+			},
+			MediaType: ocispec.MediaTypeImageIndex,
+			Manifests: []ocispec.Descriptor{referrer},
+		}
+		w.Header().Set("Content-Type", ocispec.MediaTypeImageIndex)
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	repo.MaxPageCount = 3
+
+	ctx := context.Background()
+	pages := 0
+	err = repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
+		pages++
+		return nil
+	})
+	if !errors.Is(err, errdef.ErrPageCountExceeded) {
+		t.Errorf("Repository.Referrers() error = %v, want %v", err, errdef.ErrPageCountExceeded)
+	}
+	if pages != repo.MaxPageCount {
+		t.Errorf("Repository.Referrers() fetched %d pages, want %d", pages, repo.MaxPageCount)
+	}
+}
+
 func TestRepository_Predecessors(t *testing.T) {
 	manifest := []byte(`{"layers":[]}`)
 	manifestDesc := ocispec.Descriptor{


### PR DESCRIPTION
## Summary

Tag, repository, and referrer listings follow the server-provided `Link`
header until the server stops sending one, with no cap on the number of
pages. A server can therefore advertise an endless chain of pages and
force the client to keep fetching, consuming unbounded time and memory.
`MaxMetadataBytes` already bounds each individual page, but nothing
bounds how many pages are fetched.

This adds a `MaxPageCount` option on `Repository`/`RepositoryOptions`
(inherited by `Registry`) that limits how many pages are fetched when
listing tags, repositories, or referrers via the paginated metadata
APIs:

- `Registry.Repositories` (catalog)
- `Repository.Tags`
- `Repository.referrersByAPI` (Referrers API)

When the limit is exceeded, the listing returns the new
`errdef.ErrPageCountExceeded`. Combined with `MaxMetadataBytes`, total
transfer is bounded to roughly `MaxPageCount * MaxMetadataBytes`.

`MaxPageCount` defaults to `0` (unlimited), preserving existing behavior;
callers opt in by setting a positive value.

## Test plan

- [x] `go build ./...`
- [x] `go test ./registry/remote/... ./errdef/...`
- [x] New tests: `TestRegistry_Repositories_MaxPageCount`, `TestRepository_Tags_MaxPageCount`, `TestRepository_Referrers_MaxPageCount` (each asserts `ErrPageCountExceeded` and that exactly `MaxPageCount` pages are fetched)
- [x] `TestRegistry_Repository` extended to assert `MaxPageCount` is cloned

🤖 Generated with [Claude Code](https://claude.com/claude-code)