### PR TITLE
feat: add untag support for remote registries

### DIFF
--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -685,6 +685,24 @@ func ExampleRepository_Tag() {
 	// Succeed
 }
 
+func ExampleRepository_Untag() {
+	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, exampleRepositoryName))
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+
+	tag := "latest"
+	err = repo.Untag(ctx, tag)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Succeed")
+
+	// Output:
+	// Succeed
+}
+
 // ExampleRegistry_Repositories gives example snippets for listing respositories in a HTTPS registry with pagination.
 func ExampleRegistry_Repositories() {
 	reg, err := remote.NewRegistry(host)

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -163,6 +163,8 @@ func TestMain(m *testing.M) {
 			w.WriteHeader(http.StatusCreated)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleTag) && m == "PUT":
 			w.WriteHeader(http.StatusCreated)
+		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleTag) && m == http.MethodDelete:
+			w.WriteHeader(http.StatusAccepted)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, ManifestDigest) && m == "PUT":
 			w.WriteHeader(http.StatusCreated)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, ReferenceManifestDigest) && m == "PUT":
@@ -685,6 +687,7 @@ func ExampleRepository_Tag() {
 	// Succeed
 }
 
+// ExampleRepository_Untag gives example snippets for removing a tag.
 func ExampleRepository_Untag() {
 	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", host, exampleRepositoryName))
 	if err != nil {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -440,9 +440,6 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 //
 // Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags
 func (r *Repository) Untag(ctx context.Context, reference string) error {
-	if reference == "" {
-		return errdef.ErrMissingReference
-	}
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -428,6 +428,49 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 	return r.Manifests().Tag(withPolicyChecked(ctx), desc, reference)
 }
 
+// Untag removes the association between the given tag and the manifest it
+// currently points to. The underlying content is NOT deleted.
+//
+// Tag deletion is an optional capability per the OCI Distribution Spec
+// and is not supported by all registries.
+//
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
+func (r *Repository) Untag(ctx context.Context, reference string) error {
+	if reference == "" {
+		return errdef.ErrMissingReference
+	}
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	ref, err := r.ParseReference(reference)
+	if err != nil {
+		return err
+	}
+	if err := ref.ValidateReferenceAsTag(); err != nil {
+		return err
+	}
+	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
+	url := buildRepositoryManifestURL(r.PlainHTTP, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := r.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
+	default:
+		return errutil.ParseErrorResponse(resp)
+	}
+}
+
 // PushReference pushes the manifest with a reference tag.
 func (r *Repository) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
 	if err := r.checkPolicy(ctx, reference); err != nil {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -434,7 +434,7 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 // Tag deletion is an optional capability per the OCI Distribution Spec
 // and is not supported by all registries.
 //
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags
 func (r *Repository) Untag(ctx context.Context, reference string) error {
 	if reference == "" {
 		return errdef.ErrMissingReference

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -43,8 +43,8 @@ import (
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/auth"
 	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
-	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 	"github.com/oras-project/oras-go/v3/registry/remote/internal/errutil"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 )
 
 const (
@@ -442,33 +442,15 @@ func (r *Repository) Untag(ctx context.Context, reference string) error {
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-	ref, err := r.ParseReference(reference)
-	if err != nil {
-		return err
-	}
-	if err := ref.ValidateReferenceAsTag(); err != nil {
-		return err
-	}
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
-	url := buildRepositoryManifestURL(r.PlainHTTP, ref)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := r.do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
 
-	switch resp.StatusCode {
-	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
-		return nil
-	case http.StatusNotFound:
-		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
-	default:
-		return errutil.ParseErrorResponse(resp)
+	manifests := r.Manifests()
+	untagger, ok := manifests.(content.Untagger)
+
+	if !ok {
+		return fmt.Errorf("ManifestStore %T does not implement content.Untagger interface", manifests)
 	}
+
+	return untagger.Untag(withPolicyChecked(ctx), reference)
 }
 
 // PushReference pushes the manifest with a reference tag.
@@ -1476,6 +1458,40 @@ func (s *manifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, refere
 	defer rc.Close()
 
 	return s.push(ctx, desc, rc, ref.Reference)
+}
+
+// Untag removes the association between the given tag and the manifest it currently points to.
+func (s *manifestStore) Untag(ctx context.Context, reference string) error {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	ref, err := s.ParseReference(reference)
+	if err != nil {
+		return err
+	}
+	if err := ref.ValidateReferenceAsTag(); err != nil {
+		return err
+	}
+	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
+	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.repo.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
+	default:
+		return errutil.ParseErrorResponse(resp)
+	}
 }
 
 // PushReference pushes the manifest with a reference tag.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -429,10 +429,14 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 }
 
 // Untag removes the association between the given tag and the manifest it
-// currently points to.
+// currently points to. Only tags are accepted; to delete a manifest by
+// digest, use Delete.
 //
-// Tag deletion is an optional capability per the OCI Distribution Spec
-// and is not supported by all registries.
+// Tag deletion is an optional, loosely specified capability. Some registries
+// do not support it (returning 400 or 405, surfaced here as an error), and
+// some delete the underlying manifest — and thus every tag pointing to it —
+// rather than only the given tag. This differs from the local content/oci
+// store's Untag, which never deletes the underlying content.
 //
 // Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags
 func (r *Repository) Untag(ctx context.Context, reference string) error {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -429,7 +429,7 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 }
 
 // Untag removes the association between the given tag and the manifest it
-// currently points to. The underlying content is NOT deleted.
+// currently points to.
 //
 // Tag deletion is an optional capability per the OCI Distribution Spec
 // and is not supported by all registries.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -550,7 +550,7 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 }
 
 // Untag removes the association between the given tag and the manifest it
-// currently points to. The underlying content is NOT deleted.
+// currently points to.
 //
 // Tag deletion is an optional capability per the OCI Distribution Spec
 // and is not supported by all registries.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -550,10 +550,14 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 }
 
 // Untag removes the association between the given tag and the manifest it
-// currently points to.
+// currently points to. Only tags are accepted; to delete a manifest by
+// digest, use Delete.
 //
-// Tag deletion is an optional capability per the OCI Distribution Spec
-// and is not supported by all registries.
+// Tag deletion is an optional, loosely specified capability. Some registries
+// do not support it (returning 400 or 405, surfaced here as an error), and
+// some delete the underlying manifest — and thus every tag pointing to it —
+// rather than only the given tag. This differs from the local content/oci
+// store's Untag, which never deletes the underlying content.
 //
 // Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags
 func (r *Repository) Untag(ctx context.Context, reference string) error {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -567,11 +567,9 @@ func (r *Repository) Untag(ctx context.Context, reference string) error {
 
 	manifests := r.Manifests()
 	untagger, ok := manifests.(content.Untagger)
-
 	if !ok {
-		return fmt.Errorf("ManifestStore %T does not implement content.Untagger interface", manifests)
+		return fmt.Errorf("manifest store %T does not implement content.Untagger", manifests)
 	}
-
 	return untagger.Untag(withPolicyChecked(ctx), reference)
 }
 
@@ -1645,7 +1643,7 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 		return err
 	}
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
-	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err
@@ -1660,7 +1658,7 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
 		return nil
 	case http.StatusNotFound:
-		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
+		return fmt.Errorf("%s: %w", ref, errdef.ErrNotFound)
 	default:
 		return errutil.ParseErrorResponse(resp)
 	}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -555,7 +555,7 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 // Tag deletion is an optional capability per the OCI Distribution Spec
 // and is not supported by all registries.
 //
-// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags
 func (r *Repository) Untag(ctx context.Context, reference string) error {
 	if reference == "" {
 		return errdef.ErrMissingReference

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -561,9 +561,6 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 //
 // Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags
 func (r *Repository) Untag(ctx context.Context, reference string) error {
-	if reference == "" {
-		return errdef.ErrMissingReference
-	}
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -549,6 +549,49 @@ func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference
 	return r.Manifests().Tag(withPolicyChecked(ctx), desc, reference)
 }
 
+// Untag removes the association between the given tag and the manifest it
+// currently points to. The underlying content is NOT deleted.
+//
+// Tag deletion is an optional capability per the OCI Distribution Spec
+// and is not supported by all registries.
+//
+// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
+func (r *Repository) Untag(ctx context.Context, reference string) error {
+	if reference == "" {
+		return errdef.ErrMissingReference
+	}
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	ref, err := r.ParseReference(reference)
+	if err != nil {
+		return err
+	}
+	if err := ref.ValidateReferenceAsTag(); err != nil {
+		return err
+	}
+	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
+	url := buildRepositoryManifestURL(r.PlainHTTP, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := r.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
+	default:
+		return errutil.ParseErrorResponse(resp)
+	}
+}
+
 // PushReference pushes the manifest with a reference tag.
 func (r *Repository) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
 	if err := r.checkPolicy(ctx, reference); err != nil {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -563,33 +563,15 @@ func (r *Repository) Untag(ctx context.Context, reference string) error {
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-	ref, err := r.ParseReference(reference)
-	if err != nil {
-		return err
-	}
-	if err := ref.ValidateReferenceAsTag(); err != nil {
-		return err
-	}
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
-	url := buildRepositoryManifestURL(r.PlainHTTP, ref)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := r.do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
 
-	switch resp.StatusCode {
-	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
-		return nil
-	case http.StatusNotFound:
-		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
-	default:
-		return errutil.ParseErrorResponse(resp)
+	manifests := r.Manifests()
+	untagger, ok := manifests.(content.Untagger)
+
+	if !ok {
+		return fmt.Errorf("ManifestStore %T does not implement content.Untagger interface", manifests)
 	}
+
+	return untagger.Untag(withPolicyChecked(ctx), reference)
 }
 
 // PushReference pushes the manifest with a reference tag.
@@ -1647,6 +1629,40 @@ func (s *manifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, refere
 	defer rc.Close()
 
 	return s.push(ctx, desc, rc, ref.Reference)
+}
+
+// Untag removes the association between the given tag and the manifest it currently points to.
+func (s *manifestStore) Untag(ctx context.Context, reference string) error {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	ref, err := s.ParseReference(reference)
+	if err != nil {
+		return err
+	}
+	if err := ref.ValidateReferenceAsTag(); err != nil {
+		return err
+	}
+	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
+	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.repo.do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return fmt.Errorf("%s: %w", ref.GetReference(), errdef.ErrNotFound)
+	default:
+		return errutil.ParseErrorResponse(resp)
+	}
 }
 
 // PushReference pushes the manifest with a reference tag.

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/oras-project/oras-go/v3/content"
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 )
@@ -209,6 +210,12 @@ func TestRepository_Tag_PolicyCheck(t *testing.T) {
 	assertPolicyDenied(t, err, "Tag")
 }
 
+func TestRepository_Untag_PolicyCheck(t *testing.T) {
+	repo := newRejectPolicyRepo(t)
+	err := repo.Untag(context.Background(), "latest")
+	assertPolicyDenied(t, err, "Untag")
+}
+
 func TestRepository_PushReference_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
 	err := repo.PushReference(context.Background(), testDesc, strings.NewReader("test"), "latest")
@@ -263,6 +270,12 @@ func TestRepository_ManifestStore_Resolve_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
 	_, err := repo.Manifests().Resolve(context.Background(), "latest")
 	assertPolicyDenied(t, err, "Manifests().Resolve")
+}
+
+func TestRepository_ManifestStore_Untag_PolicyCheck(t *testing.T) {
+	repo := newRejectPolicyRepo(t)
+	err := repo.Manifests().(content.Untagger).Untag(context.Background(), "latest")
+	assertPolicyDenied(t, err, "Manifests().Untag")
 }
 
 func TestRepository_BlobStore_Fetch_PolicyCheck(t *testing.T) {

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/oras-project/oras-go/v3/content"
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 )
@@ -245,6 +246,12 @@ func TestRepository_Tag_PolicyCheck(t *testing.T) {
 	assertPolicyDenied(t, err, "Tag()")
 }
 
+func TestRepository_Untag_PolicyCheck(t *testing.T) {
+	repo := newRejectPolicyRepo(t)
+	err := repo.Untag(context.Background(), "latest")
+	assertPolicyDenied(t, err, "Untag")
+}
+
 func TestRepository_PushReference_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
 	desc := ocispec.Descriptor{
@@ -333,6 +340,12 @@ func TestRepository_ManifestStore_PushReference_PolicyCheck(t *testing.T) {
 
 	err := repo.Manifests().PushReference(context.Background(), desc, strings.NewReader("test content"), "v1.0")
 	assertPolicyDenied(t, err, "Manifests().PushReference()")
+}
+
+func TestRepository_ManifestStore_Untag_PolicyCheck(t *testing.T) {
+	repo := newRejectPolicyRepo(t)
+	err := repo.Manifests().(content.Untagger).Untag(context.Background(), "latest")
+	assertPolicyDenied(t, err, "Manifests().Untag")
 }
 
 func TestRepository_BlobStore_Fetch_PolicyCheck(t *testing.T) {

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -249,7 +249,7 @@ func TestRepository_Tag_PolicyCheck(t *testing.T) {
 func TestRepository_Untag_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
 	err := repo.Untag(context.Background(), "latest")
-	assertPolicyDenied(t, err, "Untag")
+	assertPolicyDenied(t, err, "Untag()")
 }
 
 func TestRepository_PushReference_PolicyCheck(t *testing.T) {
@@ -345,7 +345,7 @@ func TestRepository_ManifestStore_PushReference_PolicyCheck(t *testing.T) {
 func TestRepository_ManifestStore_Untag_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
 	err := repo.Manifests().(content.Untagger).Untag(context.Background(), "latest")
-	assertPolicyDenied(t, err, "Manifests().Untag")
+	assertPolicyDenied(t, err, "Manifests().Untag()")
 }
 
 func TestRepository_BlobStore_Fetch_PolicyCheck(t *testing.T) {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1046,8 +1046,8 @@ func TestRepository_Untag(t *testing.T) {
 	ctx := context.Background()
 
 	err = repo.Untag(ctx, "")
-	if !errors.Is(err, errdef.ErrMissingReference) {
-		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrMissingReference)
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
 	}
 
 	err = repo.Untag(ctx, indexDesc.Digest.String())
@@ -6370,6 +6370,98 @@ func Test_ManifestStore_Tag(t *testing.T) {
 	}
 	if !bytes.Equal(gotIndex, index) {
 		t.Errorf("Repository.Tag() = %v, want %v", gotIndex, index)
+	}
+}
+
+func Test_ManifestStore_Untag(t *testing.T) {
+	index := []byte(`{"manifests":[]}`)
+	indexDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(index),
+		Size:      int64(len(index)),
+	}
+	// refOK, refAccepted and refNoContent exercise the three success status
+	// codes; refNotFound and refError exercise the error branches.
+	refOK := "ok"
+	refAccepted := "accepted"
+	refNoContent := "nocontent"
+	refNotFound := "ghost"
+	refError := "boom"
+
+	var untagged bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refOK:
+			untagged = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refAccepted:
+			untagged = true
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNoContent:
+			untagged = true
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refError:
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	store := repo.Manifests().(content.Untagger)
+	repo.PlainHTTP = true
+	ctx := context.Background()
+
+	// deleting by digest is rejected: only tags are accepted
+	err = store.Untag(ctx, indexDesc.Digest.String())
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
+	}
+
+	// an unparsable reference is rejected before any request is sent
+	err = store.Untag(ctx, "")
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
+	}
+
+	// 200, 202 and 204 are all treated as success
+	for _, ref := range []string{refOK, refAccepted, refNoContent} {
+		untagged = false
+		err = store.Untag(ctx, ref)
+		if err != nil {
+			t.Fatalf("manifestStore.Untag() error = %v", err)
+		}
+		if !untagged {
+			t.Errorf("manifestStore.Untag() did not send DELETE request for %q", ref)
+		}
+	}
+
+	err = store.Untag(ctx, refNotFound)
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}
+
+	err = store.Untag(ctx, refError)
+	if err == nil {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, true)
+	}
+
+	// closing the server makes the underlying request fail
+	ts.Close()
+	err = store.Untag(ctx, refAccepted)
+	if err == nil {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, true)
 	}
 }
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1006,6 +1006,66 @@ func TestRepository_Tag(t *testing.T) {
 	}
 }
 
+func TestRepository_Untag(t *testing.T) {
+	index := []byte(`{"manifests":[]}`)
+	indexDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(index),
+		Size:      int64(len(index)),
+	}
+	ref := "foobar"
+	refNotFound := "ghost"
+
+	var untagged bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+ref:
+			untagged = true
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	ctx := context.Background()
+
+	err = repo.Untag(ctx, "")
+	if !errors.Is(err, errdef.ErrMissingReference) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrMissingReference)
+	}
+
+	err = repo.Untag(ctx, indexDesc.Digest.String())
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
+	}
+
+	err = repo.Untag(ctx, refNotFound)
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}
+
+	err = repo.Untag(ctx, ref)
+	if err != nil {
+		t.Fatalf("Repository.Untag() error = %v", err)
+	}
+	if !untagged {
+		t.Errorf("Repository.Untag() did not send DELETE request")
+	}
+}
+
 func TestRepository_PushReference(t *testing.T) {
 	index := []byte(`{"manifests":[]}`)
 	indexDesc := ocispec.Descriptor{

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3823,6 +3823,9 @@ func TestManifestStoreInterface(t *testing.T) {
 	if _, ok := ms.(interfaces.ReferenceParser); !ok {
 		t.Error("&manifestStore{} does not conform interfaces.ReferenceParser")
 	}
+	if _, ok := ms.(content.Untagger); !ok {
+		t.Error("&manifestStore{} does not conform content.Untagger")
+	}
 }
 
 func TestRepositoryMounterInterface(t *testing.T) {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1015,6 +1015,7 @@ func TestRepository_Untag(t *testing.T) {
 	}
 	ref := "foobar"
 	refNotFound := "ghost"
+	refError := "boom"
 
 	var untagged bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1024,6 +1025,8 @@ func TestRepository_Untag(t *testing.T) {
 			w.WriteHeader(http.StatusAccepted)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
 			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refError:
+			w.WriteHeader(http.StatusInternalServerError)
 		default:
 			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
 			w.WriteHeader(http.StatusForbidden)
@@ -1057,12 +1060,24 @@ func TestRepository_Untag(t *testing.T) {
 		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrNotFound)
 	}
 
+	err = repo.Untag(ctx, refError)
+	if err == nil {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, true)
+	}
+
 	err = repo.Untag(ctx, ref)
 	if err != nil {
 		t.Fatalf("Repository.Untag() error = %v", err)
 	}
 	if !untagged {
 		t.Errorf("Repository.Untag() did not send DELETE request")
+	}
+
+	// closing the server makes the underlying request fail
+	ts.Close()
+	err = repo.Untag(ctx, ref)
+	if err == nil {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, true)
 	}
 }
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1047,8 +1047,8 @@ func TestRepository_Untag(t *testing.T) {
 	ctx := context.Background()
 
 	err = repo.Untag(ctx, "")
-	if !errors.Is(err, errdef.ErrMissingReference) {
-		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrMissingReference)
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
 	}
 
 	err = repo.Untag(ctx, indexDesc.Digest.String())
@@ -6423,6 +6423,98 @@ func Test_ManifestStore_Tag(t *testing.T) {
 	}
 	if !bytes.Equal(gotIndex, index) {
 		t.Errorf("Repository.Tag() = %v, want %v", gotIndex, index)
+	}
+}
+
+func Test_ManifestStore_Untag(t *testing.T) {
+	index := []byte(`{"manifests":[]}`)
+	indexDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(index),
+		Size:      int64(len(index)),
+	}
+	// refOK, refAccepted and refNoContent exercise the three success status
+	// codes; refNotFound and refError exercise the error branches.
+	refOK := "ok"
+	refAccepted := "accepted"
+	refNoContent := "nocontent"
+	refNotFound := "ghost"
+	refError := "boom"
+
+	var untagged bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refOK:
+			untagged = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refAccepted:
+			untagged = true
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNoContent:
+			untagged = true
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refError:
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	store := repo.Manifests().(content.Untagger)
+	repo.PlainHTTP = true
+	ctx := context.Background()
+
+	// deleting by digest is rejected: only tags are accepted
+	err = store.Untag(ctx, indexDesc.Digest.String())
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
+	}
+
+	// an unparsable reference is rejected before any request is sent
+	err = store.Untag(ctx, "")
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
+	}
+
+	// 200, 202 and 204 are all treated as success
+	for _, ref := range []string{refOK, refAccepted, refNoContent} {
+		untagged = false
+		err = store.Untag(ctx, ref)
+		if err != nil {
+			t.Fatalf("manifestStore.Untag() error = %v", err)
+		}
+		if !untagged {
+			t.Errorf("manifestStore.Untag() did not send DELETE request for %q", ref)
+		}
+	}
+
+	err = store.Untag(ctx, refNotFound)
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}
+
+	err = store.Untag(ctx, refError)
+	if err == nil {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, true)
+	}
+
+	// closing the server makes the underlying request fail
+	ts.Close()
+	err = store.Untag(ctx, refAccepted)
+	if err == nil {
+		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, true)
 	}
 }
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1027,7 +1027,8 @@ func TestRepository_Untag(t *testing.T) {
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
 			w.WriteHeader(http.StatusNotFound)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refError:
-			w.WriteHeader(http.StatusInternalServerError)
+			// registries that do not support tag deletion answer 405
+			w.WriteHeader(http.StatusMethodNotAllowed)
 		default:
 			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
 			w.WriteHeader(http.StatusForbidden)
@@ -1043,7 +1044,7 @@ func TestRepository_Untag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = repo.Untag(ctx, "")
@@ -1074,9 +1075,10 @@ func TestRepository_Untag(t *testing.T) {
 		t.Errorf("Repository.Untag() did not send DELETE request")
 	}
 
-	// closing the server makes the underlying request fail
-	ts.Close()
-	err = repo.Untag(ctx, ref)
+	// a canceled context makes the underlying request fail
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err = repo.Untag(canceledCtx, ref)
 	if err == nil {
 		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, true)
 	}
@@ -6456,7 +6458,8 @@ func Test_ManifestStore_Untag(t *testing.T) {
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
 			w.WriteHeader(http.StatusNotFound)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refError:
-			w.WriteHeader(http.StatusInternalServerError)
+			// registries that do not support tag deletion answer 405
+			w.WriteHeader(http.StatusMethodNotAllowed)
 		default:
 			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
 			w.WriteHeader(http.StatusForbidden)
@@ -6473,7 +6476,7 @@ func Test_ManifestStore_Untag(t *testing.T) {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
 	store := repo.Manifests().(content.Untagger)
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// deleting by digest is rejected: only tags are accepted
@@ -6510,9 +6513,10 @@ func Test_ManifestStore_Untag(t *testing.T) {
 		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, true)
 	}
 
-	// closing the server makes the underlying request fail
-	ts.Close()
-	err = store.Untag(ctx, refAccepted)
+	// a canceled context makes the underlying request fail
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	err = store.Untag(canceledCtx, refAccepted)
 	if err == nil {
 		t.Errorf("manifestStore.Untag() error = %v, wantErr %v", err, true)
 	}

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -3876,6 +3876,9 @@ func TestManifestStoreInterface(t *testing.T) {
 	if _, ok := ms.(interfaces.ReferenceParser); !ok {
 		t.Error("&manifestStore{} does not conform interfaces.ReferenceParser")
 	}
+	if _, ok := ms.(content.Untagger); !ok {
+		t.Error("&manifestStore{} does not conform content.Untagger")
+	}
 }
 
 func TestRepositoryMounterInterface(t *testing.T) {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1016,6 +1016,7 @@ func TestRepository_Untag(t *testing.T) {
 	}
 	ref := "foobar"
 	refNotFound := "ghost"
+	refError := "boom"
 
 	var untagged bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1025,6 +1026,8 @@ func TestRepository_Untag(t *testing.T) {
 			w.WriteHeader(http.StatusAccepted)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
 			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refError:
+			w.WriteHeader(http.StatusInternalServerError)
 		default:
 			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
 			w.WriteHeader(http.StatusForbidden)
@@ -1058,12 +1061,24 @@ func TestRepository_Untag(t *testing.T) {
 		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrNotFound)
 	}
 
+	err = repo.Untag(ctx, refError)
+	if err == nil {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, true)
+	}
+
 	err = repo.Untag(ctx, ref)
 	if err != nil {
 		t.Fatalf("Repository.Untag() error = %v", err)
 	}
 	if !untagged {
 		t.Errorf("Repository.Untag() did not send DELETE request")
+	}
+
+	// closing the server makes the underlying request fail
+	ts.Close()
+	err = repo.Untag(ctx, ref)
+	if err == nil {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, true)
 	}
 }
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -1007,6 +1007,66 @@ func TestRepository_Tag(t *testing.T) {
 	}
 }
 
+func TestRepository_Untag(t *testing.T) {
+	index := []byte(`{"manifests":[]}`)
+	indexDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(index),
+		Size:      int64(len(index)),
+	}
+	ref := "foobar"
+	refNotFound := "ghost"
+
+	var untagged bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+ref:
+			untagged = true
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/test/manifests/"+refNotFound:
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.PlainHTTP = true
+	ctx := context.Background()
+
+	err = repo.Untag(ctx, "")
+	if !errors.Is(err, errdef.ErrMissingReference) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrMissingReference)
+	}
+
+	err = repo.Untag(ctx, indexDesc.Digest.String())
+	if !errors.Is(err, errdef.ErrInvalidReference) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrInvalidReference)
+	}
+
+	err = repo.Untag(ctx, refNotFound)
+	if !errors.Is(err, errdef.ErrNotFound) {
+		t.Errorf("Repository.Untag() error = %v, wantErr %v", err, errdef.ErrNotFound)
+	}
+
+	err = repo.Untag(ctx, ref)
+	if err != nil {
+		t.Fatalf("Repository.Untag() error = %v", err)
+	}
+	if !untagged {
+		t.Errorf("Repository.Untag() did not send DELETE request")
+	}
+}
+
 func TestRepository_PushReference(t *testing.T) {
 	index := []byte(`{"manifests":[]}`)
 	indexDesc := ocispec.Descriptor{


### PR DESCRIPTION
**Description**

This PR adds tag deletion support for remote registries as per https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags.

For this, it extends `registry/remote/repository.go` and implements  `Untagger` from `content/resolver.go` introduced in https://github.com/oras-project/oras-go/pull/647.
For our downstream project, we implemented this by ourselves and thought this would be a good addition to bring to upstream.

It adds a guard by using `ValidateReferenceAsTag` to not allow deletion by digests, only tags are allowed.

Closes: https://github.com/oras-project/oras-go/issues/1028

**Testing**
- Added `ExampleRepository_Untag` to `example_test.go`
- Added `TestRepository_Untag` to `repository_test.go`
