### PR TITLE
fix(copy): re-push referenced manifests when the destination reports them missing

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/oras-project/oras-go/v3/internal/status"
 	"github.com/oras-project/oras-go/v3/internal/syncutil"
 	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -272,13 +273,83 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 		if err != nil {
 			return fmt.Errorf("failed to check cache existence: %s: %w", desc.Digest, err)
 		}
-		if exists {
-			return copyNode(ctx, proxy.Cache, dst, desc, opts)
+		pushNode := func() error {
+			if exists {
+				return copyNode(ctx, proxy.Cache, dst, desc, opts)
+			}
+			return mountOrCopyNode(ctx, src, dst, desc, opts)
 		}
-		return mountOrCopyNode(ctx, src, dst, desc, opts)
+		pushErr := pushNode()
+		if pushErr != nil && len(successors) != 0 && isMissingReferencedContentError(pushErr) {
+			// The push was rejected because the destination is missing content
+			// that this manifest references. This can happen when a previous copy
+			// was interrupted after a referenced manifest's blobs were uploaded but
+			// before that manifest itself was committed: the existence check above
+			// then reports the referenced manifest as present and skips it, yet the
+			// registry rejects this node for referencing it. Re-copy the manifest
+			// successors unconditionally and retry the push once so that an
+			// interrupted copy can self-heal instead of failing identically on
+			// every retry.
+			for _, node := range successors {
+				if !descriptor.IsManifest(node) {
+					// Blob existence is reported reliably by Exists, so
+					// re-pushing large blobs on this recovery path would be
+					// wasteful.
+					continue
+				}
+				if err := doCopyNode(ctx, src, dst, node); err != nil {
+					return err
+				}
+			}
+			pushErr = pushNode()
+		}
+		return pushErr
 	}
 
 	return syncutil.Go(ctx, limiter, fn, root)
+}
+
+// isMissingReferencedContentError reports whether err indicates that a
+// destination registry rejected a manifest because one or more of the
+// descriptors referenced by that manifest are not present in the destination.
+//
+// A registry returns MANIFEST_BLOB_UNKNOWN or BLOB_UNKNOWN when a pushed
+// manifest references content that the registry does not have; for an image
+// index that referenced content is its child manifests. copyGraph uses this to
+// trigger a one-shot, self-healing retry for graphs whose interior nodes were
+// skipped as already-existing but were not in fact durably committed by a prior
+// interrupted copy.
+//
+// References:
+//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#error-codes
+func isMissingReferencedContentError(err error) bool {
+	isMissingCode := func(code string) bool {
+		switch code {
+		case errcode.ErrorCodeManifestBlobUnknown,
+			errcode.ErrorCodeBlobUnknown,
+			errcode.ErrorCodeManifestUnknown:
+			return true
+		default:
+			return false
+		}
+	}
+	// A single inner error, e.g. exactly one missing descriptor.
+	var ec errcode.Error
+	if errors.As(err, &ec) && isMissingCode(ec.Code) {
+		return true
+	}
+	// Multiple inner errors, e.g. several missing descriptors. errcode.Errors
+	// only unwraps to a single errcode.Error when it holds exactly one element,
+	// so the multi-error case must be inspected explicitly.
+	var ecs errcode.Errors
+	if errors.As(err, &ecs) {
+		for _, e := range ecs {
+			if isMissingCode(e.Code) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // mountOrCopyNode tries to mount the node, if not falls back to copying.

--- a/copy_selfheal_internal_test.go
+++ b/copy_selfheal_internal_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
+)
+
+func TestIsMissingReferencedContentError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+		{
+			name: "single MANIFEST_BLOB_UNKNOWN",
+			err:  errcode.Error{Code: errcode.ErrorCodeManifestBlobUnknown},
+			want: true,
+		},
+		{
+			name: "single BLOB_UNKNOWN",
+			err:  errcode.Error{Code: errcode.ErrorCodeBlobUnknown},
+			want: true,
+		},
+		{
+			name: "single MANIFEST_UNKNOWN",
+			err:  errcode.Error{Code: errcode.ErrorCodeManifestUnknown},
+			want: true,
+		},
+		{
+			name: "single unrelated code",
+			err:  errcode.Error{Code: errcode.ErrorCodeNameUnknown},
+			want: false,
+		},
+		{
+			name: "multiple errors with a missing code",
+			err: errcode.Errors{
+				{Code: errcode.ErrorCodeNameUnknown},
+				{Code: errcode.ErrorCodeManifestBlobUnknown},
+			},
+			want: true,
+		},
+		{
+			name: "multiple errors without a missing code",
+			err: errcode.Errors{
+				{Code: errcode.ErrorCodeNameUnknown},
+				{Code: errcode.ErrorCodeDenied},
+			},
+			want: false,
+		},
+		{
+			name: "wrapped in CopyError",
+			err: newCopyError("Push", CopyErrorOriginDestination, errcode.Errors{
+				{Code: errcode.ErrorCodeManifestBlobUnknown},
+			}),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMissingReferencedContentError(tt.err); got != tt.want {
+				t.Errorf("isMissingReferencedContentError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/copy_selfheal_test.go
+++ b/copy_selfheal_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras_test
+
+import (
+	"bytes"
+	"context"
+	_ "crypto/sha256"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/oras-project/oras-go/v3"
+	"github.com/oras-project/oras-go/v3/content"
+	"github.com/oras-project/oras-go/v3/internal/cas"
+	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
+)
+
+// interruptedIndexDst simulates a destination registry left in the partially
+// populated state produced by an interrupted recursive copy of a multi-arch
+// image index: the child manifests' blobs have already been uploaded, but the
+// child manifests themselves were never durably committed. The destination
+// nonetheless reports those child manifests as already existing (a HEAD
+// false-positive), so a plain copy skips re-pushing them; and it rejects any
+// index that references a not-yet-committed child manifest with
+// MANIFEST_BLOB_UNKNOWN, exactly as a spec-compliant registry does.
+type interruptedIndexDst struct {
+	content.Storage
+	mu        sync.Mutex
+	phantom   map[digest.Digest]bool // reported as existing but not yet committed
+	committed map[digest.Digest]bool // actually pushed during the copy
+}
+
+func newInterruptedIndexDst(storage content.Storage, phantom ...digest.Digest) *interruptedIndexDst {
+	d := &interruptedIndexDst{
+		Storage:   storage,
+		phantom:   make(map[digest.Digest]bool),
+		committed: make(map[digest.Digest]bool),
+	}
+	for _, dg := range phantom {
+		d.phantom[dg] = true
+	}
+	return d
+}
+
+func (d *interruptedIndexDst) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	d.mu.Lock()
+	phantom := d.phantom[target.Digest] && !d.committed[target.Digest]
+	d.mu.Unlock()
+	if phantom {
+		// Falsely report the not-yet-committed child manifest as present.
+		return true, nil
+	}
+	return d.Storage.Exists(ctx, target)
+}
+
+func (d *interruptedIndexDst) Push(ctx context.Context, expected ocispec.Descriptor, r io.Reader) error {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if expected.MediaType == ocispec.MediaTypeImageIndex {
+		var idx ocispec.Index
+		if err := json.Unmarshal(body, &idx); err != nil {
+			return err
+		}
+		var missing errcode.Errors
+		d.mu.Lock()
+		for _, m := range idx.Manifests {
+			if d.phantom[m.Digest] && !d.committed[m.Digest] {
+				missing = append(missing, errcode.Error{
+					Code:    errcode.ErrorCodeManifestBlobUnknown,
+					Message: "blob unknown to registry",
+					Detail:  m.Digest.String(),
+				})
+			}
+		}
+		d.mu.Unlock()
+		if len(missing) > 0 {
+			// Reject the index just like a registry whose referenced child
+			// manifests are not all present.
+			return missing
+		}
+	}
+	d.mu.Lock()
+	if d.phantom[expected.Digest] {
+		d.committed[expected.Digest] = true
+	}
+	d.mu.Unlock()
+	return d.Storage.Push(ctx, expected, bytes.NewReader(body))
+}
+
+// TestCopyGraph_SelfHealsInterruptedIndexCopy reproduces the failure in which a
+// re-run of a recursive copy of a multi-arch image index never self-heals: the
+// not-yet-committed child manifests are reported as already existing and thus
+// skipped, and the subsequent index push is rejected with MANIFEST_BLOB_UNKNOWN.
+// With the self-healing retry in copyGraph, the skipped child manifests are
+// re-pushed and the index push succeeds.
+func TestCopyGraph_SelfHealsInterruptedIndexCopy(t *testing.T) {
+	ctx := context.Background()
+	src := cas.NewMemory()
+
+	var blobs [][]byte
+	var descs []ocispec.Descriptor
+	appendBlob := func(mediaType string, blob []byte) ocispec.Descriptor {
+		desc := ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+		}
+		blobs = append(blobs, blob)
+		descs = append(descs, desc)
+		return desc
+	}
+	makeManifest := func(config ocispec.Descriptor, layers ...ocispec.Descriptor) ocispec.Descriptor {
+		m := ocispec.Manifest{Config: config, Layers: layers}
+		j, err := json.Marshal(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return appendBlob(ocispec.MediaTypeImageManifest, j)
+	}
+	makeIndex := func(manifests ...ocispec.Descriptor) ocispec.Descriptor {
+		idx := ocispec.Index{Manifests: manifests}
+		j, err := json.Marshal(idx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return appendBlob(ocispec.MediaTypeImageIndex, j)
+	}
+
+	// A two-platform index: each child manifest has its own config + layer,
+	// mirroring linux/amd64 and linux/arm64 children of mongo:7.0.34.
+	cfgA := appendBlob(ocispec.MediaTypeImageConfig, []byte("config-amd64"))
+	layerA := appendBlob(ocispec.MediaTypeImageLayer, []byte("layer-amd64"))
+	cfgB := appendBlob(ocispec.MediaTypeImageConfig, []byte("config-arm64"))
+	layerB := appendBlob(ocispec.MediaTypeImageLayer, []byte("layer-arm64"))
+	manifestA := makeManifest(cfgA, layerA)
+	manifestB := makeManifest(cfgB, layerB)
+	root := makeIndex(manifestA, manifestB)
+
+	for i := range blobs {
+		if err := src.Push(ctx, descs[i], bytes.NewReader(blobs[i])); err != nil {
+			t.Fatalf("failed to seed src: %d: %v", i, err)
+		}
+	}
+
+	// Simulate the interrupted-copy state in the destination: every blob has
+	// already been uploaded, but the two child manifests were never committed
+	// (and the destination reports them as existing).
+	backing := cas.NewMemory()
+	for _, d := range []ocispec.Descriptor{cfgA, layerA, cfgB, layerB} {
+		body, err := content.FetchAll(ctx, src, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := backing.Push(ctx, d, bytes.NewReader(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dst := newInterruptedIndexDst(backing, manifestA.Digest, manifestB.Digest)
+
+	// Copy the index. Without the self-healing retry this fails with
+	// MANIFEST_BLOB_UNKNOWN; with it, the copy succeeds.
+	if err := oras.CopyGraph(ctx, src, dst, root, oras.CopyGraphOptions{}); err != nil {
+		t.Fatalf("CopyGraph() error = %v, want nil", err)
+	}
+
+	// The index and both child manifests must now be present and correct.
+	for _, d := range []ocispec.Descriptor{manifestA, manifestB, root} {
+		got, err := content.FetchAll(ctx, backing, d)
+		if err != nil {
+			t.Fatalf("missing content %s after copy: %v", d.Digest, err)
+		}
+		want, err := content.FetchAll(ctx, src, d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("content mismatch for %s", d.Digest)
+		}
+	}
+}


### PR DESCRIPTION
## What this does
Makes `CopyGraph` self-heal a partially-copied graph. When the destination rejects a manifest push because it is missing referenced content (`MANIFEST_BLOB_UNKNOWN` / `BLOB_UNKNOWN` / `MANIFEST_UNKNOWN`), the copy now re-pushes the node's manifest successors and retries the push once, instead of returning the error.

## Why
`CopyGraph` skips a node whose sub-DAG it believes already exists ("skip if a rooted sub-DAG exists"). If a prior copy was interrupted after a child manifest's blobs were uploaded but before the child manifest was committed, the destination can report the child as present (`Exists`/HEAD) yet reject the parent that references it. For a multi-arch image index this means the index push fails with `MANIFEST_BLOB_UNKNOWN`, and since the child is skipped on every run, re-running the same `oras cp --recursive` never recovers.

This was hit in production mirroring a multi-arch image (`mongo:7.0.34`) between two registries; the only manual workaround was copying each child manifest by digest and re-pushing the index.

## How
- `copyGraph`: wrap the node push; on a "missing referenced content" error, re-copy the manifest successors unconditionally (bypassing the existence short-circuit) and retry the push once. No-op on the success path; blob successors are not re-pushed.
- `isMissingReferencedContentError`: typed classification via `errcode` (handles both a single `errcode.Error` and a multi-error `errcode.Errors`); no string matching.

## Testing
- `TestCopyGraph_SelfHealsInterruptedIndexCopy`: end-to-end reproduction against a destination that emulates the interrupted state — fails without this change (`MANIFEST_BLOB_UNKNOWN`), passes with it.
- `TestIsMissingReferencedContentError`: unit test for the classifier (100% covered).
- `go test -race ./...` passes; `gofmt` / `go vet` clean; new files carry the Apache license header.

## Notes for reviewers
- Design choice: detection currently uses the registry-specific `errcode` package from transport-agnostic `copyGraph`. An alternative is a sentinel in `errdef` that the remote `manifestStore` maps `MANIFEST_BLOB_UNKNOWN` / `BLOB_UNKNOWN` onto. Happy to switch if you prefer that layering.
- Scope: recovers the immediate manifest successors (the index -> child-manifest case). No API or signature changes; no breaking changes.

Fixes #1211
