### PR TITLE
fix(auth): reject unsafe bearer realm URLs

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -185,6 +186,49 @@ func (c *Client) cache() Cache {
 	return c.Cache
 }
 
+// validateRealm rejects bearer token realm URLs that would have the client
+// forward credentials to obviously unsafe destinations:
+//
+//   - schemes other than http or https,
+//   - http realms when the registry was contacted over https (TLS downgrade),
+//   - hosts that are IP literals in loopback, link-local, private, or
+//     unspecified ranges (e.g. cloud instance metadata services such as
+//     169.254.169.254).
+//
+// Cross-host realms with a public hostname are permitted, because the
+// distribution spec allows a separate token endpoint (e.g. Docker Hub's
+// auth.docker.io). When the registry itself is reached at the same hostname
+// as the realm, the IP-literal check is skipped so loopback and in-cluster
+// deployments continue to work.
+func validateRealm(realm string, registryURL *url.URL) error {
+	if realm == "" {
+		return nil
+	}
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return fmt.Errorf("failed to parse bearer realm %q: %w", realm, err)
+	}
+	switch realmURL.Scheme {
+	case "https":
+		// always allowed
+	case "http":
+		if registryURL != nil && registryURL.Scheme == "https" {
+			return fmt.Errorf("bearer realm %q uses http but registry was contacted over https", realm)
+		}
+	default:
+		return fmt.Errorf("bearer realm %q uses unsupported scheme %q", realm, realmURL.Scheme)
+	}
+	if ip := net.ParseIP(realmURL.Hostname()); ip != nil {
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			ip.IsPrivate() || ip.IsUnspecified() {
+			if registryURL == nil || realmURL.Hostname() != registryURL.Hostname() {
+				return fmt.Errorf("bearer realm host %q is a loopback, link-local, private, or unspecified address", realmURL.Hostname())
+			}
+		}
+	}
+	return nil
+}
+
 // SetUserAgent sets the user agent for all out-going requests.
 func (c *Client) SetUserAgent(userAgent string) {
 	if c.Header == nil {
@@ -296,6 +340,9 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 
 		// attempt with credentials
 		realm := params["realm"]
+		if err := validateRealm(realm, originalReq.URL); err != nil {
+			return nil, fmt.Errorf("%s %q: %w", resp.Request.Method, resp.Request.URL, err)
+		}
 		service := params["service"]
 		token, err := cache.Set(ctx, host, SchemeBearer, key, func(ctx context.Context) (string, error) {
 			return c.fetchBearerToken(ctx, host, realm, service, scopes)

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -3744,7 +3744,7 @@ func TestClient_StaticCredential_basicAuth(t *testing.T) {
 	testPassword := "password"
 
 	// create a test server
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
@@ -3816,7 +3816,7 @@ func TestClient_StaticCredential_withAccessToken(t *testing.T) {
 	defer as.Close()
 
 	// create a test server
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
@@ -3910,7 +3910,7 @@ func TestClient_StaticCredential_withRefreshToken(t *testing.T) {
 	defer as.Close()
 
 	// create a test server
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
@@ -4220,6 +4220,42 @@ func Test_sameHTTPOrigin(t *testing.T) {
 			}
 			if got := sameHTTPOrigin(a, b); got != tt.want {
 				t.Errorf("sameHTTPOrigin(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_validateRealm(t *testing.T) {
+	registryHTTPS, _ := url.Parse("https://registry.example.com/v2/")
+	registryHTTP, _ := url.Parse("http://registry.example.com/v2/")
+	registryLoopback, _ := url.Parse("http://127.0.0.1:5000/v2/")
+
+	tests := []struct {
+		name     string
+		realm    string
+		registry *url.URL
+		wantErr  bool
+	}{
+		{"empty realm is allowed", "", registryHTTPS, false},
+		{"https realm is allowed", "https://auth.example.com/token", registryHTTPS, false},
+		{"https cross-host realm is allowed", "https://other.example.com/token", registryHTTPS, false},
+		{"http realm against plain-http registry is allowed", "http://auth.example.com/token", registryHTTP, false},
+		{"http realm against https registry is rejected (TLS downgrade)", "http://auth.example.com/token", registryHTTPS, true},
+		{"non-http scheme is rejected", "file:///etc/passwd", registryHTTPS, true},
+		{"ftp scheme is rejected", "ftp://auth.example.com/token", registryHTTPS, true},
+		{"IMDS IPv4 is rejected", "http://169.254.169.254/latest/meta-data/", registryHTTP, true},
+		{"loopback IPv4 is rejected when registry is on a public host", "http://127.0.0.1:9090/token", registryHTTPS, true},
+		{"loopback IPv6 is rejected when registry is on a public host", "http://[::1]:9090/token", registryHTTPS, true},
+		{"private RFC1918 is rejected when registry is on a public host", "http://10.0.0.5/token", registryHTTP, true},
+		{"unspecified address is rejected", "http://0.0.0.0/token", registryHTTP, true},
+		{"loopback realm is allowed when registry shares the loopback hostname", "http://127.0.0.1:9090/token", registryLoopback, false},
+		{"unparseable realm is rejected", "://bad-url", registryHTTPS, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRealm(tt.realm, tt.registry)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRealm(%q, %v) error = %v, wantErr %v", tt.realm, tt.registry, err, tt.wantErr)
 			}
 		})
 	}

--- a/registry/remote/auth/example_test.go
+++ b/registry/remote/auth/example_test.go
@@ -84,7 +84,7 @@ func TestMain(m *testing.M) {
 	defer as.Close()
 
 	// create a test server
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
@@ -134,7 +134,6 @@ func TestMain(m *testing.M) {
 	clientConfigTargetURL = fmt.Sprintf("%s/clientConfig", host)
 	accessTokenTargetURL = fmt.Sprintf("%s/accessToken", host)
 	refreshTokenTargetURL = fmt.Sprintf("%s/refreshToken", host)
-	http.DefaultClient = ts.Client()
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
  Fixes #1276

  ## Summary

  - Forward-port the v2 bearer realm validation fix (7a9f4b0) to v3.
  - Reject bearer `realm` URLs with schemes other than http or https.
  - Reject http realms when the registry was contacted over https (TLS downgrade).
  - Reject realm hosts that are loopback, link-local, private, or unspecified IP
    literals (e.g. the cloud instance metadata endpoint 169.254.169.254), unless
    the realm hostname matches the registry hostname
  - Move the affected existing tests from `httptest.NewTLSServer` to
    `httptest.NewServer`

  ## Testing

  make test — 33 packages ok, 0 failures