### PR TITLE
feat(file): support clamping tarball timestamps

### DIFF
--- a/content/file/file.go
+++ b/content/file/file.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -80,6 +81,16 @@ type Store struct {
 	// When specified, some metadata such as change time
 	// will be removed from the files in the tarballs. Default value: false.
 	TarReproducible bool
+	// TarModTime, when not nil, sets the upper bound for the timestamps in the
+	// tarballs generated for the added directories. Any entry with a
+	// modification time later than TarModTime is clamped down to TarModTime,
+	// while entries older than it are left unchanged. Access and change times
+	// are set to the same clamped value.
+	// This allows callers to implement SOURCE_DATE_EPOCH style reproducible
+	// builds. Reference: https://reproducible-builds.org/specs/source-date-epoch/
+	// TarModTime takes precedence over TarReproducible when both are set.
+	// Default value: nil.
+	TarModTime *time.Time
 	// AllowPathTraversalOnWrite controls if path traversal is allowed
 	// when writing files. When specified, writing files
 	// outside the working directory will be allowed. Default value: false.
@@ -508,6 +519,19 @@ func (s *Store) pushDir(name, target string, expected ocispec.Descriptor, conten
 	return nil
 }
 
+// returns upper bound for the timestamps in the tarballs generated for the added directories.
+func (s *Store) tarModTime() *time.Time {
+	if s.TarModTime != nil {
+		return s.TarModTime
+	}
+
+	// to ensure reproducible builds when TarModTime is not set, use zero time
+	if s.TarReproducible {
+		return &time.Time{}
+	}
+	return nil
+}
+
 // descriptorFromDir generates descriptor from the given directory.
 func (s *Store) descriptorFromDir(ctx context.Context, name, mediaType, dir string) (desc ocispec.Descriptor, err error) {
 	// make a temp file to store the gzip
@@ -536,7 +560,7 @@ func (s *Store) descriptorFromDir(ctx context.Context, name, mediaType, dir stri
 	tw := io.MultiWriter(gzw, tarDigester.Hash())
 	buf := bufPool.Get().(*[]byte)
 	defer bufPool.Put(buf)
-	if err := tarDirectory(ctx, dir, name, tw, s.TarReproducible, *buf); err != nil {
+	if err := tarDirectory(ctx, dir, name, tw, s.tarModTime(), *buf); err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to tar %s: %w", dir, err)
 	}
 

--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -3501,4 +3502,36 @@ func equalDescriptorSet(actual []ocispec.Descriptor, expected []ocispec.Descript
 		}
 	}
 	return true
+}
+
+func TestStore_tarModTime(t *testing.T) {
+	clamp := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	zero := time.Time{}
+
+	tests := []struct {
+		name            string
+		tarReproducible bool
+		tarModTime      *time.Time
+		want            *time.Time
+	}{
+		{"neither set keeps the times on disk", false, nil, nil},
+		{"TarReproducible clamps to the zero time", true, nil, &zero},
+		{"TarModTime clamps to the given time", false, &clamp, &clamp},
+		{"TarModTime takes precedence over TarReproducible", true, &clamp, &clamp},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Store{
+				TarReproducible: tt.tarReproducible,
+				TarModTime:      tt.tarModTime,
+			}
+			got := s.tarModTime()
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("tarModTime() = %v, want %v", got, tt.want)
+			}
+			if got != nil && !got.Equal(*tt.want) {
+				t.Errorf("tarModTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/content/file/utils.go
+++ b/content/file/utils.go
@@ -33,7 +33,7 @@ import (
 
 // tarDirectory walks the directory specified by path, and tar those files with a new
 // path prefix.
-func tarDirectory(ctx context.Context, root, prefix string, w io.Writer, removeTimes bool, buf []byte) (err error) {
+func tarDirectory(ctx context.Context, root, prefix string, w io.Writer, modTime *time.Time, buf []byte) (err error) {
 	tw := tar.NewWriter(w)
 	defer func() {
 		closeErr := tw.Close()
@@ -80,10 +80,12 @@ func tarDirectory(ctx context.Context, root, prefix string, w io.Writer, removeT
 		header.Uname = ""
 		header.Gname = ""
 
-		if removeTimes {
-			header.ModTime = time.Time{}
-			header.AccessTime = time.Time{}
-			header.ChangeTime = time.Time{}
+		if modTime != nil {
+			if header.ModTime.After(*modTime) {
+				header.ModTime = *modTime
+			}
+			header.AccessTime = header.ModTime
+			header.ChangeTime = header.ModTime
 		}
 
 		// Write file

--- a/content/file/utils_test.go
+++ b/content/file/utils_test.go
@@ -21,9 +21,11 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func Test_tarDirectory(t *testing.T) {
@@ -61,7 +63,7 @@ func Test_tarDirectory(t *testing.T) {
 			}
 		}()
 
-		err := tarDirectory(context.Background(), tmpdir, "prefix", gw, false, nil)
+		err := tarDirectory(context.Background(), tmpdir, "prefix", gw, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -86,7 +88,7 @@ func Test_tarDirectory(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err := tarDirectory(ctx, tmpdir, "prefix", gw, false, nil)
+		err := tarDirectory(ctx, tmpdir, "prefix", gw, nil, nil)
 		if err == nil {
 			t.Fatal("expected context cancellation error, got nil")
 		}
@@ -474,4 +476,118 @@ func createTar(t *testing.T, entries []tarEntry) []byte {
 		t.Fatalf("failed to close tar writer: %v", err)
 	}
 	return buf.Bytes()
+}
+
+func modTimeTestDir(t *testing.T, fileModTime time.Time) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("test content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, fileModTime, fileModTime); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// modTimeHeaders tars root and returns the headers of the resulting tarball.
+func modTimeHeaders(t *testing.T, root string, modTime *time.Time) []*tar.Header {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := tarDirectory(context.Background(), root, "prefix", &buf, modTime, nil); err != nil {
+		t.Fatalf("tarDirectory() error = %v", err)
+	}
+	var headers []*tar.Header
+	tr := tar.NewReader(&buf)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to read tar: %v", err)
+		}
+		headers = append(headers, header)
+	}
+	return headers
+}
+
+// modTimeFind returns the header with the given name.
+func modTimeFind(t *testing.T, headers []*tar.Header, name string) *tar.Header {
+	t.Helper()
+	for _, header := range headers {
+		if header.Name == name {
+			return header
+		}
+	}
+	t.Fatalf("header %q not found", name)
+	return nil
+}
+
+func Test_tarDirectory_modTime(t *testing.T) {
+	clamp := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	older := time.Date(2019, 6, 15, 12, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+	t.Run("nil modTime keeps the original time", func(t *testing.T) {
+		headers := modTimeHeaders(t, modTimeTestDir(t, newer), nil)
+		header := modTimeFind(t, headers, "prefix/file.txt")
+		if !header.ModTime.Equal(newer) {
+			t.Errorf("ModTime = %v, want %v", header.ModTime, newer)
+		}
+	})
+
+	t.Run("entry newer than modTime is clamped down", func(t *testing.T) {
+		headers := modTimeHeaders(t, modTimeTestDir(t, newer), &clamp)
+		for _, header := range headers {
+			if !header.ModTime.Equal(clamp) {
+				t.Errorf("%s: ModTime = %v, want %v", header.Name, header.ModTime, clamp)
+			}
+		}
+	})
+
+	t.Run("entry older than modTime is left unchanged", func(t *testing.T) {
+		headers := modTimeHeaders(t, modTimeTestDir(t, older), &clamp)
+		header := modTimeFind(t, headers, "prefix/file.txt")
+		if !header.ModTime.Equal(older) {
+			t.Errorf("ModTime = %v, want %v", header.ModTime, older)
+		}
+	})
+
+	// The zero time is how TarReproducible is expressed, and tar stores
+	// timestamps as seconds since the Unix epoch, so every entry is written
+	// out as 0.
+	t.Run("zero modTime clamps every entry to the epoch", func(t *testing.T) {
+		zero := time.Time{}
+		headers := modTimeHeaders(t, modTimeTestDir(t, newer), &zero)
+		if len(headers) == 0 {
+			t.Fatal("no headers produced")
+		}
+		for _, header := range headers {
+			if header.ModTime.Unix() != 0 {
+				t.Errorf("%s: ModTime = %v, want the Unix epoch", header.Name, header.ModTime)
+			}
+		}
+	})
+}
+
+// Test_tarDirectory_modTime_reproducible verifies that identical content whose
+// timestamps differ produces byte-identical tarballs once clamped.
+func Test_tarDirectory_modTime_reproducible(t *testing.T) {
+	clamp := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	dir1 := modTimeTestDir(t, time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC))
+	dir2 := modTimeTestDir(t, time.Date(2026, 9, 1, 8, 30, 0, 0, time.UTC))
+
+	tarDir := func(root string) []byte {
+		var buf bytes.Buffer
+		if err := tarDirectory(context.Background(), root, "prefix", &buf, &clamp, nil); err != nil {
+			t.Fatalf("tarDirectory() error = %v", err)
+		}
+		return buf.Bytes()
+	}
+
+	if !bytes.Equal(tarDir(dir1), tarDir(dir2)) {
+		t.Error("tarballs of identical content with different timestamps are not byte-identical")
+	}
 }


### PR DESCRIPTION
Fixes #1252

  ## Summary

  - Add `Store.TarModTime *time.Time` to clamp the timestamps of generated directory
    tarballs to a caller-supplied upper bound.
  - Apply `modTime = min(originalModTime, TarModTime)` per entry, so entries newer
    than the bound are rewritten while entries already older keep their real time.
    Access and change times follow the clamped value.
  - Keep `TarReproducible` working unchanged.
  - Thread the value through `tarDirectory`, replacing the `removeTimes` bool.

 ## question
 - `Packing the same directory twice with the same clamp time yields a
   byte-identical tarball digest, including across machines where file mtimes
   differ but are ≤ clamp.` -- since we are using min(originalModTime, clamp) how would different mtimes <= clamp would have byte-identical tarball digest , isn't it should be >= clamp?

  ## Testing
  - `An entry with mtime newer than the clamp is rewritten to the clamp; an
    entry older than the clamp keeps its original mtime.`  --done
 - `Existing TarReproducible behavior is unchanged when the new field is unset.` -- done
 - `make test` — 33 packages ok, 0 failures.

