### PR TITLE
fix: prevent hardlink path traversal via process CWD (GHSA-fxhp-mv3v-67qp)

### DIFF
--- a/content/file/utils.go
+++ b/content/file/utils.go
@@ -188,6 +188,11 @@ func extractTarDirectory(dirPath, dirName string, r io.Reader, buf []byte, prese
 			// This is a known limitation and will not be addressed.
 			var target string
 			if target, err = ensureLinkPath(dirPath, dirName, filePath, header.Linkname); err == nil {
+				if !filepath.IsAbs(target) {
+					// link(2) resolves relative paths against the process CWD, not
+					// the link file's directory. Resolve explicitly to prevent escape.
+					target = filepath.Join(filepath.Dir(filePath), target)
+				}
 				err = os.Link(target, filePath)
 			}
 		case tar.TypeSymlink:

--- a/content/file/utils_test.go
+++ b/content/file/utils_test.go
@@ -376,6 +376,61 @@ func Test_extractTarDirectory_HardLink(t *testing.T) {
 			t.Error("extractTarDirectory() error = nil, wantErr = true")
 		}
 	})
+
+	t.Run("hard link with relative linkname must not escape extract dir via process CWD", func(t *testing.T) {
+		// GHSA-fxhp-mv3v-67qp: a tarball TypeLink entry with a relative Linkname
+		// was passed verbatim to os.Link, which resolves relative paths against the
+		// process CWD rather than the link file's directory. An attacker-controlled
+		// registry could use this to hardlink a CWD file into the extract tree.
+		cwdDir := t.TempDir()
+		sentinelPath := filepath.Join(cwdDir, "sentinel.txt")
+		if err := os.WriteFile(sentinelPath, []byte("secret"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(cwdDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(origDir) //nolint:errcheck
+
+		extractDir := t.TempDir()
+		dirName := "base"
+		dirPath := filepath.Join(extractDir, dirName)
+		buf := make([]byte, 1024)
+
+		// The relative Linkname "sentinel.txt" would resolve against the process
+		// CWD (cwdDir) via link(2) if not explicitly resolved first.
+		tarData := createTar(t, []tarEntry{
+			{name: "base/", mode: os.ModeDir | 0777},
+			{name: "base/evil_link", linkname: "sentinel.txt", mode: 0666, isHardLink: true},
+		})
+
+		err = extractTarDirectory(dirPath, dirName, bytes.NewReader(tarData), buf, false)
+		if err != nil {
+			// Expected: target resolves to <extractDir>/base/sentinel.txt which
+			// doesn't exist, so os.Link returns an error. No escape occurred.
+			return
+		}
+
+		// If extraction succeeded, verify the hardlink does not share an inode
+		// with the CWD sentinel file (i.e., it did not escape the extract dir).
+		evilLinkPath := filepath.Join(dirPath, "evil_link")
+		evilInfo, statErr := os.Lstat(evilLinkPath)
+		if statErr != nil {
+			return // link was not created; no escape
+		}
+		sentinelInfo, statErr := os.Lstat(sentinelPath)
+		if statErr != nil {
+			t.Fatal(statErr)
+		}
+		if os.SameFile(evilInfo, sentinelInfo) {
+			t.Error("hardlink escaped extract dir: evil_link shares inode with CWD sentinel file")
+		}
+	})
 }
 
 type tarEntry struct {


### PR DESCRIPTION
## Summary

Backport of the `main`-branch fix (b11f777) to the **v2** release line for **GHSA-fxhp-mv3v-67qp / CVE-2026-50163**.

`ensureLinkPath` validated `TypeLink` (hardlink) targets by resolving relative paths against the link file's directory, but returned the *original, unresolved* target string. The caller passed this to `os.Link`, which resolves relative paths against the process **CWD** via `link(2)` — not the link file's directory. A crafted OCI artifact could exploit this to hardlink a CWD file into the extract tree, creating a shared inode with an arbitrary file outside the extraction directory.

The fix landed on `main` (now the v3 module) but was never carried to the v2 line, so v2.6.1 and earlier remain vulnerable. This PR closes that gap.

## Fix

Explicitly resolve relative hardlink targets against `filepath.Dir` of the link file before calling `os.Link`. Symlink handling is unaffected since `os.Symlink` stores the path verbatim and resolves at access time.

## Test

Adds a regression test that sets the process CWD to a directory containing a sentinel file and verifies that a tar `TypeLink` entry with a relative `Linkname` cannot hardlink that file into the extract tree. The test fails without the fix ("hardlink escaped extract dir") and passes with it.

Suggested release: **v2.6.2**.