### PR TITLE
fix: enforce policy for exists operations

### DIFF
--- a/registry/remote/middleware.go
+++ b/registry/remote/middleware.go
@@ -63,12 +63,13 @@ func WithPolicyEnforcement(evaluator *policy.Evaluator, transport policy.Transpo
 	}
 }
 
-// policyEnforcingRepository wraps a Repository and enforces policy on all operations.
+// policyEnforcingRepository wraps a Repository and makes an explicit policy
+// decision for every operation.
 //
 // The wrapped repository is held in a named field rather than embedded so that
 // every method of registry.Repository must be implemented explicitly. If a new
 // method is added to the interface, this type fails to compile until the method
-// is handled here, ensuring no operation silently bypasses policy enforcement.
+// is handled here, ensuring policy behavior is considered for every operation.
 type policyEnforcingRepository struct {
 	repo      registry.Repository
 	evaluator *policy.Evaluator
@@ -111,12 +112,15 @@ func (r *policyEnforcingRepository) Push(ctx context.Context, expected ocispec.D
 	return r.repo.Push(ctx, expected, content)
 }
 
-// Exists returns true if the described content exists.
+// Exists returns true if the described content exists with policy enforcement.
 func (r *policyEnforcingRepository) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	if err := r.checkPolicy(ctx, target.Digest.String()); err != nil {
+		return false, err
+	}
 	return r.repo.Exists(ctx, target)
 }
 
-// Delete removes the content identified by the descriptor.
+// Delete removes content without a policy check so denied content remains removable.
 func (r *policyEnforcingRepository) Delete(ctx context.Context, target ocispec.Descriptor) error {
 	return r.repo.Delete(ctx, target)
 }
@@ -153,12 +157,12 @@ func (r *policyEnforcingRepository) PushReference(ctx context.Context, expected 
 	return r.repo.PushReference(ctx, expected, content, reference)
 }
 
-// Referrers lists the descriptors that refer to the given descriptor.
+// Referrers bypasses policy checks so policy verification can discover attestations.
 func (r *policyEnforcingRepository) Referrers(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
 	return r.repo.Referrers(ctx, desc, artifactType, fn)
 }
 
-// Tags lists the tags available in the repository.
+// Tags bypasses policy checks because it returns names rather than image content.
 func (r *policyEnforcingRepository) Tags(ctx context.Context, last string, fn func(tags []string) error) error {
 	return r.repo.Tags(ctx, last, fn)
 }
@@ -182,7 +186,7 @@ func (r *policyEnforcingRepository) Manifests() registry.ManifestStore {
 // policyEnforcingBlobStore wraps a BlobStore with policy enforcement.
 //
 // As with policyEnforcingRepository, the wrapped store is a named field so that
-// every registry.BlobStore method must be implemented explicitly.
+// every registry.BlobStore method must make an explicit policy decision.
 type policyEnforcingBlobStore struct {
 	blobs registry.BlobStore
 	repo  *policyEnforcingRepository
@@ -204,12 +208,15 @@ func (s *policyEnforcingBlobStore) Push(ctx context.Context, expected ocispec.De
 	return s.blobs.Push(ctx, expected, content)
 }
 
-// Exists returns true if the described content exists.
+// Exists returns true if the described content exists with policy enforcement.
 func (s *policyEnforcingBlobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	if err := s.repo.checkPolicy(ctx, target.Digest.String()); err != nil {
+		return false, err
+	}
 	return s.blobs.Exists(ctx, target)
 }
 
-// Delete removes the content identified by the descriptor.
+// Delete removes content without a policy check so denied content remains removable.
 func (s *policyEnforcingBlobStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
 	return s.blobs.Delete(ctx, target)
 }
@@ -230,7 +237,7 @@ func (s *policyEnforcingBlobStore) FetchReference(ctx context.Context, reference
 // policyEnforcingManifestStore wraps a ManifestStore with policy enforcement.
 //
 // As with policyEnforcingRepository, the wrapped store is a named field so that
-// every registry.ManifestStore method must be implemented explicitly.
+// every registry.ManifestStore method must make an explicit policy decision.
 type policyEnforcingManifestStore struct {
 	manifests registry.ManifestStore
 	repo      *policyEnforcingRepository
@@ -252,12 +259,15 @@ func (s *policyEnforcingManifestStore) Push(ctx context.Context, expected ocispe
 	return s.manifests.Push(ctx, expected, content)
 }
 
-// Exists returns true if the described content exists.
+// Exists returns true if the described content exists with policy enforcement.
 func (s *policyEnforcingManifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
+	if err := s.repo.checkPolicy(ctx, target.Digest.String()); err != nil {
+		return false, err
+	}
 	return s.manifests.Exists(ctx, target)
 }
 
-// Delete removes the content identified by the descriptor.
+// Delete removes content without a policy check so denied content remains removable.
 func (s *policyEnforcingManifestStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
 	return s.manifests.Delete(ctx, target)
 }

--- a/registry/remote/middleware_test.go
+++ b/registry/remote/middleware_test.go
@@ -302,6 +302,9 @@ func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
 	if _, err := wrapped.Fetch(ctx, desc); err == nil {
 		t.Error("Fetch() should return error when policy denies access")
 	}
+	if _, err := wrapped.Exists(ctx, desc); err == nil {
+		t.Error("Exists() should return error when policy denies access")
+	}
 	if err := wrapped.Push(ctx, desc, strings.NewReader("content")); err == nil {
 		t.Error("Push() should return error when policy denies access")
 	}
@@ -323,6 +326,9 @@ func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
 	if _, err := blobs.Fetch(ctx, desc); err == nil {
 		t.Error("Blobs().Fetch() should return error when policy denies access")
 	}
+	if _, err := blobs.Exists(ctx, desc); err == nil {
+		t.Error("Blobs().Exists() should return error when policy denies access")
+	}
 	if err := blobs.Push(ctx, desc, strings.NewReader("content")); err == nil {
 		t.Error("Blobs().Push() should return error when policy denies access")
 	}
@@ -335,6 +341,9 @@ func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
 	if _, err := manifests.Fetch(ctx, desc); err == nil {
 		t.Error("Manifests().Fetch() should return error when policy denies access")
 	}
+	if _, err := manifests.Exists(ctx, desc); err == nil {
+		t.Error("Manifests().Exists() should return error when policy denies access")
+	}
 	if err := manifests.Push(ctx, desc, strings.NewReader("content")); err == nil {
 		t.Error("Manifests().Push() should return error when policy denies access")
 	}
@@ -346,6 +355,48 @@ func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
 	}
 	if err := manifests.Tag(ctx, desc, "latest"); err == nil {
 		t.Error("Manifests().Tag() should return error when policy denies access")
+	}
+}
+
+func TestWithPolicyEnforcement_PolicyDenied_CarveOuts(t *testing.T) {
+	pol := &policy.Policy{
+		Default: []policy.PolicyRequirement{
+			&policy.Reject{},
+		},
+		Transports: make(map[policy.TransportName]policy.TransportScopes),
+	}
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	desc := ocispec.Descriptor{Digest: "sha256:test"}
+	baseRepo := &mockRepository{
+		referrersResult: []ocispec.Descriptor{desc},
+		tagsResult:      []string{"latest"},
+	}
+	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
+	wrapped := middleware(baseRepo)
+	ctx := context.Background()
+
+	if err := wrapped.Delete(ctx, desc); err != nil {
+		t.Errorf("Delete() error = %v, want nil", err)
+	}
+	if err := wrapped.Tags(ctx, "", func(tags []string) error {
+		if len(tags) != 1 || tags[0] != "latest" {
+			t.Errorf("Tags() = %v, want [latest]", tags)
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("Tags() error = %v, want nil", err)
+	}
+	if err := wrapped.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
+		if len(referrers) != 1 || referrers[0].Digest != desc.Digest {
+			t.Errorf("Referrers() = %v, want [%v]", referrers, desc)
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("Referrers() error = %v, want nil", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- enforce policy checks for repository, blob-store, and manifest-store `Exists` calls
- document why `Delete`, `Tags`, and `Referrers` intentionally bypass admission checks
- add deny-all regression coverage for gated operations and the intentional carve-outs

## Tests

```
go test ./registry/remote -count=1
```

322 tests passed.

Fixes #1265