### PR TITLE
fix: graph.Memory should use digest as map key

### DIFF
--- a/internal/graph/memory.go
+++ b/internal/graph/memory.go
@@ -25,7 +25,6 @@ import (
 	"github.com/oras-project/oras-go/v3/content"
 	"github.com/oras-project/oras-go/v3/errdef"
 	"github.com/oras-project/oras-go/v3/internal/container/set"
-	"github.com/oras-project/oras-go/v3/internal/descriptor"
 	"github.com/oras-project/oras-go/v3/internal/status"
 	"github.com/oras-project/oras-go/v3/internal/syncutil"
 )
@@ -34,9 +33,9 @@ import (
 type Memory struct {
 	// nodes has the following properties and behaviors:
 	//  1. a node exists in Memory.nodes if and only if it exists in the memory
-	//  2. Memory.nodes saves the ocispec.Descriptor map keys, which are used by
+	//  2. Memory.nodes saves the ocispec.Descriptor indexed by digest, which are used by
 	//    the other fields.
-	nodes map[descriptor.Descriptor]ocispec.Descriptor
+	nodes map[digest.Digest]ocispec.Descriptor
 
 	// predecessors has the following properties and behaviors:
 	//  1. a node exists in Memory.predecessors if it has at least one predecessor
@@ -44,14 +43,14 @@ type Memory struct {
 	//    the memory.
 	//  2. a node does not exist in Memory.predecessors, if it doesn't have any predecessors
 	//    in the memory.
-	predecessors map[descriptor.Descriptor]set.Set[descriptor.Descriptor]
+	predecessors map[digest.Digest]set.Set[digest.Digest]
 
 	// successors has the following properties and behaviors:
 	//  1. a node exists in Memory.successors if and only if it exists in the memory.
 	//  2. a node's entry in Memory.successors is always consistent with the actual
 	//    content of the node, regardless of whether or not each successor exists
 	//    in the memory.
-	successors map[descriptor.Descriptor]set.Set[descriptor.Descriptor]
+	successors map[digest.Digest]set.Set[digest.Digest]
 
 	lock sync.RWMutex
 }
@@ -59,9 +58,9 @@ type Memory struct {
 // NewMemory creates a new memory PredecessorFinder.
 func NewMemory() *Memory {
 	return &Memory{
-		nodes:        make(map[descriptor.Descriptor]ocispec.Descriptor),
-		predecessors: make(map[descriptor.Descriptor]set.Set[descriptor.Descriptor]),
-		successors:   make(map[descriptor.Descriptor]set.Set[descriptor.Descriptor]),
+		nodes:        make(map[digest.Digest]ocispec.Descriptor),
+		predecessors: make(map[digest.Digest]set.Set[digest.Digest]),
+		successors:   make(map[digest.Digest]set.Set[digest.Digest]),
 	}
 }
 
@@ -108,14 +107,13 @@ func (m *Memory) Predecessors(_ context.Context, node ocispec.Descriptor) ([]oci
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
-	key := descriptor.FromOCI(node)
-	set, exists := m.predecessors[key]
+	set, exists := m.predecessors[node.Digest]
 	if !exists {
 		return nil, nil
 	}
 	var res []ocispec.Descriptor
-	for k := range set {
-		res = append(res, m.nodes[k])
+	for digest := range set {
+		res = append(res, m.nodes[digest])
 	}
 	return res, nil
 }
@@ -126,25 +124,24 @@ func (m *Memory) Remove(node ocispec.Descriptor) []ocispec.Descriptor {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	nodeKey := descriptor.FromOCI(node)
 	var danglings []ocispec.Descriptor
 	// remove the node from its successors' predecessor list
-	for successorKey := range m.successors[nodeKey] {
-		predecessorEntry := m.predecessors[successorKey]
-		predecessorEntry.Delete(nodeKey)
+	for successorDigest := range m.successors[node.Digest] {
+		predecessorEntry := m.predecessors[successorDigest]
+		predecessorEntry.Delete(node.Digest)
 
 		// if none of the predecessors of the node still exists, we remove the
 		// predecessors entry and return it as a dangling node. Otherwise, we do
 		// not remove the entry.
 		if len(predecessorEntry) == 0 {
-			delete(m.predecessors, successorKey)
-			if _, exists := m.nodes[successorKey]; exists {
-				danglings = append(danglings, m.nodes[successorKey])
+			delete(m.predecessors, successorDigest)
+			if _, exists := m.nodes[successorDigest]; exists {
+				danglings = append(danglings, m.nodes[successorDigest])
 			}
 		}
 	}
-	delete(m.successors, nodeKey)
-	delete(m.nodes, nodeKey)
+	delete(m.successors, node.Digest)
+	delete(m.nodes, node.Digest)
 	return danglings
 }
 
@@ -154,8 +151,8 @@ func (m *Memory) DigestSet() set.Set[digest.Digest] {
 	defer m.lock.RUnlock()
 
 	s := set.New[digest.Digest]()
-	for desc := range m.nodes {
-		s.Add(desc.Digest)
+	for digest := range m.nodes {
+		s.Add(digest)
 	}
 	return s
 }
@@ -170,22 +167,20 @@ func (m *Memory) index(ctx context.Context, fetcher content.Fetcher, node ocispe
 	defer m.lock.Unlock()
 
 	// index the node
-	nodeKey := descriptor.FromOCI(node)
-	m.nodes[nodeKey] = node
+	m.nodes[node.Digest] = node
 
 	// for each successor, put it into the node's successors list, and
 	// put node into the succeesor's predecessors list
-	successorSet := set.New[descriptor.Descriptor]()
-	m.successors[nodeKey] = successorSet
+	successorSet := set.New[digest.Digest]()
+	m.successors[node.Digest] = successorSet
 	for _, successor := range successors {
-		successorKey := descriptor.FromOCI(successor)
-		successorSet.Add(successorKey)
-		predecessorSet, exists := m.predecessors[successorKey]
+		successorSet.Add(successor.Digest)
+		predecessorSet, exists := m.predecessors[successor.Digest]
 		if !exists {
-			predecessorSet = set.New[descriptor.Descriptor]()
-			m.predecessors[successorKey] = predecessorSet
+			predecessorSet = set.New[digest.Digest]()
+			m.predecessors[successor.Digest] = predecessorSet
 		}
-		predecessorSet.Add(nodeKey)
+		predecessorSet.Add(node.Digest)
 	}
 	return successors, nil
 }
@@ -195,7 +190,6 @@ func (m *Memory) Exists(node ocispec.Descriptor) bool {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
-	nodeKey := descriptor.FromOCI(node)
-	_, exists := m.nodes[nodeKey]
+	_, exists := m.nodes[node.Digest]
 	return exists
 }

--- a/internal/graph/memory_test.go
+++ b/internal/graph/memory_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/oras-project/oras-go/v3/internal/cas"
-	"github.com/oras-project/oras-go/v3/internal/descriptor"
 )
 
 // +------------------------------+
@@ -104,19 +103,14 @@ func TestMemory_IndexAndRemove(t *testing.T) {
 		t.Errorf("testFetcher.Fetch() = %v, want %v", got, blobs[4])
 	}
 
-	nodeKeyA := descriptor.FromOCI(descA)
-	nodeKeyB := descriptor.FromOCI(descB)
-	nodeKeyC := descriptor.FromOCI(descC)
-	nodeKeyD := descriptor.FromOCI(descD)
-
 	// index and check the information of node D
 	testMemory.Index(ctx, testFetcher, descD)
 	// 1. verify its existence in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyD]; !exists {
+	if _, exists := testMemory.nodes[descD.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "D")
 	}
 	// 2. verify that the entry of D exists in testMemory.successors and it's empty
-	successorsD, exists := testMemory.successors[nodeKeyD]
+	successorsD, exists := testMemory.successors[descD.Digest]
 	if !exists {
 		t.Errorf("successor entry of %s should exist", "D")
 	}
@@ -127,7 +121,7 @@ func TestMemory_IndexAndRemove(t *testing.T) {
 		t.Errorf("successors of %s should be empty", "D")
 	}
 	// 3. there should be no entry of D in testMemory.predecessors yet
-	_, exists = testMemory.predecessors[nodeKeyD]
+	_, exists = testMemory.predecessors[descD.Digest]
 	if exists {
 		t.Errorf("predecessor entry of %s should not exist yet", "D")
 	}
@@ -135,11 +129,11 @@ func TestMemory_IndexAndRemove(t *testing.T) {
 	// index and check the information of node C
 	testMemory.Index(ctx, testFetcher, descC)
 	// 1. verify its existence in memory.nodes
-	if _, exists := testMemory.nodes[nodeKeyC]; !exists {
+	if _, exists := testMemory.nodes[descC.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "C")
 	}
 	// 2. verify that the entry of C exists in testMemory.successors and it's empty
-	successorsC, exists := testMemory.successors[nodeKeyC]
+	successorsC, exists := testMemory.successors[descC.Digest]
 	if !exists {
 		t.Errorf("successor entry of %s should exist", "C")
 	}
@@ -150,7 +144,7 @@ func TestMemory_IndexAndRemove(t *testing.T) {
 		t.Errorf("successors of %s should be empty", "C")
 	}
 	// 3. there should be no entry of C in testMemory.predecessors yet
-	_, exists = testMemory.predecessors[nodeKeyC]
+	_, exists = testMemory.predecessors[descC.Digest]
 	if exists {
 		t.Errorf("predecessor entry of %s should not exist yet", "C")
 	}
@@ -158,48 +152,48 @@ func TestMemory_IndexAndRemove(t *testing.T) {
 	// index and check the information of node A
 	testMemory.Index(ctx, testFetcher, descA)
 	// 1. verify its existence in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyA]; !exists {
+	if _, exists := testMemory.nodes[descA.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "A")
 	}
 	// 2. verify that the entry of A exists in testMemory.successors and it contains
 	// node B and node D
-	successorsA, exists := testMemory.successors[nodeKeyA]
+	successorsA, exists := testMemory.successors[descA.Digest]
 	if !exists {
 		t.Errorf("successor entry of %s should exist", "A")
 	}
 	if successorsA == nil {
 		t.Errorf("successors of %s should be a set, not nil", "A")
 	}
-	if !successorsA.Contains(nodeKeyB) {
+	if !successorsA.Contains(descB.Digest) {
 		t.Errorf("successors of %s should contain %s", "A", "B")
 	}
-	if !successorsA.Contains(nodeKeyD) {
+	if !successorsA.Contains(descD.Digest) {
 		t.Errorf("successors of %s should contain %s", "A", "D")
 	}
 	// 3. verify that node A exists in the predecessors lists of its successors.
 	// there should be an entry of D in testMemory.predecessors by now and it
 	// should contain A but not B
-	predecessorsD, exists := testMemory.predecessors[nodeKeyD]
+	predecessorsD, exists := testMemory.predecessors[descD.Digest]
 	if !exists {
 		t.Errorf("predecessor entry of %s should exist by now", "D")
 	}
-	if !predecessorsD.Contains(nodeKeyA) {
+	if !predecessorsD.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "D", "A")
 	}
-	if predecessorsD.Contains(nodeKeyB) {
+	if predecessorsD.Contains(descB.Digest) {
 		t.Errorf("predecessors of %s should not contain %s yet", "D", "B")
 	}
 	// there should be an entry of B in testMemory.predecessors now
 	// and it should contain A
-	predecessorsB, exists := testMemory.predecessors[nodeKeyB]
+	predecessorsB, exists := testMemory.predecessors[descB.Digest]
 	if !exists {
 		t.Errorf("predecessor entry of %s should exist by now", "B")
 	}
-	if !predecessorsB.Contains(nodeKeyA) {
+	if !predecessorsB.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "B", "A")
 	}
 	// 4. there should be no entry of A in testMemory.predecessors
-	_, exists = testMemory.predecessors[nodeKeyA]
+	_, exists = testMemory.predecessors[descA.Digest]
 	if exists {
 		t.Errorf("predecessor entry of %s should not exist", "A")
 	}
@@ -207,100 +201,100 @@ func TestMemory_IndexAndRemove(t *testing.T) {
 	// index and check the information of node B
 	testMemory.Index(ctx, testFetcher, descB)
 	// 1. verify its existence in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyB]; !exists {
+	if _, exists := testMemory.nodes[descB.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "B")
 	}
 	// 2. verify that the entry of B exists in testMemory.successors and it contains
 	// node C and node D
-	successorsB, exists := testMemory.successors[nodeKeyB]
+	successorsB, exists := testMemory.successors[descB.Digest]
 	if !exists {
 		t.Errorf("successor entry of %s should exist", "B")
 	}
 	if successorsB == nil {
 		t.Errorf("successors of %s should be a set, not nil", "B")
 	}
-	if !successorsB.Contains(nodeKeyC) {
+	if !successorsB.Contains(descC.Digest) {
 		t.Errorf("successors of %s should contain %s", "B", "C")
 	}
-	if !successorsB.Contains(nodeKeyD) {
+	if !successorsB.Contains(descD.Digest) {
 		t.Errorf("successors of %s should contain %s", "B", "D")
 	}
 	// 3. verify that node B exists in the predecessors lists of its successors.
 	// there should be an entry of C in testMemory.predecessors by now
 	// and it should contain B
-	predecessorsC, exists := testMemory.predecessors[nodeKeyC]
+	predecessorsC, exists := testMemory.predecessors[descC.Digest]
 	if !exists {
 		t.Errorf("predecessor entry of %s should exist by now", "C")
 	}
-	if !predecessorsC.Contains(nodeKeyB) {
+	if !predecessorsC.Contains(descB.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "C", "B")
 	}
 	// predecessors of D should have been updated now to have node A and B
-	if !predecessorsD.Contains(nodeKeyB) {
+	if !predecessorsD.Contains(descB.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "D", "B")
 	}
-	if !predecessorsD.Contains(nodeKeyA) {
+	if !predecessorsD.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "D", "A")
 	}
 
 	// remove node B and check the stored information
 	testMemory.Remove(descB)
 	// 1. verify that node B no longer exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyB]; exists {
+	if _, exists := testMemory.nodes[descB.Digest]; exists {
 		t.Errorf("nodes entry of %s should no longer exist", "B")
 	}
 	// 2. verify B' predecessors info: B's entry in testMemory.predecessors should
 	// still exist, since its predecessor A still exists
-	predecessorsB, exists = testMemory.predecessors[nodeKeyB]
+	predecessorsB, exists = testMemory.predecessors[descB.Digest]
 	if !exists {
 		t.Errorf("testDeletableMemory.predecessors should still contain the entry of %s", "B")
 	}
-	if !predecessorsB.Contains(nodeKeyA) {
+	if !predecessorsB.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should still contain %s", "B", "A")
 	}
 	// 3. verify B' successors info: B's entry in testMemory.successors should no
 	// longer exist
-	if _, exists := testMemory.successors[nodeKeyB]; exists {
+	if _, exists := testMemory.successors[descB.Digest]; exists {
 		t.Errorf("testDeletableMemory.successors should not contain the entry of %s", "B")
 	}
 	// 4. verify B' predecessors' successors info: B should still exist in A's
 	// successors
-	if !successorsA.Contains(nodeKeyB) {
+	if !successorsA.Contains(descB.Digest) {
 		t.Errorf("successors of %s should still contain %s", "A", "B")
 	}
 	// 5. verify B' successors' predecessors info: C's entry in testMemory.predecessors
 	// should no longer exist, since C's only predecessor B is already deleted
-	if _, exists = testMemory.predecessors[nodeKeyC]; exists {
+	if _, exists = testMemory.predecessors[descC.Digest]; exists {
 		t.Errorf("predecessor entry of %s should no longer exist by now, since all its predecessors have been deleted", "C")
 	}
 	// B should no longer exist in D's predecessors
-	if predecessorsD.Contains(nodeKeyB) {
+	if predecessorsD.Contains(descB.Digest) {
 		t.Errorf("predecessors of %s should not contain %s", "D", "B")
 	}
 	// but A still exists in D's predecessors
-	if !predecessorsD.Contains(nodeKeyA) {
+	if !predecessorsD.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should still contain %s", "D", "A")
 	}
 
 	// remove node A and check the stored information
 	testMemory.Remove(descA)
 	// 1. verify that node A no longer exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyA]; exists {
+	if _, exists := testMemory.nodes[descA.Digest]; exists {
 		t.Errorf("nodes entry of %s should no longer exist", "A")
 	}
 	// 2. verify A' successors info: A's entry in testMemory.successors should no
 	// longer exist
-	if _, exists := testMemory.successors[nodeKeyA]; exists {
+	if _, exists := testMemory.successors[descA.Digest]; exists {
 		t.Errorf("testDeletableMemory.successors should not contain the entry of %s", "A")
 	}
 	// 3. verify A' successors' predecessors info: D's entry in testMemory.predecessors
 	// should no longer exist, since all predecessors of D are already deleted
-	if _, exists = testMemory.predecessors[nodeKeyD]; exists {
+	if _, exists = testMemory.predecessors[descD.Digest]; exists {
 		t.Errorf("predecessor entry of %s should no longer exist by now, since all its predecessors have been deleted", "D")
 	}
 	// B's entry in testMemory.predecessors should no longer exist, since B's only
 	// predecessor A is already deleted
-	if _, exists = testMemory.predecessors[nodeKeyB]; exists {
+	if _, exists = testMemory.predecessors[descB.Digest]; exists {
 		t.Errorf("predecessor entry of %s should no longer exist by now, since all its predecessors have been deleted", "B")
 	}
 }
@@ -392,106 +386,99 @@ func TestMemory_IndexAllAndPredecessors(t *testing.T) {
 		t.Errorf("testFetcher.Fetch() = %v, want %v", got, blobs[4])
 	}
 
-	nodeKeyA := descriptor.FromOCI(descA)
-	nodeKeyB := descriptor.FromOCI(descB)
-	nodeKeyC := descriptor.FromOCI(descC)
-	nodeKeyD := descriptor.FromOCI(descD)
-	nodeKeyE := descriptor.FromOCI(descE)
-	nodeKeyF := descriptor.FromOCI(descF)
-
 	// index node A into testMemory using IndexAll
 	testMemory.IndexAll(ctx, testFetcher, descA)
 
 	// check the information of node A
 	// 1. verify that node A exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyA]; !exists {
+	if _, exists := testMemory.nodes[descA.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "A")
 	}
 	// 2. verify that there is no entry of A in predecessors
-	if _, exists := testMemory.predecessors[nodeKeyA]; exists {
+	if _, exists := testMemory.predecessors[descA.Digest]; exists {
 		t.Errorf("there should be no entry of %s in predecessors", "A")
 	}
 	// 3. verify that A has successors B, C, D
-	successorsA, exists := testMemory.successors[nodeKeyA]
+	successorsA, exists := testMemory.successors[descA.Digest]
 	if !exists {
 		t.Errorf("there should be an entry of %s in successors", "A")
 	}
-	if !successorsA.Contains(nodeKeyB) {
+	if !successorsA.Contains(descB.Digest) {
 		t.Errorf("successors of %s should contain %s", "A", "B")
 	}
-	if !successorsA.Contains(nodeKeyC) {
+	if !successorsA.Contains(descC.Digest) {
 		t.Errorf("successors of %s should contain %s", "A", "C")
 	}
-	if !successorsA.Contains(nodeKeyD) {
+	if !successorsA.Contains(descD.Digest) {
 		t.Errorf("successors of %s should contain %s", "A", "D")
 	}
 
 	// check the information of node B
 	// 1. verify that node B exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyB]; !exists {
+	if _, exists := testMemory.nodes[descB.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "B")
 	}
 	// 2. verify that B has node A in its predecessors
-	predecessorsB := testMemory.predecessors[nodeKeyB]
-	if !predecessorsB.Contains(nodeKeyA) {
+	predecessorsB := testMemory.predecessors[descB.Digest]
+	if !predecessorsB.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "B", "A")
 	}
 	// 3. verify that B has node E in its successors
-	successorsB := testMemory.successors[nodeKeyB]
-	if !successorsB.Contains(nodeKeyE) {
+	successorsB := testMemory.successors[descB.Digest]
+	if !successorsB.Contains(descE.Digest) {
 		t.Errorf("successors of %s should contain %s", "B", "E")
 	}
 
 	// check the information of node C
 	// 1. verify that node C exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyC]; !exists {
+	if _, exists := testMemory.nodes[descC.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "C")
 	}
 	// 2. verify that C has node A in its predecessors
-	predecessorsC := testMemory.predecessors[nodeKeyC]
-	if !predecessorsC.Contains(nodeKeyA) {
+	predecessorsC := testMemory.predecessors[descC.Digest]
+	if !predecessorsC.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "C", "A")
 	}
 	// 3. verify that C has node E and F in its successors
-	successorsC := testMemory.successors[nodeKeyC]
-	if !successorsC.Contains(nodeKeyE) {
+	successorsC := testMemory.successors[descC.Digest]
+	if !successorsC.Contains(descE.Digest) {
 		t.Errorf("successors of %s should contain %s", "C", "E")
 	}
-	if !successorsC.Contains(nodeKeyF) {
+	if !successorsC.Contains(descF.Digest) {
 		t.Errorf("successors of %s should contain %s", "C", "F")
 	}
 
 	// check the information of node D
 	// 1. verify that node D exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyD]; !exists {
+	if _, exists := testMemory.nodes[descD.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "D")
 	}
 	// 2. verify that D has node A in its predecessors
-	predecessorsD := testMemory.predecessors[nodeKeyD]
-	if !predecessorsD.Contains(nodeKeyA) {
+	predecessorsD := testMemory.predecessors[descD.Digest]
+	if !predecessorsD.Contains(descA.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "D", "A")
 	}
 	// 3. verify that D has node F in its successors
-	successorsD := testMemory.successors[nodeKeyD]
-	if !successorsD.Contains(nodeKeyF) {
+	successorsD := testMemory.successors[descD.Digest]
+	if !successorsD.Contains(descF.Digest) {
 		t.Errorf("successors of %s should contain %s", "D", "F")
 	}
 
 	// check the information of node E
 	// 1. verify that node E exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyE]; !exists {
+	if _, exists := testMemory.nodes[descE.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "E")
 	}
 	// 2. verify that E has node B and C in its predecessors
-	predecessorsE := testMemory.predecessors[nodeKeyE]
-	if !predecessorsE.Contains(nodeKeyB) {
+	predecessorsE := testMemory.predecessors[descE.Digest]
+	if !predecessorsE.Contains(descB.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "E", "B")
 	}
-	if !predecessorsE.Contains(nodeKeyC) {
+	if !predecessorsE.Contains(descC.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "E", "C")
 	}
 	// 3. verify that E has an entry in successors and it's empty
-	successorsE, exists := testMemory.successors[nodeKeyE]
+	successorsE, exists := testMemory.successors[descE.Digest]
 	if !exists {
 		t.Errorf("entry %s should exist in testMemory.successors", "E")
 	}
@@ -504,19 +491,19 @@ func TestMemory_IndexAllAndPredecessors(t *testing.T) {
 
 	// check the information of node F
 	// 1. verify that node F exists in testMemory.nodes
-	if _, exists := testMemory.nodes[nodeKeyF]; !exists {
+	if _, exists := testMemory.nodes[descF.Digest]; !exists {
 		t.Errorf("nodes entry of %s should exist", "F")
 	}
 	// 2. verify that F has node C and D in its predecessors
-	predecessorsF := testMemory.predecessors[nodeKeyF]
-	if !predecessorsF.Contains(nodeKeyC) {
+	predecessorsF := testMemory.predecessors[descF.Digest]
+	if !predecessorsF.Contains(descC.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "F", "C")
 	}
-	if !predecessorsF.Contains(nodeKeyD) {
+	if !predecessorsF.Contains(descD.Digest) {
 		t.Errorf("predecessors of %s should contain %s", "F", "D")
 	}
 	// 3. verify that F has an entry in successors and it's empty
-	successorsF, exists := testMemory.successors[nodeKeyF]
+	successorsF, exists := testMemory.successors[descF.Digest]
 	if !exists {
 		t.Errorf("entry %s should exist in testMemory.successors", "F")
 	}
@@ -557,34 +544,34 @@ func TestMemory_IndexAllAndPredecessors(t *testing.T) {
 
 	// remove node C and check the stored information
 	testMemory.Remove(descC)
-	if predecessorsE.Contains(nodeKeyC) {
+	if predecessorsE.Contains(descC.Digest) {
 		t.Errorf("predecessors of %s should not contain %s", "E", "C")
 	}
-	if predecessorsF.Contains(nodeKeyC) {
+	if predecessorsF.Contains(descC.Digest) {
 		t.Errorf("predecessors of %s should not contain %s", "F", "C")
 	}
-	if !successorsA.Contains(nodeKeyC) {
+	if !successorsA.Contains(descC.Digest) {
 		t.Errorf("successors of %s should still contain %s", "A", "C")
 	}
-	if _, exists := testMemory.successors[nodeKeyC]; exists {
+	if _, exists := testMemory.successors[descC.Digest]; exists {
 		t.Errorf("testMemory.successors should not contain the entry of %s", "C")
 	}
-	if _, exists := testMemory.predecessors[nodeKeyC]; !exists {
+	if _, exists := testMemory.predecessors[descC.Digest]; !exists {
 		t.Errorf("entry %s in predecessors should still exists since it still has at least one predecessor node present", "C")
 	}
 
 	// remove node A and check the stored information
 	testMemory.Remove(descA)
-	if _, exists := testMemory.predecessors[nodeKeyB]; exists {
+	if _, exists := testMemory.predecessors[descB.Digest]; exists {
 		t.Errorf("entry %s in predecessors should no longer exists", "B")
 	}
-	if _, exists := testMemory.predecessors[nodeKeyC]; exists {
+	if _, exists := testMemory.predecessors[descC.Digest]; exists {
 		t.Errorf("entry %s in predecessors should no longer exists", "C")
 	}
-	if _, exists := testMemory.predecessors[nodeKeyD]; exists {
+	if _, exists := testMemory.predecessors[descD.Digest]; exists {
 		t.Errorf("entry %s in predecessors should no longer exists", "D")
 	}
-	if _, exists := testMemory.successors[nodeKeyA]; exists {
+	if _, exists := testMemory.successors[descA.Digest]; exists {
 		t.Errorf("testDeletableMemory.successors should not contain the entry of %s", "A")
 	}
 
@@ -763,5 +750,133 @@ func TestMemory_Exists(t *testing.T) {
 		if exists := testMemory.Exists(descriptors[i]); exists != true {
 			t.Errorf("digest of blob[%d] should exist in digestSet", i)
 		}
+	}
+}
+
+// TestMemory_SharedBlobDigestUnderDifferentMediaType is a regression test for
+// the garbage-collection bug fixed in #1095 (reported in #1093): when two
+// manifests reference the same blob digest under different media types, the
+// graph must treat the blob as a single digest-keyed node. Keying on the full
+// descriptor (media type + digest + size) split it into two nodes, so removing
+// one manifest wrongly reported the still-referenced blob as dangling and GC
+// pruned it. This test fails on the pre-fix (descriptor-keyed) code.
+func TestMemory_SharedBlobDigestUnderDifferentMediaType(t *testing.T) {
+	testFetcher := cas.NewMemory()
+	testMemory := NewMemory()
+	ctx := context.Background()
+
+	// generate test content
+	var blobs [][]byte
+	appendBlob := func(mediaType string, blob []byte) ocispec.Descriptor {
+		blobs = append(blobs, blob)
+		return ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+		}
+	}
+	// generateManifest builds an OCI image manifest referencing the given
+	// config and layers. content.Successors later parses the actual media
+	// types recorded in the manifest JSON, so the shared layer is surfaced
+	// under whatever media type each manifest declared for it.
+	generateManifest := func(config ocispec.Descriptor, layers ...ocispec.Descriptor) ocispec.Descriptor {
+		manifest := ocispec.Manifest{
+			Config: config,
+			Layers: layers,
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
+	}
+
+	// The shared blob: identical bytes => identical digest, but referenced by
+	// the two manifests below under two DIFFERENT layer media types.
+	sharedBytes := []byte("shared blob referenced under two media types")
+	sharedDigest := digest.FromBytes(sharedBytes)
+	sharedAsTypeA := appendBlob("application/vnd.test.layer.type-a", sharedBytes)
+	sharedAsTypeB := ocispec.Descriptor{
+		MediaType: "application/vnd.test.layer.type-b", // same digest & size, different media type
+		Digest:    sharedDigest,
+		Size:      int64(len(sharedBytes)),
+	}
+
+	// distinct configs so that manifestA and manifestB have distinct digests
+	configA := appendBlob(ocispec.MediaTypeImageConfig, []byte("config A"))
+	configB := appendBlob(ocispec.MediaTypeImageConfig, []byte("config B"))
+
+	manifestA := generateManifest(configA, sharedAsTypeA) // refs shared blob as type-a
+	manifestB := generateManifest(configB, sharedAsTypeB) // refs shared blob as type-b
+
+	// push everything into the (digest-keyed) CAS used as the fetcher
+	push := func(desc ocispec.Descriptor, data []byte) {
+		if err := testFetcher.Push(ctx, desc, bytes.NewReader(data)); err != nil {
+			t.Fatalf("push %s: %v", desc.Digest, err)
+		}
+	}
+	push(sharedAsTypeA, sharedBytes)
+	push(configA, []byte("config A"))
+	push(configB, []byte("config B"))
+	push(manifestA, blobs[len(blobs)-2])
+	push(manifestB, blobs[len(blobs)-1])
+
+	// index the shared blob node itself (a leaf), then both manifests
+	if err := testMemory.Index(ctx, testFetcher, sharedAsTypeA); err != nil {
+		t.Fatalf("Index(sharedAsTypeA): %v", err)
+	}
+	if err := testMemory.Index(ctx, testFetcher, manifestA); err != nil {
+		t.Fatalf("Index(manifestA): %v", err)
+	}
+	if err := testMemory.Index(ctx, testFetcher, manifestB); err != nil {
+		t.Fatalf("Index(manifestB): %v", err)
+	}
+
+	// Invariant 1: the shared blob is a SINGLE node keyed by digest, with BOTH
+	// manifests as predecessors, regardless of the media type used to look it up.
+	predsViaA, err := testMemory.Predecessors(ctx, sharedAsTypeA)
+	if err != nil {
+		t.Fatalf("Predecessors(sharedAsTypeA): %v", err)
+	}
+	predsViaB, err := testMemory.Predecessors(ctx, sharedAsTypeB)
+	if err != nil {
+		t.Fatalf("Predecessors(sharedAsTypeB): %v", err)
+	}
+	if len(predsViaA) != 2 {
+		t.Errorf("shared blob (lookup type-a) should have 2 predecessors, got %d", len(predsViaA))
+	}
+	if len(predsViaB) != 2 {
+		t.Errorf("shared blob (lookup type-b) should have 2 predecessors, got %d", len(predsViaB))
+	}
+
+	// Invariant 2 (the core GC bug): removing manifestA must NOT report the
+	// shared blob as dangling, because manifestB still references the same digest.
+	danglings := testMemory.Remove(manifestA)
+	for _, d := range danglings {
+		if d.Digest == sharedDigest {
+			t.Errorf("shared blob %s was incorrectly reported dangling after removing manifestA; manifestB still references it", sharedDigest)
+		}
+	}
+
+	// Invariant 3: the shared blob still exists and still lists manifestB as its
+	// (only remaining) predecessor, whether looked up as type-a or type-b.
+	if !testMemory.Exists(sharedAsTypeB) {
+		t.Errorf("shared blob should still exist after removing manifestA")
+	}
+	predsAfter, err := testMemory.Predecessors(ctx, sharedAsTypeB)
+	if err != nil {
+		t.Fatalf("Predecessors after remove: %v", err)
+	}
+	if len(predsAfter) != 1 {
+		t.Fatalf("shared blob should have exactly 1 predecessor (manifestB) after removing manifestA, got %d", len(predsAfter))
+	}
+	if predsAfter[0].Digest != manifestB.Digest {
+		t.Errorf("remaining predecessor should be manifestB %s, got %s", manifestB.Digest, predsAfter[0].Digest)
+	}
+
+	// Invariant 4: DigestSet still contains the shared digest.
+	ds := testMemory.DigestSet()
+	if !ds.Contains(sharedDigest) {
+		t.Errorf("DigestSet should still contain shared blob digest %s", sharedDigest)
 	}
 }


### PR DESCRIPTION
## Description

Forward-port of #1095 (which fixed #1093) from `v2` to `main` (v3). Fixes #1258.

`internal/graph/memory.go` keyed its `nodes`, `predecessors`, and `successors` maps on `internal/descriptor.Descriptor`, which includes `MediaType` and `Size` in addition to `Digest`. Two manifests that reference the same blob **digest** under a different **media type** were therefore treated as distinct graph nodes, while the on-disk CAS is keyed purely by digest. When one manifest is removed, garbage collection misidentifies the shared blob as dangling and prunes it — invalidating the other manifest (the KitOps reproducer in #1093).

## Fix

Key the graph maps on `digest.Digest` to match the on-disk CAS, mirroring the merged v2 fix (#1095):

- Drop the `internal/descriptor` import; use `node.Digest` / `successor.Digest` instead of `descriptor.FromOCI(...)`.
- `nodes`, `predecessors`, `successors` are now `map[digest.Digest]...`.
- `memory_test.go` adapted to key on `desc*.Digest`.

## Regression test

Beyond the faithful forward-port, this adds `TestMemory_SharedBlobDigestUnderDifferentMediaType`: it builds two real manifests that reference the same blob digest under different layer media types and asserts the shared blob stays a single digest-keyed node — in particular that removing one manifest does **not** report the still-referenced blob as dangling. The test **fails** on the pre-fix (descriptor-keyed) code and passes on the fix, so it directly guards the #1093 GC regression. (Happy to drop it if you'd prefer strict parity with #1095.)

## Testing

- `go test ./...` passes.
- `make check-encoding` passes.
- Verified the new regression test fails on the pre-fix commit and passes on `HEAD`.

No public API change.

---
<sub>Disclosure: prepared with AI assistance (Claude Code); I reviewed the diff and verified the tests (including fail-on-pre-fix) locally.</sub>
