### PR TITLE
fix: validate caller-supplied config descriptors

### DIFF
--- a/pack.go
+++ b/pack.go
@@ -100,7 +100,8 @@ type PackManifestOptions struct {
 	ManifestAnnotations map[string]string
 
 	// ConfigDescriptor is a pointer to the descriptor of the config blob.
-	// If not nil, ConfigAnnotations will be ignored.
+	// If not nil, the caller is responsible for pushing the config blob to
+	// pusher and populating Digest and Size. ConfigAnnotations will be ignored.
 	ConfigDescriptor *ocispec.Descriptor
 
 	// ConfigAnnotations is the annotation map of the config descriptor.
@@ -166,8 +167,10 @@ type PackOptions struct {
 	PackImageManifest bool
 
 	// ConfigDescriptor is a pointer to the descriptor of the config blob.
-	// If not nil, artifactType will be implied by the mediaType of the
-	// specified ConfigDescriptor, and ConfigAnnotations will be ignored.
+	// If not nil, the caller is responsible for pushing the config blob to
+	// pusher and populating Digest and Size. artifactType will be implied by
+	// the mediaType of the specified ConfigDescriptor, and ConfigAnnotations
+	// will be ignored.
 	// This option is valid only when PackImageManifest is true.
 	ConfigDescriptor *ocispec.Descriptor
 
@@ -225,8 +228,8 @@ func packManifestV1_0(ctx context.Context, pusher content.Pusher, artifactType s
 	// prepare config
 	var configDesc ocispec.Descriptor
 	if opts.ConfigDescriptor != nil {
-		if err := validateMediaType(opts.ConfigDescriptor.MediaType); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("invalid config mediaType format: %w", err)
+		if err := validateConfigDescriptor(*opts.ConfigDescriptor); err != nil {
+			return ocispec.Descriptor{}, err
 		}
 		configDesc = *opts.ConfigDescriptor
 	} else {
@@ -272,6 +275,9 @@ func packManifestV1_1_RC2(ctx context.Context, pusher content.Pusher, configMedi
 	// prepare config
 	var configDesc ocispec.Descriptor
 	if opts.ConfigDescriptor != nil {
+		if err := validateConfigDescriptor(*opts.ConfigDescriptor); err != nil {
+			return ocispec.Descriptor{}, err
+		}
 		configDesc = *opts.ConfigDescriptor
 	} else {
 		var err error
@@ -318,8 +324,8 @@ func packManifestV1_1(ctx context.Context, pusher content.Pusher, artifactType s
 	var emptyBlobExists bool
 	var configDesc ocispec.Descriptor
 	if opts.ConfigDescriptor != nil {
-		if err := validateMediaType(opts.ConfigDescriptor.MediaType); err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("invalid config mediaType format: %w", err)
+		if err := validateConfigDescriptor(*opts.ConfigDescriptor); err != nil {
+			return ocispec.Descriptor{}, err
 		}
 		configDesc = *opts.ConfigDescriptor
 	} else {
@@ -443,6 +449,17 @@ func ensureAnnotationCreated(annotations map[string]string, annotationCreatedKey
 func validateMediaType(mediaType string) error {
 	if !mediaTypeRegexp.MatchString(mediaType) {
 		return fmt.Errorf("%s: %w", mediaType, errdef.ErrInvalidMediaType)
+	}
+	return nil
+}
+
+// validateConfigDescriptor validates a caller-supplied config descriptor.
+func validateConfigDescriptor(desc ocispec.Descriptor) error {
+	if err := validateMediaType(desc.MediaType); err != nil {
+		return fmt.Errorf("invalid config mediaType format: %w", err)
+	}
+	if err := desc.Digest.Validate(); err != nil {
+		return fmt.Errorf("invalid config digest %q: %v: %w", desc.Digest, err, errdef.ErrInvalidDigest)
 	}
 	return nil
 }

--- a/pack_test.go
+++ b/pack_test.go
@@ -786,6 +786,57 @@ func Test_PackManifest_ImageV1_0_InvalidMediaType(t *testing.T) {
 	}
 }
 
+func Test_Pack_InvalidConfigDescriptorDigest(t *testing.T) {
+	tests := []struct {
+		name   string
+		digest digest.Digest
+		pack   func(context.Context, content.Pusher, *ocispec.Descriptor) error
+	}{
+		{
+			name: "manifest v1.0 empty digest",
+			pack: func(ctx context.Context, pusher content.Pusher, config *ocispec.Descriptor) error {
+				_, err := PackManifest(ctx, pusher, PackManifestVersion1_0, "application/vnd.test", PackManifestOptions{
+					ConfigDescriptor: config,
+				})
+				return err
+			},
+		},
+		{
+			name:   "manifest v1.1 invalid digest",
+			digest: digest.Digest("invalid"),
+			pack: func(ctx context.Context, pusher content.Pusher, config *ocispec.Descriptor) error {
+				_, err := PackManifest(ctx, pusher, PackManifestVersion1_1, "application/vnd.test", PackManifestOptions{
+					ConfigDescriptor: config,
+				})
+				return err
+			},
+		},
+		{
+			name: "deprecated pack empty digest",
+			pack: func(ctx context.Context, pusher content.Pusher, config *ocispec.Descriptor) error {
+				_, err := Pack(ctx, pusher, "application/vnd.test", nil, PackOptions{
+					PackImageManifest: true,
+					ConfigDescriptor:  config,
+				})
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := &ocispec.Descriptor{
+				MediaType: "application/vnd.test.config",
+				Digest:    test.digest,
+			}
+			err := test.pack(context.Background(), memory.New(), config)
+			if !errors.Is(err, errdef.ErrInvalidDigest) {
+				t.Errorf("Pack() error = %v, wantErr = %v", err, errdef.ErrInvalidDigest)
+			}
+		})
+	}
+}
+
 func Test_PackManifest_ImageV1_0_InvalidDateTimeFormat(t *testing.T) {
 	s := memory.New()
 


### PR DESCRIPTION
## Summary

- validate caller-supplied config descriptor media types and digests
- apply validation to OCI 1.0, OCI 1.1, and deprecated RC2 packing paths
- return errors wrapping `errdef.ErrInvalidDigest` for empty or invalid digests
- document caller responsibility for pushing the config blob and setting digest and size

## Verification

- added a failing regression test covering all three packing paths before implementation
- `go test . -run Test_Pack_InvalidConfigDescriptorDigest -count=1`
- `make test`
- `gofmt -d pack.go pack_test.go`
- `git diff --check`

Closes #1268
