### PR TITLE
fix(auth): drop credentials on cross-origin redirects

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -122,7 +122,50 @@ func (c *Client) send(req *http.Request) (*http.Response, error) {
 	for key, values := range c.Header {
 		req.Header[key] = append(req.Header[key], values...)
 	}
-	return c.client().Do(req)
+	// Drop the Authorization header when a redirect crosses an HTTP origin
+	// (scheme, host, or port). The standard library only strips sensitive
+	// headers when the hostname changes, so a redirect to a different port on
+	// the same host would otherwise forward credentials to an unintended
+	// endpoint. Any caller-provided CheckRedirect is preserved.
+	// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+	client := c.client()
+	clientCopy := *client
+	checkRedirect := client.CheckRedirect
+	clientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 && !sameHTTPOrigin(via[len(via)-1].URL, req.URL) {
+			req.Header.Del(headerAuthorization)
+		}
+		if checkRedirect != nil {
+			return checkRedirect(req, via)
+		}
+		return nil
+	}
+	return clientCopy.Do(req)
+}
+
+// sameHTTPOrigin reports whether a and b share the same HTTP origin, i.e. the
+// same scheme and host. Default ports are normalized so that, for example,
+// "example.com" and "example.com:443" compare equal over https.
+func sameHTTPOrigin(a, b *url.URL) bool {
+	if !strings.EqualFold(a.Scheme, b.Scheme) {
+		return false
+	}
+	return canonicalHost(a) == canonicalHost(b)
+}
+
+// canonicalHost returns the lower-cased host of u with the default port for its
+// scheme applied when no explicit port is present.
+func canonicalHost(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "https":
+			port = "443"
+		case "http":
+			port = "80"
+		}
+	}
+	return strings.ToLower(u.Hostname()) + ":" + port
 }
 
 // credential resolves the credential for the given registry.
@@ -168,6 +211,9 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 	var attemptedKey string
 	cache := c.cache()
 	host := originalReq.Host
+	if host == "" {
+		host = originalReq.URL.Host
+	}
 	scheme, err := cache.GetScheme(ctx, host)
 	if err == nil {
 		switch scheme {
@@ -191,6 +237,13 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusUnauthorized {
+		return resp, nil
+	}
+	// If the challenge came from a different origin than originally requested
+	// (e.g. the request was redirected to another host or port), do not resolve
+	// or send the registry credentials to that origin.
+	// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+	if resp.Request != nil && !sameHTTPOrigin(originalReq.URL, resp.Request.URL) {
 		return resp, nil
 	}
 

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -3977,3 +3977,250 @@ func TestClient_fetchBasicAuth(t *testing.T) {
 		t.Errorf("incorrect error: %v, expected %v", err, ErrBasicCredentialNotFound)
 	}
 }
+
+// TestClient_Do_Basic_Auth_RedirectAfterAuth verifies that the Authorization
+// header is not forwarded when an authenticated request is redirected to a
+// different HTTP origin (here, a different port on the same host).
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+func TestClient_Do_Basic_Auth_RedirectAfterAuth(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	var sinkGotAuth atomic.Bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sinkGotAuth.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer sink.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != wantAuth {
+			w.Header().Set("Www-Authenticate", `Basic realm="origin"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// authenticated: redirect to a different origin (different port)
+		http.Redirect(w, r, sink.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatalf("invalid origin server: %v", err)
+	}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != originURL.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, originURL.Host)
+			}
+			return credentials.Credential{Username: username, Password: password}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if sinkGotAuth.Load() {
+		t.Error("Authorization header was forwarded to a redirect target on a different origin")
+	}
+}
+
+// TestClient_Do_Basic_Auth_RedirectBeforeAuth verifies that credentials are not
+// resolved or sent when the 401 challenge originates from a different HTTP
+// origin reached through a pre-authentication redirect.
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+func TestClient_Do_Basic_Auth_RedirectBeforeAuth(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+
+	var sinkGotAuth atomic.Bool
+	sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sinkGotAuth.Store(true)
+		}
+		w.Header().Set("Www-Authenticate", `Basic realm="sink"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer sink.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// redirect to a different origin before any authentication happens
+		http.Redirect(w, r, sink.URL+r.URL.RequestURI(), http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+
+	originURL, err := url.Parse(origin.URL)
+	if err != nil {
+		t.Fatalf("invalid origin server: %v", err)
+	}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != originURL.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, originURL.Host)
+			}
+			return credentials.Credential{Username: username, Password: password}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, origin.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if sinkGotAuth.Load() {
+		t.Error("credential was forwarded to a sink reached through a pre-auth redirect")
+	}
+}
+
+// TestClient_Do_Basic_Auth_SameOriginRedirect verifies that credentials are
+// still forwarded across a same-origin redirect (e.g. a path-only redirect),
+// guarding against an over-broad fix.
+func TestClient_Do_Basic_Auth_SameOriginRedirect(t *testing.T) {
+	username := "test_user"
+	password := "test_password"
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	var targetAuthOK atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect":
+			http.Redirect(w, r, "/target", http.StatusTemporaryRedirect)
+		case "/target":
+			if r.Header.Get("Authorization") != wantAuth {
+				w.Header().Set("Www-Authenticate", `Basic realm="target"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			targetAuthOK.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test server: %v", err)
+	}
+
+	client := &Client{
+		CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+			if reg != tsURL.Host {
+				return credentials.EmptyCredential, fmt.Errorf("registry mismatch: got %v, want %v", reg, tsURL.Host)
+			}
+			return credentials.Credential{Username: username, Password: password}, nil
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/redirect", nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if !targetAuthOK.Load() {
+		t.Error("credential was not forwarded across a same-origin redirect")
+	}
+}
+
+// TestClient_send_PreservesCheckRedirect verifies that a caller-provided
+// CheckRedirect callback on the underlying HTTP client is still invoked.
+func TestClient_send_PreservesCheckRedirect(t *testing.T) {
+	var called atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/a":
+			http.Redirect(w, r, "/b", http.StatusTemporaryRedirect)
+		case "/b":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	client := &Client{
+		Client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				called.Store(true)
+				return nil
+			},
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/a", nil)
+	if err != nil {
+		t.Fatalf("failed to create test request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Client.Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+	if !called.Load() {
+		t.Error("caller-provided CheckRedirect was not invoked")
+	}
+}
+
+func Test_sameHTTPOrigin(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"identical", "http://example.com:5000", "http://example.com:5000", true},
+		{"different port", "http://example.com:5000", "http://example.com:6000", false},
+		{"default https port normalized", "https://example.com", "https://example.com:443", true},
+		{"default http port normalized", "http://example.com", "http://example.com:80", true},
+		{"scheme mismatch", "http://example.com", "https://example.com", false},
+		{"case-insensitive host", "https://Example.COM", "https://example.com", true},
+		{"different host", "https://example.com", "https://evil.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := url.Parse(tt.a)
+			if err != nil {
+				t.Fatalf("failed to parse %q: %v", tt.a, err)
+			}
+			b, err := url.Parse(tt.b)
+			if err != nil {
+				t.Fatalf("failed to parse %q: %v", tt.b, err)
+			}
+			if got := sameHTTPOrigin(a, b); got != tt.want {
+				t.Errorf("sameHTTPOrigin(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1275 

## Summary

  - Forward-port the v2 cross-origin redirect credential fix (3c2e884) to v3.
  - Drop the Authorization header when a redirect crosses an HTTP origin, comparing
    scheme, host, and port with default ports normalized.
  - Skip credential resolution when a 401 challenge arrives from a different origin
    than the one originally requested.
  - Verified that `TestClient_Do_Basic_Auth_RedirectAfterAuth` and
  `TestClient_Do_Basic_Auth_RedirectBeforeAuth` fail on unpatched `main` and pass
  with the fix, while the same-origin control passes either way.

  ## Testing
  - `make test` — 33 packages ok, 0 failures
  