### PR TITLE
fix: validate caller-supplied config descriptor in Pack/PackManifest

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -101,6 +101,12 @@ type PackManifestOptions struct {
 
 	// ConfigDescriptor is a pointer to the descriptor of the config blob.
 	// If not nil, ConfigAnnotations will be ignored.
+	//
+	// When set, the caller is responsible for pushing the referenced config
+	// blob to the target and for populating the descriptor's Digest and Size.
+	// PackManifest uses the descriptor as-is and does NOT push the config blob.
+	// The descriptor's Digest MUST be valid, otherwise PackManifest returns an
+	// error wrapping [errdef.ErrInvalidDigest].
 	ConfigDescriptor *ocispec.Descriptor
 
 	// ConfigAnnotations is the annotation map of the config descriptor.
@@ -225,8 +231,8 @@ func packManifestV1_0(ctx context.Context, pusher content.Pusher, artifactType s
 	// prepare config
 	var configDesc ocispec.Descriptor
 	if opts.ConfigDescriptor != nil {
-		if err := validateMediaType(opts.ConfigDescriptor.MediaType); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("invalid config mediaType format: %w", err)
+		if err := validateConfigDescriptor(*opts.ConfigDescriptor); err != nil {
+			return ocispec.Descriptor{}, err
 		}
 		configDesc = *opts.ConfigDescriptor
 	} else {
@@ -272,6 +278,9 @@ func packManifestV1_1_RC2(ctx context.Context, pusher content.Pusher, configMedi
 	// prepare config
 	var configDesc ocispec.Descriptor
 	if opts.ConfigDescriptor != nil {
+		if err := validateConfigDescriptor(*opts.ConfigDescriptor); err != nil {
+			return ocispec.Descriptor{}, err
+		}
 		configDesc = *opts.ConfigDescriptor
 	} else {
 		var err error
@@ -318,8 +327,8 @@ func packManifestV1_1(ctx context.Context, pusher content.Pusher, artifactType s
 	var emptyBlobExists bool
 	var configDesc ocispec.Descriptor
 	if opts.ConfigDescriptor != nil {
-		if err := validateMediaType(opts.ConfigDescriptor.MediaType); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("invalid config mediaType format: %w", err)
+		if err := validateConfigDescriptor(*opts.ConfigDescriptor); err != nil {
+			return ocispec.Descriptor{}, err
 		}
 		configDesc = *opts.ConfigDescriptor
 	} else {
@@ -443,6 +452,22 @@ func ensureAnnotationCreated(annotations map[string]string, annotationCreatedKey
 func validateMediaType(mediaType string) error {
 	if !mediaTypeRegexp.MatchString(mediaType) {
 		return fmt.Errorf("%s: %w", mediaType, errdef.ErrInvalidMediaType)
+	}
+	return nil
+}
+
+// validateConfigDescriptor validates a caller-supplied config descriptor.
+// When a config descriptor is provided to Pack or PackManifest, the caller is
+// responsible for pushing the config blob and populating the descriptor's
+// Digest and Size. Validating the descriptor here prevents silently producing
+// a manifest that references a non-existent config blob (e.g. an empty digest),
+// which some registries accept while dropping the descriptor's annotations.
+func validateConfigDescriptor(config ocispec.Descriptor) error {
+	if err := validateMediaType(config.MediaType); err != nil {
+		return fmt.Errorf("invalid config mediaType format: %w", err)
+	}
+	if err := config.Digest.Validate(); err != nil {
+		return fmt.Errorf("invalid config descriptor digest %q: %w", config.Digest, errdef.ErrInvalidDigest)
 	}
 	return nil
 }

--- a/pack_test.go
+++ b/pack_test.go
@@ -523,6 +523,27 @@ func Test_Pack_ImageV1_1_RC2_InvalidDateTimeFormat(t *testing.T) {
 	}
 }
 
+func Test_Pack_ImageV1_1_RC2_InvalidConfigDigest(t *testing.T) {
+	s := memory.New()
+
+	ctx := context.Background()
+	// a config descriptor with a valid media type but an empty (invalid) digest,
+	// as produced when the caller forgets to push the config blob and populate
+	// the descriptor. See https://github.com/oras-project/oras-go/issues/1236
+	configDesc := ocispec.Descriptor{
+		MediaType:   "application/vnd.test.config",
+		Annotations: map[string]string{"foo": "bar"},
+	}
+	opts := PackOptions{
+		PackImageManifest: true,
+		ConfigDescriptor:  &configDesc,
+	}
+	_, err := Pack(ctx, s, "", nil, opts)
+	if wantErr := errdef.ErrInvalidDigest; !errors.Is(err, wantErr) {
+		t.Errorf("Oras.Pack() error = %v, wantErr = %v", err, wantErr)
+	}
+}
+
 func Test_PackManifest_ImageV1_0(t *testing.T) {
 	s := memory.New()
 
@@ -782,6 +803,26 @@ func Test_PackManifest_ImageV1_0_InvalidMediaType(t *testing.T) {
 	}
 	_, err = PackManifest(ctx, s, PackManifestVersion1_0, artifactType, opts)
 	if wantErr := errdef.ErrInvalidMediaType; !errors.Is(err, wantErr) {
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
+	}
+}
+
+func Test_PackManifest_ImageV1_0_InvalidConfigDigest(t *testing.T) {
+	s := memory.New()
+
+	ctx := context.Background()
+	// a config descriptor with a valid media type but an empty (invalid) digest,
+	// as produced when the caller forgets to push the config blob and populate
+	// the descriptor. See https://github.com/oras-project/oras-go/issues/1236
+	configDesc := ocispec.Descriptor{
+		MediaType:   "application/vnd.test.config",
+		Annotations: map[string]string{"foo": "bar"},
+	}
+	opts := PackManifestOptions{
+		ConfigDescriptor: &configDesc,
+	}
+	_, err := PackManifest(ctx, s, PackManifestVersion1_0, "", opts)
+	if wantErr := errdef.ErrInvalidDigest; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 }
@@ -1061,6 +1102,26 @@ func Test_PackManifest_ImageV1_1_InvalidMediaType(t *testing.T) {
 	}
 	_, err = PackManifest(ctx, s, PackManifestVersion1_1, artifactType, opts)
 	if wantErr := errdef.ErrInvalidMediaType; !errors.Is(err, wantErr) {
+		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
+	}
+}
+
+func Test_PackManifest_ImageV1_1_InvalidConfigDigest(t *testing.T) {
+	s := memory.New()
+
+	ctx := context.Background()
+	// a config descriptor with a valid media type but an empty (invalid) digest,
+	// as produced when the caller forgets to push the config blob and populate
+	// the descriptor. See https://github.com/oras-project/oras-go/issues/1236
+	configDesc := ocispec.Descriptor{
+		MediaType:   "application/vnd.test.config",
+		Annotations: map[string]string{"foo": "bar"},
+	}
+	opts := PackManifestOptions{
+		ConfigDescriptor: &configDesc,
+	}
+	_, err := PackManifest(ctx, s, PackManifestVersion1_1, "application/vnd.test", opts)
+	if wantErr := errdef.ErrInvalidDigest; !errors.Is(err, wantErr) {
 		t.Errorf("Oras.PackManifest() error = %v, wantErr = %v", err, wantErr)
 	}
 }


### PR DESCRIPTION
## What this PR does

When a `ConfigDescriptor` is supplied to `Pack` / `PackManifest`, the caller is responsible for pushing the config blob and populating the descriptor's `Digest` and `Size`. The library uses the descriptor verbatim and does **not** push the config blob in that path.

Previously, a partially-populated descriptor (e.g. only `MediaType` and `Annotations` set, with an empty `Digest` and zero `Size`) was accepted and produced a manifest referencing a non-existent config blob:

```json
"config": {
  "digest": "",
  "mediaType": "application/vnd.custom.config.v1+json",
  "size": 0
}
```

Some registries (e.g. GHCR) accept such manifests while silently dropping the config descriptor's annotations, which is confusing to debug.

## Change

- Add `validateConfigDescriptor`, which validates both the media type format and the digest of a caller-supplied config descriptor.
- Apply it in `packManifestV1_0`, `packManifestV1_1`, and the deprecated `packManifestV1_1_RC2` paths. Callers now get an error wrapping `errdef.ErrInvalidDigest` instead of a silently-malformed manifest.
- Clarify the `ConfigDescriptor` godoc to state that the caller must push the config blob and populate `Digest`/`Size`.

Because this only rejects manifests that were already malformed, and oras-go v3 has not been released yet, this is not a breaking change.

## Tests

Added `Test_PackManifest_ImageV1_0_InvalidConfigDigest`, `Test_PackManifest_ImageV1_1_InvalidConfigDigest`, and `Test_Pack_ImageV1_1_RC2_InvalidConfigDigest`. Full suite (`go test ./...`) passes.

Fixes #1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)