### PR TITLE
feat(remote): add repository middleware with policy enforcement

### DIFF
--- a/registry/remote/middleware.go
+++ b/registry/remote/middleware.go
@@ -1,0 +1,225 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+)
+
+// RepositoryMiddleware wraps a registry.Repository to add cross-cutting concerns.
+type RepositoryMiddleware func(registry.Repository) registry.Repository
+
+// Compose chains multiple middlewares together.
+// The first middleware is the outermost (executed first for requests,
+// last for responses).
+func Compose(middlewares ...RepositoryMiddleware) RepositoryMiddleware {
+	return func(repo registry.Repository) registry.Repository {
+		for i := len(middlewares) - 1; i >= 0; i-- {
+			repo = middlewares[i](repo)
+		}
+		return repo
+	}
+}
+
+// WithPolicyEnforcement creates a middleware that adds policy checks to all operations.
+// The transport and scope parameters are used for constructing image references
+// for policy evaluation.
+func WithPolicyEnforcement(evaluator *policy.Evaluator, transport policy.TransportName, scope string) RepositoryMiddleware {
+	return func(repo registry.Repository) registry.Repository {
+		return &policyEnforcingRepository{
+			Repository: repo,
+			evaluator:  evaluator,
+			transport:  transport,
+			scope:      scope,
+		}
+	}
+}
+
+// policyEnforcingRepository wraps a Repository and enforces policy on all operations.
+type policyEnforcingRepository struct {
+	registry.Repository
+	evaluator *policy.Evaluator
+	transport policy.TransportName
+	scope     string
+}
+
+// checkPolicy validates access against the configured policy.
+func (r *policyEnforcingRepository) checkPolicy(ctx context.Context, reference string) error {
+	if r.evaluator == nil {
+		return nil
+	}
+
+	imageRef := policy.ImageReference{
+		Transport: r.transport,
+		Scope:     r.scope,
+		Reference: reference,
+	}
+
+	allowed, err := r.evaluator.IsImageAllowed(ctx, imageRef)
+	if err != nil {
+		return fmt.Errorf("policy check failed: %w", err)
+	}
+	if !allowed {
+		return fmt.Errorf("access denied by policy for %s", reference)
+	}
+	return nil
+}
+
+// Fetch fetches the content identified by the descriptor with policy enforcement.
+func (r *policyEnforcingRepository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	if err := r.checkPolicy(ctx, target.Digest.String()); err != nil {
+		return nil, err
+	}
+	return r.Repository.Fetch(ctx, target)
+}
+
+// Push pushes the content, matching the expected descriptor, with policy enforcement.
+func (r *policyEnforcingRepository) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	if err := r.checkPolicy(ctx, expected.Digest.String()); err != nil {
+		return err
+	}
+	return r.Repository.Push(ctx, expected, content)
+}
+
+// Resolve resolves a reference to a manifest descriptor with policy enforcement.
+func (r *policyEnforcingRepository) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return r.Repository.Resolve(ctx, reference)
+}
+
+// Tag tags a manifest descriptor with a reference string with policy enforcement.
+func (r *policyEnforcingRepository) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	return r.Repository.Tag(ctx, desc, reference)
+}
+
+// FetchReference fetches the manifest identified by the reference with policy enforcement.
+func (r *policyEnforcingRepository) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	return r.Repository.FetchReference(ctx, reference)
+}
+
+// PushReference pushes the manifest with a reference tag with policy enforcement.
+func (r *policyEnforcingRepository) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	return r.Repository.PushReference(ctx, expected, content, reference)
+}
+
+// Blobs returns a policy-enforcing blob store.
+func (r *policyEnforcingRepository) Blobs() registry.BlobStore {
+	return &policyEnforcingBlobStore{
+		BlobStore: r.Repository.Blobs(),
+		repo:      r,
+	}
+}
+
+// Manifests returns a policy-enforcing manifest store.
+func (r *policyEnforcingRepository) Manifests() registry.ManifestStore {
+	return &policyEnforcingManifestStore{
+		ManifestStore: r.Repository.Manifests(),
+		repo:          r,
+	}
+}
+
+// policyEnforcingBlobStore wraps a BlobStore with policy enforcement.
+type policyEnforcingBlobStore struct {
+	registry.BlobStore
+	repo *policyEnforcingRepository
+}
+
+// Fetch fetches the content with policy enforcement.
+func (s *policyEnforcingBlobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	if err := s.repo.checkPolicy(ctx, target.Digest.String()); err != nil {
+		return nil, err
+	}
+	return s.BlobStore.Fetch(ctx, target)
+}
+
+// Push pushes the content with policy enforcement.
+func (s *policyEnforcingBlobStore) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	if err := s.repo.checkPolicy(ctx, expected.Digest.String()); err != nil {
+		return err
+	}
+	return s.BlobStore.Push(ctx, expected, content)
+}
+
+// FetchReference fetches the blob identified by the reference with policy enforcement.
+func (s *policyEnforcingBlobStore) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	return s.BlobStore.FetchReference(ctx, reference)
+}
+
+// policyEnforcingManifestStore wraps a ManifestStore with policy enforcement.
+type policyEnforcingManifestStore struct {
+	registry.ManifestStore
+	repo *policyEnforcingRepository
+}
+
+// Fetch fetches the content with policy enforcement.
+func (s *policyEnforcingManifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	if err := s.repo.checkPolicy(ctx, target.Digest.String()); err != nil {
+		return nil, err
+	}
+	return s.ManifestStore.Fetch(ctx, target)
+}
+
+// Push pushes the content with policy enforcement.
+func (s *policyEnforcingManifestStore) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	if err := s.repo.checkPolicy(ctx, expected.Digest.String()); err != nil {
+		return err
+	}
+	return s.ManifestStore.Push(ctx, expected, content)
+}
+
+// FetchReference fetches the manifest identified by the reference with policy enforcement.
+func (s *policyEnforcingManifestStore) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	return s.ManifestStore.FetchReference(ctx, reference)
+}
+
+// PushReference pushes the manifest with a reference tag with policy enforcement.
+func (s *policyEnforcingManifestStore) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	return s.ManifestStore.PushReference(ctx, expected, content, reference)
+}
+
+// Tag tags a manifest descriptor with a reference string with policy enforcement.
+func (s *policyEnforcingManifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	return s.ManifestStore.Tag(ctx, desc, reference)
+}

--- a/registry/remote/middleware.go
+++ b/registry/remote/middleware.go
@@ -43,31 +43,42 @@ func Compose(middlewares ...RepositoryMiddleware) RepositoryMiddleware {
 // WithPolicyEnforcement creates a middleware that adds policy checks to all operations.
 // The transport and scope parameters are used for constructing image references
 // for policy evaluation.
+//
+// If evaluator is nil, a no-op middleware is returned that leaves the repository
+// unchanged, so callers pay no per-operation cost when policy enforcement is
+// disabled.
 func WithPolicyEnforcement(evaluator *policy.Evaluator, transport policy.TransportName, scope string) RepositoryMiddleware {
+	if evaluator == nil {
+		return func(repo registry.Repository) registry.Repository {
+			return repo
+		}
+	}
 	return func(repo registry.Repository) registry.Repository {
 		return &policyEnforcingRepository{
-			Repository: repo,
-			evaluator:  evaluator,
-			transport:  transport,
-			scope:      scope,
+			repo:      repo,
+			evaluator: evaluator,
+			transport: transport,
+			scope:     scope,
 		}
 	}
 }
 
 // policyEnforcingRepository wraps a Repository and enforces policy on all operations.
+//
+// The wrapped repository is held in a named field rather than embedded so that
+// every method of registry.Repository must be implemented explicitly. If a new
+// method is added to the interface, this type fails to compile until the method
+// is handled here, ensuring no operation silently bypasses policy enforcement.
 type policyEnforcingRepository struct {
-	registry.Repository
+	repo      registry.Repository
 	evaluator *policy.Evaluator
 	transport policy.TransportName
 	scope     string
 }
 
 // checkPolicy validates access against the configured policy.
+// The evaluator is guaranteed non-nil by WithPolicyEnforcement.
 func (r *policyEnforcingRepository) checkPolicy(ctx context.Context, reference string) error {
-	if r.evaluator == nil {
-		return nil
-	}
-
 	imageRef := policy.ImageReference{
 		Transport: r.transport,
 		Scope:     r.scope,
@@ -89,7 +100,7 @@ func (r *policyEnforcingRepository) Fetch(ctx context.Context, target ocispec.De
 	if err := r.checkPolicy(ctx, target.Digest.String()); err != nil {
 		return nil, err
 	}
-	return r.Repository.Fetch(ctx, target)
+	return r.repo.Fetch(ctx, target)
 }
 
 // Push pushes the content, matching the expected descriptor, with policy enforcement.
@@ -97,7 +108,17 @@ func (r *policyEnforcingRepository) Push(ctx context.Context, expected ocispec.D
 	if err := r.checkPolicy(ctx, expected.Digest.String()); err != nil {
 		return err
 	}
-	return r.Repository.Push(ctx, expected, content)
+	return r.repo.Push(ctx, expected, content)
+}
+
+// Exists returns true if the described content exists.
+func (r *policyEnforcingRepository) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	return r.repo.Exists(ctx, target)
+}
+
+// Delete removes the content identified by the descriptor.
+func (r *policyEnforcingRepository) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return r.repo.Delete(ctx, target)
 }
 
 // Resolve resolves a reference to a manifest descriptor with policy enforcement.
@@ -105,7 +126,7 @@ func (r *policyEnforcingRepository) Resolve(ctx context.Context, reference strin
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	return r.Repository.Resolve(ctx, reference)
+	return r.repo.Resolve(ctx, reference)
 }
 
 // Tag tags a manifest descriptor with a reference string with policy enforcement.
@@ -113,7 +134,7 @@ func (r *policyEnforcingRepository) Tag(ctx context.Context, desc ocispec.Descri
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-	return r.Repository.Tag(ctx, desc, reference)
+	return r.repo.Tag(ctx, desc, reference)
 }
 
 // FetchReference fetches the manifest identified by the reference with policy enforcement.
@@ -121,7 +142,7 @@ func (r *policyEnforcingRepository) FetchReference(ctx context.Context, referenc
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	return r.Repository.FetchReference(ctx, reference)
+	return r.repo.FetchReference(ctx, reference)
 }
 
 // PushReference pushes the manifest with a reference tag with policy enforcement.
@@ -129,29 +150,42 @@ func (r *policyEnforcingRepository) PushReference(ctx context.Context, expected 
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-	return r.Repository.PushReference(ctx, expected, content, reference)
+	return r.repo.PushReference(ctx, expected, content, reference)
+}
+
+// Referrers lists the descriptors that refer to the given descriptor.
+func (r *policyEnforcingRepository) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
+	return r.repo.Referrers(ctx, desc, artifactType, fn)
+}
+
+// Tags lists the tags available in the repository.
+func (r *policyEnforcingRepository) Tags(ctx context.Context, last string, fn func(tags []string) error) error {
+	return r.repo.Tags(ctx, last, fn)
 }
 
 // Blobs returns a policy-enforcing blob store.
 func (r *policyEnforcingRepository) Blobs() registry.BlobStore {
 	return &policyEnforcingBlobStore{
-		BlobStore: r.Repository.Blobs(),
-		repo:      r,
+		blobs: r.repo.Blobs(),
+		repo:  r,
 	}
 }
 
 // Manifests returns a policy-enforcing manifest store.
 func (r *policyEnforcingRepository) Manifests() registry.ManifestStore {
 	return &policyEnforcingManifestStore{
-		ManifestStore: r.Repository.Manifests(),
-		repo:          r,
+		manifests: r.repo.Manifests(),
+		repo:      r,
 	}
 }
 
 // policyEnforcingBlobStore wraps a BlobStore with policy enforcement.
+//
+// As with policyEnforcingRepository, the wrapped store is a named field so that
+// every registry.BlobStore method must be implemented explicitly.
 type policyEnforcingBlobStore struct {
-	registry.BlobStore
-	repo *policyEnforcingRepository
+	blobs registry.BlobStore
+	repo  *policyEnforcingRepository
 }
 
 // Fetch fetches the content with policy enforcement.
@@ -159,7 +193,7 @@ func (s *policyEnforcingBlobStore) Fetch(ctx context.Context, target ocispec.Des
 	if err := s.repo.checkPolicy(ctx, target.Digest.String()); err != nil {
 		return nil, err
 	}
-	return s.BlobStore.Fetch(ctx, target)
+	return s.blobs.Fetch(ctx, target)
 }
 
 // Push pushes the content with policy enforcement.
@@ -167,7 +201,22 @@ func (s *policyEnforcingBlobStore) Push(ctx context.Context, expected ocispec.De
 	if err := s.repo.checkPolicy(ctx, expected.Digest.String()); err != nil {
 		return err
 	}
-	return s.BlobStore.Push(ctx, expected, content)
+	return s.blobs.Push(ctx, expected, content)
+}
+
+// Exists returns true if the described content exists.
+func (s *policyEnforcingBlobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	return s.blobs.Exists(ctx, target)
+}
+
+// Delete removes the content identified by the descriptor.
+func (s *policyEnforcingBlobStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return s.blobs.Delete(ctx, target)
+}
+
+// Resolve resolves a reference to a descriptor.
+func (s *policyEnforcingBlobStore) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
+	return s.blobs.Resolve(ctx, reference)
 }
 
 // FetchReference fetches the blob identified by the reference with policy enforcement.
@@ -175,13 +224,16 @@ func (s *policyEnforcingBlobStore) FetchReference(ctx context.Context, reference
 	if err := s.repo.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	return s.BlobStore.FetchReference(ctx, reference)
+	return s.blobs.FetchReference(ctx, reference)
 }
 
 // policyEnforcingManifestStore wraps a ManifestStore with policy enforcement.
+//
+// As with policyEnforcingRepository, the wrapped store is a named field so that
+// every registry.ManifestStore method must be implemented explicitly.
 type policyEnforcingManifestStore struct {
-	registry.ManifestStore
-	repo *policyEnforcingRepository
+	manifests registry.ManifestStore
+	repo      *policyEnforcingRepository
 }
 
 // Fetch fetches the content with policy enforcement.
@@ -189,7 +241,7 @@ func (s *policyEnforcingManifestStore) Fetch(ctx context.Context, target ocispec
 	if err := s.repo.checkPolicy(ctx, target.Digest.String()); err != nil {
 		return nil, err
 	}
-	return s.ManifestStore.Fetch(ctx, target)
+	return s.manifests.Fetch(ctx, target)
 }
 
 // Push pushes the content with policy enforcement.
@@ -197,7 +249,22 @@ func (s *policyEnforcingManifestStore) Push(ctx context.Context, expected ocispe
 	if err := s.repo.checkPolicy(ctx, expected.Digest.String()); err != nil {
 		return err
 	}
-	return s.ManifestStore.Push(ctx, expected, content)
+	return s.manifests.Push(ctx, expected, content)
+}
+
+// Exists returns true if the described content exists.
+func (s *policyEnforcingManifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	return s.manifests.Exists(ctx, target)
+}
+
+// Delete removes the content identified by the descriptor.
+func (s *policyEnforcingManifestStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return s.manifests.Delete(ctx, target)
+}
+
+// Resolve resolves a reference to a descriptor.
+func (s *policyEnforcingManifestStore) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
+	return s.manifests.Resolve(ctx, reference)
 }
 
 // FetchReference fetches the manifest identified by the reference with policy enforcement.
@@ -205,7 +272,7 @@ func (s *policyEnforcingManifestStore) FetchReference(ctx context.Context, refer
 	if err := s.repo.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	return s.ManifestStore.FetchReference(ctx, reference)
+	return s.manifests.FetchReference(ctx, reference)
 }
 
 // PushReference pushes the manifest with a reference tag with policy enforcement.
@@ -213,7 +280,7 @@ func (s *policyEnforcingManifestStore) PushReference(ctx context.Context, expect
 	if err := s.repo.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-	return s.ManifestStore.PushReference(ctx, expected, content, reference)
+	return s.manifests.PushReference(ctx, expected, content, reference)
 }
 
 // Tag tags a manifest descriptor with a reference string with policy enforcement.
@@ -221,5 +288,12 @@ func (s *policyEnforcingManifestStore) Tag(ctx context.Context, desc ocispec.Des
 	if err := s.repo.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-	return s.ManifestStore.Tag(ctx, desc, reference)
+	return s.manifests.Tag(ctx, desc, reference)
 }
+
+// Ensure the wrappers satisfy the registry interfaces they enforce policy on.
+var (
+	_ registry.Repository    = (*policyEnforcingRepository)(nil)
+	_ registry.BlobStore     = (*policyEnforcingBlobStore)(nil)
+	_ registry.ManifestStore = (*policyEnforcingManifestStore)(nil)
+)

--- a/registry/remote/middleware_test.go
+++ b/registry/remote/middleware_test.go
@@ -277,6 +277,114 @@ func TestWithPolicyEnforcement_Manifests(t *testing.T) {
 	}
 }
 
+func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
+	// Create a policy that rejects everything so every wrapped operation
+	// short-circuits on the policy check before reaching the base repository.
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.Reject{},
+		},
+		Transports: make(map[policy.TransportName]policy.TransportScopes),
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+
+	// Repository-level operations.
+	if _, err := wrapped.Fetch(ctx, desc); err == nil {
+		t.Error("Fetch() should return error when policy denies access")
+	}
+	if err := wrapped.Push(ctx, desc, strings.NewReader("content")); err == nil {
+		t.Error("Push() should return error when policy denies access")
+	}
+	if _, err := wrapped.Resolve(ctx, "latest"); err == nil {
+		t.Error("Resolve() should return error when policy denies access")
+	}
+	if err := wrapped.Tag(ctx, desc, "latest"); err == nil {
+		t.Error("Tag() should return error when policy denies access")
+	}
+	if _, _, err := wrapped.FetchReference(ctx, "latest"); err == nil {
+		t.Error("FetchReference() should return error when policy denies access")
+	}
+	if err := wrapped.PushReference(ctx, desc, strings.NewReader("content"), "latest"); err == nil {
+		t.Error("PushReference() should return error when policy denies access")
+	}
+
+	// Blob store operations.
+	blobs := wrapped.Blobs()
+	if _, err := blobs.Fetch(ctx, desc); err == nil {
+		t.Error("Blobs().Fetch() should return error when policy denies access")
+	}
+	if err := blobs.Push(ctx, desc, strings.NewReader("content")); err == nil {
+		t.Error("Blobs().Push() should return error when policy denies access")
+	}
+	if _, _, err := blobs.FetchReference(ctx, "sha256:test"); err == nil {
+		t.Error("Blobs().FetchReference() should return error when policy denies access")
+	}
+
+	// Manifest store operations.
+	manifests := wrapped.Manifests()
+	if _, err := manifests.Fetch(ctx, desc); err == nil {
+		t.Error("Manifests().Fetch() should return error when policy denies access")
+	}
+	if err := manifests.Push(ctx, desc, strings.NewReader("content")); err == nil {
+		t.Error("Manifests().Push() should return error when policy denies access")
+	}
+	if _, _, err := manifests.FetchReference(ctx, "latest"); err == nil {
+		t.Error("Manifests().FetchReference() should return error when policy denies access")
+	}
+	if err := manifests.PushReference(ctx, desc, strings.NewReader("content"), "latest"); err == nil {
+		t.Error("Manifests().PushReference() should return error when policy denies access")
+	}
+	if err := manifests.Tag(ctx, desc, "latest"); err == nil {
+		t.Error("Manifests().Tag() should return error when policy denies access")
+	}
+}
+
+func TestWithPolicyEnforcement_EvaluatorError(t *testing.T) {
+	// A policy that registers an empty requirement set for the configured
+	// transport/scope. GetRequirementsForImage returns no requirements, which
+	// IsImageAllowed surfaces as an error, exercising the evaluator-error
+	// branch of checkPolicy.
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.InsecureAcceptAnything{},
+		},
+		Transports: map[policy.TransportName]policy.TransportScopes{
+			policy.TransportNameDocker: {
+				"test/repo": {},
+			},
+		},
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+
+	_, err = wrapped.Fetch(ctx, desc)
+	if err == nil {
+		t.Fatal("Fetch() should return error when the evaluator fails")
+	}
+	if !strings.Contains(err.Error(), "policy check failed") {
+		t.Errorf("error should wrap the evaluator failure, got: %v", err)
+	}
+}
+
 // orderTrackingRepository tracks the order of middleware execution.
 type orderTrackingRepository struct {
 	registry.Repository

--- a/registry/remote/middleware_test.go
+++ b/registry/remote/middleware_test.go
@@ -1,0 +1,461 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+)
+
+func TestCompose(t *testing.T) {
+	var order []string
+
+	middleware1 := func(repo registry.Repository) registry.Repository {
+		order = append(order, "m1-start")
+		return &orderTrackingRepository{
+			Repository: repo,
+			name:       "m1",
+			order:      &order,
+		}
+	}
+
+	middleware2 := func(repo registry.Repository) registry.Repository {
+		order = append(order, "m2-start")
+		return &orderTrackingRepository{
+			Repository: repo,
+			name:       "m2",
+			order:      &order,
+		}
+	}
+
+	composed := Compose(middleware1, middleware2)
+
+	baseRepo := &mockRepository{}
+	wrapped := composed(baseRepo)
+
+	// Trigger an operation to test the order
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+	wrapped.Fetch(ctx, desc)
+
+	// Verify order: middleware1 wraps middleware2 wraps base
+	// So m1 should be outermost
+	expected := []string{"m2-start", "m1-start", "m1-fetch", "m2-fetch"}
+	if len(order) != len(expected) {
+		t.Fatalf("order = %v, want %v", order, expected)
+	}
+	for i, v := range expected {
+		if order[i] != v {
+			t.Errorf("order[%d] = %s, want %s", i, order[i], v)
+		}
+	}
+}
+
+func TestCompose_Empty(t *testing.T) {
+	composed := Compose()
+
+	baseRepo := &mockRepository{}
+	wrapped := composed(baseRepo)
+
+	if wrapped != baseRepo {
+		t.Error("Compose() with no middlewares should return original repository")
+	}
+}
+
+func TestWithPolicyEnforcement_NoEvaluator(t *testing.T) {
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(nil, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	// With nil evaluator, all operations should pass through
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+
+	_, err := wrapped.Fetch(ctx, desc)
+	if err != nil {
+		t.Errorf("Fetch() error = %v, want nil", err)
+	}
+}
+
+func TestWithPolicyEnforcement_PolicyDenied(t *testing.T) {
+	// Create a policy that rejects everything
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.Reject{},
+		},
+		Transports: make(map[policy.TransportName]policy.TransportScopes),
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+
+	_, err = wrapped.Fetch(ctx, desc)
+	if err == nil {
+		t.Error("Fetch() should return error when policy denies access")
+	}
+	if !strings.Contains(err.Error(), "denied") && !strings.Contains(err.Error(), "policy") {
+		t.Errorf("error should mention policy denial: %v", err)
+	}
+}
+
+func TestWithPolicyEnforcement_PolicyAllowed(t *testing.T) {
+	// Create a policy that allows everything
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.InsecureAcceptAnything{},
+		},
+		Transports: make(map[policy.TransportName]policy.TransportScopes),
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	ctx := context.Background()
+
+	// Test Fetch
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+	_, err = wrapped.Fetch(ctx, desc)
+	if err != nil {
+		t.Errorf("Fetch() error = %v, want nil", err)
+	}
+
+	// Test Push
+	err = wrapped.Push(ctx, desc, strings.NewReader("content"))
+	if err != nil {
+		t.Errorf("Push() error = %v, want nil", err)
+	}
+
+	// Test Resolve
+	_, err = wrapped.Resolve(ctx, "latest")
+	if err != nil {
+		t.Errorf("Resolve() error = %v, want nil", err)
+	}
+
+	// Test Tag
+	err = wrapped.Tag(ctx, desc, "latest")
+	if err != nil {
+		t.Errorf("Tag() error = %v, want nil", err)
+	}
+
+	// Test FetchReference
+	_, _, err = wrapped.FetchReference(ctx, "latest")
+	if err != nil {
+		t.Errorf("FetchReference() error = %v, want nil", err)
+	}
+
+	// Test PushReference
+	err = wrapped.PushReference(ctx, desc, strings.NewReader("content"), "latest")
+	if err != nil {
+		t.Errorf("PushReference() error = %v, want nil", err)
+	}
+}
+
+func TestWithPolicyEnforcement_Blobs(t *testing.T) {
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.InsecureAcceptAnything{},
+		},
+		Transports: make(map[policy.TransportName]policy.TransportScopes),
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+
+	blobs := wrapped.Blobs()
+
+	// Test Fetch
+	_, err = blobs.Fetch(ctx, desc)
+	if err != nil {
+		t.Errorf("Blobs().Fetch() error = %v, want nil", err)
+	}
+
+	// Test Push
+	err = blobs.Push(ctx, desc, strings.NewReader("content"))
+	if err != nil {
+		t.Errorf("Blobs().Push() error = %v, want nil", err)
+	}
+
+	// Test FetchReference
+	_, _, err = blobs.FetchReference(ctx, "sha256:test")
+	if err != nil {
+		t.Errorf("Blobs().FetchReference() error = %v, want nil", err)
+	}
+}
+
+func TestWithPolicyEnforcement_Manifests(t *testing.T) {
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.InsecureAcceptAnything{},
+		},
+		Transports: make(map[policy.TransportName]policy.TransportScopes),
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	baseRepo := &mockRepository{}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+
+	ctx := context.Background()
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+
+	manifests := wrapped.Manifests()
+
+	// Test Fetch
+	_, err = manifests.Fetch(ctx, desc)
+	if err != nil {
+		t.Errorf("Manifests().Fetch() error = %v, want nil", err)
+	}
+
+	// Test Push
+	err = manifests.Push(ctx, desc, strings.NewReader("content"))
+	if err != nil {
+		t.Errorf("Manifests().Push() error = %v, want nil", err)
+	}
+
+	// Test FetchReference
+	_, _, err = manifests.FetchReference(ctx, "latest")
+	if err != nil {
+		t.Errorf("Manifests().FetchReference() error = %v, want nil", err)
+	}
+
+	// Test PushReference
+	err = manifests.PushReference(ctx, desc, strings.NewReader("content"), "latest")
+	if err != nil {
+		t.Errorf("Manifests().PushReference() error = %v, want nil", err)
+	}
+
+	// Test Tag
+	err = manifests.Tag(ctx, desc, "latest")
+	if err != nil {
+		t.Errorf("Manifests().Tag() error = %v, want nil", err)
+	}
+}
+
+// orderTrackingRepository tracks the order of middleware execution.
+type orderTrackingRepository struct {
+	registry.Repository
+	name  string
+	order *[]string
+}
+
+func (r *orderTrackingRepository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	*r.order = append(*r.order, r.name+"-fetch")
+	return r.Repository.Fetch(ctx, target)
+}
+
+// mockRepository implements registry.Repository for testing.
+type mockRepository struct {
+	fetchErr           error
+	pushErr            error
+	existsResult       bool
+	existsErr          error
+	deleteErr          error
+	resolveDesc        ocispec.Descriptor
+	resolveErr         error
+	tagErr             error
+	pushReferenceErr   error
+	fetchReferenceRC   io.ReadCloser
+	fetchReferenceErr  error
+	referrersResult    []ocispec.Descriptor
+	referrersErr       error
+	tagsResult         []string
+	tagsErr            error
+	predecessorsResult []ocispec.Descriptor
+	predecessorsErr    error
+}
+
+func (r *mockRepository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	if r.fetchErr != nil {
+		return nil, r.fetchErr
+	}
+	return io.NopCloser(bytes.NewReader([]byte("content"))), nil
+}
+
+func (r *mockRepository) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	return r.pushErr
+}
+
+func (r *mockRepository) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	return r.existsResult, r.existsErr
+}
+
+func (r *mockRepository) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return r.deleteErr
+}
+
+func (r *mockRepository) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
+	return r.resolveDesc, r.resolveErr
+}
+
+func (r *mockRepository) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
+	return r.tagErr
+}
+
+func (r *mockRepository) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
+	return r.pushReferenceErr
+}
+
+func (r *mockRepository) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	if r.fetchReferenceErr != nil {
+		return ocispec.Descriptor{}, nil, r.fetchReferenceErr
+	}
+	rc := r.fetchReferenceRC
+	if rc == nil {
+		rc = io.NopCloser(bytes.NewReader([]byte("content")))
+	}
+	return ocispec.Descriptor{Digest: digest.FromString("test")}, rc, nil
+}
+
+func (r *mockRepository) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
+	if r.referrersErr != nil {
+		return r.referrersErr
+	}
+	if len(r.referrersResult) > 0 {
+		return fn(r.referrersResult)
+	}
+	return nil
+}
+
+func (r *mockRepository) Tags(ctx context.Context, last string, fn func(tags []string) error) error {
+	if r.tagsErr != nil {
+		return r.tagsErr
+	}
+	if len(r.tagsResult) > 0 {
+		return fn(r.tagsResult)
+	}
+	return nil
+}
+
+func (r *mockRepository) Predecessors(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	return r.predecessorsResult, r.predecessorsErr
+}
+
+func (r *mockRepository) Blobs() registry.BlobStore {
+	return &mockBlobStore{repo: r}
+}
+
+func (r *mockRepository) Manifests() registry.ManifestStore {
+	return &mockManifestStore{repo: r}
+}
+
+// mockBlobStore implements registry.BlobStore for testing.
+type mockBlobStore struct {
+	repo *mockRepository
+}
+
+func (s *mockBlobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	return s.repo.Fetch(ctx, target)
+}
+
+func (s *mockBlobStore) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	return s.repo.Push(ctx, expected, content)
+}
+
+func (s *mockBlobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	return s.repo.Exists(ctx, target)
+}
+
+func (s *mockBlobStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return s.repo.Delete(ctx, target)
+}
+
+func (s *mockBlobStore) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
+	return s.repo.Resolve(ctx, reference)
+}
+
+func (s *mockBlobStore) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	return s.repo.FetchReference(ctx, reference)
+}
+
+// mockManifestStore implements registry.ManifestStore for testing.
+type mockManifestStore struct {
+	repo *mockRepository
+}
+
+func (s *mockManifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	return s.repo.Fetch(ctx, target)
+}
+
+func (s *mockManifestStore) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	return s.repo.Push(ctx, expected, content)
+}
+
+func (s *mockManifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	return s.repo.Exists(ctx, target)
+}
+
+func (s *mockManifestStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	return s.repo.Delete(ctx, target)
+}
+
+func (s *mockManifestStore) Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error) {
+	return s.repo.Resolve(ctx, reference)
+}
+
+func (s *mockManifestStore) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	return s.repo.FetchReference(ctx, reference)
+}
+
+func (s *mockManifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
+	return s.repo.Tag(ctx, desc, reference)
+}
+
+func (s *mockManifestStore) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
+	return s.repo.PushReference(ctx, expected, content, reference)
+}
+
+// Ensure mock types implement the expected interfaces.
+var (
+	_ registry.Repository    = (*mockRepository)(nil)
+	_ registry.BlobStore     = (*mockBlobStore)(nil)
+	_ registry.ManifestStore = (*mockManifestStore)(nil)
+)
+
+// Suppress unused variable warning
+var _ = errors.New


### PR DESCRIPTION
## What

Adds a repository middleware mechanism to `registry/remote`:

- `RepositoryMiddleware` — a `func(registry.Repository) registry.Repository`
  decorator type
- `Compose(...)` — chains multiple middlewares into one
- `WithPolicyEnforcement(evaluator, transport, scope)` — wraps a repository so
  `Fetch`/`Resolve`/`FetchReference` (and the `Blobs()` / `Manifests()`
  sub-stores) are gated by a `policy.Evaluator`

## Why standalone

Self-contained: depends only on the already-merged `registry` interfaces and
`registry/remote/policy` (#1187). No dependency on the in-flight config,
builder, or repository PRs.

Part of the **feat/everything (#1130)** v3 breakdown. The companion mirror
fallback logic (originally bundled with middleware) lands separately, since it
depends on the client builder and repository-struct updates.

## Testing

`go build ./...` and `go test ./registry/remote/ -run 'Middleware|Compose|Policy'`
pass.