### PR TITLE
ci: harden release version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,12 @@ jobs:
           BRANCH: ${{ github.head_ref }}
         run: |
           VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate semantic version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if ! [[ "$VERSION" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
             echo "Error: '$VERSION' does not follow semantic versioning"
             echo "Expected: vX.Y.Z or vX.Y.Z-(alpha|beta|rc).N"
@@ -56,11 +57,14 @@ jobs:
           fi
 
       - name: Create and push tag
+        env:
+          MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.version.outputs.version }} ${{ github.event.pull_request.merge_commit_sha }}
-          git push origin ${{ steps.version.outputs.version }}
+          git tag "$VERSION" "$MERGE_COMMIT"
+          git push origin "$VERSION"
 
       - name: Write release notes from PR body
         env:


### PR DESCRIPTION
## Summary

- pass the branch-derived release version through step environment variables instead of rendering it into shell source
- quote the version and merge commit when creating and pushing the release tag
- quote `GITHUB_OUTPUT` so the hardened workflow passes Actionlint

Fixes #1261

## Test plan

- `actionlint .github/workflows/release.yml`
- valid semantic-version shell regression check
- malicious branch-version shell regression check confirming no command execution
- `make test`