### PR TITLE
ci: ignore JSON release event license header

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -32,6 +32,7 @@ header:
     - '**/*.md'
     - 'CODEOWNERS'
     - 'LICENSE'
+    - '.github/act/release-event.json'
     - 'go.mod'
     - 'go.sum'
     - '**/testdata/**'


### PR DESCRIPTION
## What

- ignore `.github/act/release-event.json` in the license header checker

## Why

The file is JSON and cannot contain a comment-style Apache header. The current `check-license` job reports it as the only invalid file, so this keeps the checker aligned with the file format without weakening checks for source files.

## Validation

- `license-eye@v0.8.0 header check -c .github/licenserc.yml` (246 checked, 216 valid, 30 ignored, 0 invalid)
- `git diff --check`

Fixes #1262