### PR TITLE
fix(remote): bound repository list pagination

### DIFF
--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -45,6 +45,12 @@ type Registry struct {
 	// If zero, the page size is determined by the remote registry.
 	// Reference: https://distribution.github.io/distribution/spec/api/#catalog
 	RepositoryListPageSize int
+
+	// RepositoryListMaxPages limits the total number of pages fetched during
+	// repository listing, bounding server-driven pagination so a malicious or
+	// misbehaving registry cannot force unbounded requests.
+	// If zero, repository listing is unlimited.
+	RepositoryListMaxPages int
 }
 
 // NewRegistry creates a client to the remote registry with the specified domain
@@ -130,7 +136,10 @@ func (r *Registry) Repositories(ctx context.Context, last string, fn func(repos 
 	ctx = auth.AppendScopesForHost(ctx, r.Reference.Host(), auth.ScopeRegistryCatalog)
 	url := buildRegistryCatalogURL(r.PlainHTTP, r.Reference)
 	var err error
-	for err == nil {
+	for page := 0; err == nil; page++ {
+		if r.RepositoryListMaxPages > 0 && page >= r.RepositoryListMaxPages {
+			return fmt.Errorf("repository listing exceeded %d pages: %w", r.RepositoryListMaxPages, errdef.ErrTooManyPages)
+		}
 		url, err = r.repositories(ctx, last, fn, url)
 		// clear `last` for subsequent pages
 		last = ""

--- a/registry/remote/registry_test.go
+++ b/registry/remote/registry_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -213,6 +214,54 @@ func TestRegistry_Repositories(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatalf("Registry.Repositories() error = %v", err)
+	}
+}
+
+func TestRegistry_Repositories_MaxPages(t *testing.T) {
+	requestCount := 0
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Method != http.MethodGet || r.URL.Path != "/v2/_catalog" {
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if requestCount < 3 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s/v2/_catalog>; rel="next"`, ts.URL))
+		}
+		if err := json.NewEncoder(w).Encode(struct {
+			Repositories []string `json:"repositories"`
+		}{Repositories: []string{"test"}}); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	reg, err := NewRegistry(uri.Host)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+	reg.PlainHTTP = true
+	reg.RepositoryListMaxPages = 2
+
+	callbackCount := 0
+	err = reg.Repositories(context.Background(), "", func(repos []string) error {
+		callbackCount++
+		return nil
+	})
+	if !errors.Is(err, errdef.ErrTooManyPages) {
+		t.Errorf("Registry.Repositories() error = %v, want %v", err, errdef.ErrTooManyPages)
+	}
+	if requestCount != reg.RepositoryListMaxPages {
+		t.Errorf("Registry.Repositories() request count = %d, want %d", requestCount, reg.RepositoryListMaxPages)
+	}
+	if callbackCount != reg.RepositoryListMaxPages {
+		t.Errorf("Registry.Repositories() callback count = %d, want %d", callbackCount, reg.RepositoryListMaxPages)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add Registry.RepositoryListMaxPages using the established zero-means-unlimited convention
- stop catalog pagination at the configured limit and wrap errdef.ErrTooManyPages
- verify the request and callback bound with a focused regression test

## Testing

- make test
- go test ./registry/remote
- go test ./registry/remote -run TestRegistry_Repositories_MaxPages -count=1

Fixes #1274