### PR TITLE
fix(content): bound ReadAll allocation by content, not descriptor size

### DIFF
--- a/content/reader.go
+++ b/content/reader.go
@@ -16,6 +16,7 @@ limitations under the License.
 package content
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -24,11 +25,15 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// maxDescriptorSize is the upper-bound for descriptor sizes accepted by
-// ReadAll. Descriptors sourced from attacker-supplied OCI layouts can carry
-// arbitrarily large Size values; without this cap, make([]byte, desc.Size)
-// triggers a runtime panic before any allocation occurs.
-const maxDescriptorSize = 32 * 1024 * 1024 // 32 MiB
+// maxInitialBufferSize bounds the buffer that ReadAll pre-allocates from
+// desc.Size before any content is read. desc.Size is attacker-controllable: a
+// crafted OCI layout index.json can declare an arbitrarily large Size (e.g.
+// 2^62), and make([]byte, desc.Size) on such a value triggers a runtime panic
+// ("makeslice: len out of range") before any allocation occurs. ReadAll caps
+// the initial allocation at this value and grows the buffer as it reads, so the
+// declared size is never trusted for allocation while legitimately large
+// content (e.g. plugin or chart layers) is still read in full.
+const maxInitialBufferSize = 32 * 1024 * 1024 // 32 MiB
 
 var (
 	// ErrInvalidDescriptorSize is returned by ReadAll() when
@@ -125,22 +130,32 @@ func NewVerifyReader(r io.Reader, desc ocispec.Descriptor) *VerifyReader {
 // The read content is verified against the size and the digest
 // using a VerifyReader.
 func ReadAll(r io.Reader, desc ocispec.Descriptor) ([]byte, error) {
-	if desc.Size < 0 || desc.Size > maxDescriptorSize {
+	if desc.Size < 0 {
 		return nil, ErrInvalidDescriptorSize
 	}
-	buf := make([]byte, desc.Size)
 
 	vr := NewVerifyReader(r, desc)
-	if n, err := io.ReadFull(vr, buf); err != nil {
+
+	// Do not pre-allocate desc.Size directly: it is attacker-controllable and a
+	// forged value (e.g. 2^62) would panic make(). Cap the initial allocation
+	// and let the buffer grow as content is read. The VerifyReader enforces the
+	// declared size and digest, so a size that does not match the actual content
+	// still fails verification rather than over-allocating.
+	initialCap := desc.Size
+	if initialCap > maxInitialBufferSize {
+		initialCap = maxInitialBufferSize
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, initialCap))
+	if _, err := buf.ReadFrom(vr); err != nil {
 		if errors.Is(err, io.ErrUnexpectedEOF) {
-			return nil, fmt.Errorf("read failed: expected content size of %d, got %d, for digest %s: %w", desc.Size, n, desc.Digest.String(), err)
+			return nil, fmt.Errorf("read failed: expected content size of %d, got %d, for digest %s: %w", desc.Size, buf.Len(), desc.Digest.String(), err)
 		}
 		return nil, fmt.Errorf("read failed: %w", err)
 	}
 	if err := vr.Verify(); err != nil {
 		return nil, err
 	}
-	return buf, nil
+	return buf.Bytes(), nil
 }
 
 // ensureEOF ensures the read operation ends with an EOF and no

--- a/content/reader_test.go
+++ b/content/reader_test.go
@@ -262,15 +262,42 @@ func TestReadAll_InvalidDescriptorSize(t *testing.T) {
 }
 
 func TestReadAll_OversizedDescriptor(t *testing.T) {
+	// Regression test for GHSA-f36w-mj3v-6jqv: a crafted descriptor can declare
+	// an enormous Size (here 2^62). ReadAll must not pre-allocate that size,
+	// which would panic make() with "makeslice: len out of range". Instead it
+	// reads the actual content and, because the content is shorter than the
+	// declared size, fails verification with io.ErrUnexpectedEOF rather than
+	// panicking.
 	content := []byte("example content")
 	desc := ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageLayer,
 		Digest:    digest.FromBytes(content),
-		Size:      4611686018427387904, // 2^62, triggers makeslice panic without the cap
+		Size:      4611686018427387904, // 2^62
 	}
 	r := bytes.NewReader(content)
 	_, err := ReadAll(r, desc)
-	if err == nil || !errors.Is(err, ErrInvalidDescriptorSize) {
-		t.Errorf("ReadAll() error = %v, want %v", err, ErrInvalidDescriptorSize)
+	if err == nil || !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("ReadAll() error = %v, want %v", err, io.ErrUnexpectedEOF)
+	}
+}
+
+func TestReadAll_LargeContent(t *testing.T) {
+	// Content larger than maxInitialBufferSize must still be read in full.
+	// Regression test: the previous 32 MiB cap in ReadAll rejected legitimate
+	// large blobs (e.g. plugin or chart layers) with ErrInvalidDescriptorSize,
+	// breaking OCI pulls into the in-memory store.
+	size := maxInitialBufferSize + 1024*1024 // 33 MiB, exceeds the initial buffer cap
+	content := make([]byte, size)
+	for i := range content {
+		content[i] = byte(i % 251)
+	}
+	desc := NewDescriptorFromBytes("test", content)
+	r := bytes.NewReader(content)
+	got, err := ReadAll(r, desc)
+	if err != nil {
+		t.Fatal("ReadAll() error = ", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Error("ReadAll() returned content that does not match the input")
 	}
 }


### PR DESCRIPTION
## What this fixes

`content.ReadAll` currently rejects any descriptor with `Size > 32 MiB`
(`maxDescriptorSize`, added in #1153 for GHSA-f36w-mj3v-6jqv). That cap
over-corrected: `ReadAll` is also used by the in-memory store's `Push`
(`internal/cas/memory.go`) and by `FetchAll`/`FetchBytes`, so it now
rejects legitimate, digest-verified blobs. This broke OCI pulls of large
artifacts — e.g. installing the helm-unittest plugin (~160 MiB layer):

```
Error: failed to pull plugin from oci://ghcr.io/helm-unittest/helm-unittest/unittest:1.1.1: failed to perform "Push" on destination: invalid descriptor size
```

See helm/helm#32247.

## Root cause

The underlying vulnerability (#1153) was eagerly pre-allocating
`make([]byte, desc.Size)` from an attacker-controllable size, which panics
(`makeslice: len out of range`) on a forged value such as `2^62`. The
32 MiB rejection treated the symptom (size) rather than the cause
(trusting the size for allocation).

## Fix

Cap only the **initial** buffer allocation and grow the buffer as content
is read. The `VerifyReader` (LimitedReader + digest verifier) continues to
enforce the declared size and digest, so:

- a forged size now fails verification (`io.ErrUnexpectedEOF`) instead of
  panicking, and
- legitimately large, digest-verified content is read in full.

The manifest/metadata read paths remain independently bounded by
`limitSize(..., MaxMetadataBytes)` before calling `ReadAll`
(`registry/remote/repository.go`), so removing the blanket cap does not
reopen the metadata DoS that #1153 addressed.

## Tests

- `TestReadAll_OversizedDescriptor` updated: a `2^62` descriptor now fails
  with `io.ErrUnexpectedEOF` (no panic), still guarding GHSA-f36w-mj3v-6jqv.
- `TestReadAll_LargeContent` added: a 33 MiB blob (over the old cap)
  round-trips through `ReadAll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)