### PR TITLE
fix: redact sensitive request data from debug logs

### DIFF
--- a/registry/remote/logging_transport.go
+++ b/registry/remote/logging_transport.go
@@ -29,6 +29,8 @@ import (
 // sensitiveHeaders is the set of headers whose values are scrubbed from logs.
 var sensitiveHeaders = []string{
 	"Authorization",
+	"Cookie",
+	"Proxy-Authorization",
 	"Set-Cookie",
 }
 
@@ -73,10 +75,15 @@ func NewLoggingTransport(inner http.RoundTripper, logger *slog.Logger) *LoggingT
 // RoundTrip implements http.RoundTripper, logging the request and response.
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	id := requestCounter.Add(1) - 1
+	loggedURL := *req.URL
+	loggedURL.RawQuery = ""
+	loggedURL.ForceQuery = false
+	loggedURL.Fragment = ""
+	loggedURL.RawFragment = ""
 
 	t.logger.Debug(req.Method,
 		"id", id,
-		"url", req.URL,
+		"url", loggedURL.Redacted(),
 		"header", formatHeaders(req.Header),
 	)
 
@@ -99,7 +106,7 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 // formatHeaders returns a human-readable representation of the headers with
-// sensitive values (Authorization, Set-Cookie) replaced by "*****".
+// sensitive values replaced by "*****".
 func formatHeaders(header http.Header) string {
 	if len(header) == 0 {
 		return "   Empty header"

--- a/registry/remote/logging_transport_test.go
+++ b/registry/remote/logging_transport_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package remote
 
 import (
+	"bytes"
 	"io"
 	"log/slog"
 	"net/http"
@@ -41,14 +42,21 @@ func TestNewLoggingTransport_Defaults(t *testing.T) {
 
 func TestLoggingTransport_RoundTrip(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("token"); got != "query-secret" {
+			t.Errorf("query token = %q, want query-secret", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"ok"}`))
 	}))
 	defer srv.Close()
 
-	lt := NewLoggingTransport(http.DefaultTransport, slog.Default())
-	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	lt := NewLoggingTransport(http.DefaultTransport, logger)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"?token=query-secret", nil)
+	req.Header.Set("Cookie", "session=cookie-secret")
+	req.Header.Set("Proxy-Authorization", "Bearer proxy-secret")
 	resp, err := lt.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip() error = %v", err)
@@ -62,6 +70,11 @@ func TestLoggingTransport_RoundTrip(t *testing.T) {
 	}
 	if string(body) != `{"status":"ok"}` {
 		t.Errorf("body = %q, want %q", body, `{"status":"ok"}`)
+	}
+	for _, secret := range []string{"query-secret", "cookie-secret", "proxy-secret"} {
+		if strings.Contains(logs.String(), secret) {
+			t.Errorf("logs contain sensitive value %q", secret)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1271

## Summary

- redact `Cookie` and `Proxy-Authorization` alongside the existing sensitive headers
- omit query strings and fragments from the URL written to debug logs without mutating the outgoing request
- add end-to-end regression coverage for header and query credential leakage

## Testing

- `go test ./registry/remote`
- `go test ./...`
- `go test -race ./registry/remote`

`go vet ./...` still reports the existing lock-copy warning in `registry/remote/auth.go:37`.
