### PR TITLE
ci: forward-port GitOps release workflow to main

### DIFF
--- a/.github/act/release-event.json
+++ b/.github/act/release-event.json
@@ -1,0 +1,23 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "merged": true,
+    "number": 999,
+    "title": "chore: prepare release v3.0.0",
+    "body": "## New Features\n\n* Test feature\n\n## Bug Fixes\n\n* Test fix",
+    "head": {
+      "ref": "release/v3.0.0",
+      "sha": "abc123def456"
+    },
+    "base": {
+      "ref": "main"
+    }
+  },
+  "repository": {
+    "full_name": "oras-project/oras-go",
+    "name": "oras-go",
+    "owner": {
+      "login": "oras-project"
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Extract version from branch name
+        id: version
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          VERSION="${BRANCH#release/}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Validate semantic version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! [[ "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+            echo "Error: '$VERSION' does not follow semantic versioning"
+            echo "Expected: vX.Y.Z or vX.Y.Z-(alpha|beta|rc).N"
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.version.outputs.version }} ${{ github.event.pull_request.merge_commit_sha }}
+          git push origin ${{ steps.version.outputs.version }}
+
+      - name: Write release notes from PR body
+        env:
+          NOTES: ${{ github.event.pull_request.body }}
+        run: printf '%s\n' "$NOTES" > /tmp/release-notes.md
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          version: latest
+          args: release --clean --release-notes /tmp/release-notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,26 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+# oras-go is a library — no binary builds or archives needed.
+builds:
+  - skip: true
+
+checksum:
+  disable: true
+
+release:
+  # Tags containing -alpha, -beta, or -rc are automatically marked pre-release.
+  prerelease: auto
+  draft: false

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,108 @@
+# Releasing oras-go
+
+Releases are created via a GitOps workflow. Merging a `release/vX.Y.Z` branch
+into `main` automatically tags the commit and publishes the GitHub Release.
+
+## Steps
+
+### 1. Create a release branch
+
+The release branch needs at least one commit so GitHub will allow a PR to be
+opened. Use an empty commit as a lightweight marker:
+
+```bash
+git fetch upstream
+git checkout -b release/v3.0.0 upstream/main
+git commit --allow-empty -s -m "chore: prepare release v3.0.0"
+git push origin release/v3.0.0
+```
+
+The release does not need to contain the changes being released — those are
+already on `main`. The PR is a trigger: when it merges, the workflow tags the
+PR's `merge_commit_sha` (the exact commit that landed on `main`), which includes
+all prior work on the branch.
+
+### 2. Open a pull request
+
+Open a PR from `release/v3.0.0` targeting the `main` branch. Write the release
+notes directly in the PR description using the format from prior releases:
+
+```markdown
+## New Features
+...
+
+## Bug Fixes
+...
+
+## Documentation
+...
+
+## Other Changes
+...
+```
+
+The PR description becomes the GitHub Release body verbatim, so write it in
+its final form.
+
+### 3. Get approvals
+
+Branch protection on `main` requires approval from at least 3 of the 4 owners
+listed in [OWNERS.md](OWNERS.md). Reviewers should verify:
+
+- The target commit is correct
+- The release notes are accurate and complete
+- All CI checks pass
+
+### 4. Merge
+
+Merge the PR. The [release workflow](.github/workflows/release.yml)
+automatically:
+
+1. Extracts the version from the branch name (`release/v3.0.0` → `v3.0.0`)
+2. Creates and pushes the git tag
+3. Publishes the GitHub Release with the PR body as release notes
+
+## Pre-releases
+
+Tags containing `-alpha`, `-beta`, or `-rc` (e.g., `v3.0.0-rc.1`) are
+automatically marked as pre-release on GitHub. Use the same branch naming
+convention: `release/v3.0.0-rc.1`.
+
+## Testing the workflow locally
+
+Three levels of local validation are available without triggering a real release:
+
+**1. Validate the GoReleaser config:**
+```bash
+goreleaser check
+```
+
+**2. Validate workflow structure and job matching (dry run):**
+```bash
+act pull_request \
+  -e .github/act/release-event.json \
+  -W .github/workflows/release.yml \
+  -n
+```
+
+**3. Run the workflow end-to-end with a fake token (Colima + cached actions required):**
+```bash
+act pull_request \
+  -e .github/act/release-event.json \
+  -W .github/workflows/release.yml \
+  -s GITHUB_TOKEN=fake \
+  --pull=false \
+  --action-offline-mode \
+  --container-daemon-socket -
+```
+
+This runs all steps up to and including version extraction (`version=vX.Y.Z` will
+appear in the output). The `git push` step then fails with a permission error —
+that is expected and confirms no tag was pushed. The mock event payload is at
+`.github/act/release-event.json`.
+
+## Updating the documentation site
+
+After a release, update [oras-www](https://github.com/oras-project/oras-www)
+to reflect the new version. See the `CLAUDE.md` in that repository for the
+exact steps.


### PR DESCRIPTION
## Summary

- forward-port the reviewed GitOps release workflow and GoReleaser configuration from #1161
- target `main` with v3 release examples and the action SHAs already used on `main`
- pass the release branch through the step environment to avoid direct untrusted-context interpolation

Fixes #1257

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- `go run github.com/goreleaser/goreleaser/v2@v2.17.1 check`
- `go run github.com/nektos/act@v0.2.89 pull_request -e .github/act/release-event.json -W .github/workflows/release.yml -l -P ubuntu-latest=catthehacker/ubuntu:act-latest`
- `make test`
- `git diff --check`