### PR TITLE
refactor(remote)!: hoist shared config to Registry, add parent pointer to Repository

### DIFF
--- a/content/cache/target_test.go
+++ b/content/cache/target_test.go
@@ -322,7 +322,7 @@ func TestReferenceTarget_FetchReference(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create repository:", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	// create cache
 	cache := memory.New()
@@ -441,7 +441,7 @@ func TestNew_WithReferenceFetcher(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create repository:", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	// create cache
 	cache := memory.New()
@@ -571,7 +571,7 @@ func TestReferenceTarget_FetchReference_Error(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create repository:", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	cache := memory.New()
 	ctx := context.Background()
@@ -740,7 +740,7 @@ func TestReferenceTarget_FetchReference_CacheFetchFailsFallsBack(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create repository:", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	// Cache that always fails on Fetch — simulates a corrupt or unavailable cache.
 	// FetchReference should fall back to the source and succeed.

--- a/content_test.go
+++ b/content_test.go
@@ -154,7 +154,7 @@ func TestTag_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test with manifest tag
@@ -419,7 +419,7 @@ func TestTagN_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test TagN with empty dstReferences
@@ -707,7 +707,7 @@ func TestResolve_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test Resolve with TargetPlatform
@@ -1027,7 +1027,7 @@ func TestFetch_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test Fetch with empty option by valid manifest tag
@@ -1458,7 +1458,7 @@ func TestFetchBytes_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test FetchBytes with empty option by valid manifest tag
@@ -1768,7 +1768,7 @@ func TestPushBytes_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test PushBytes with blob
@@ -2003,7 +2003,7 @@ func TestTagBytesN_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test TagBytesN with no reference

--- a/example_copy_test.go
+++ b/example_copy_test.go
@@ -449,7 +449,7 @@ func Example_extendedCopyArtifactAndReferrersToRepository() {
 		panic(err)
 	}
 	// Note: The below code can be omitted if authentication is not required.
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: retry.DefaultClient,
 		Cache:  auth.NewCache(),
 		CredentialFunc: credentials.StaticCredentialFunc(registry, credentials.Credential{

--- a/example_test.go
+++ b/example_test.go
@@ -47,7 +47,7 @@ func Example_pullFilesFromRemoteRepository() {
 		panic(err)
 	}
 	// Note: The below code can be omitted if authentication is not required
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: retry.DefaultClient,
 		Cache:  auth.NewCache(),
 		CredentialFunc: credentials.StaticCredentialFunc(reg, credentials.Credential{
@@ -82,7 +82,7 @@ func Example_pullImageFromRemoteRepository() {
 		panic(err)
 	}
 	// Note: The below code can be omitted if authentication is not required
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: retry.DefaultClient,
 		Cache:  auth.NewCache(),
 		CredentialFunc: credentials.StaticCredentialFunc(reg, credentials.Credential{
@@ -124,10 +124,10 @@ func Example_pullImageUsingDockerCredentials() {
 	if err != nil {
 		panic(err)
 	}
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client:         retry.DefaultClient,
 		Cache:          auth.NewCache(),
-		CredentialFunc: remote.GetCredentialFunc(credStore), // Use the credentials store
+		CredentialFunc: remote.NewCredentialFunc(credStore), // Use the credentials store
 	}
 
 	// 2. Copy from the remote repository to the OCI layout store
@@ -187,7 +187,7 @@ func Example_pushFilesToRemoteRepository() {
 		panic(err)
 	}
 	// Note: The below code can be omitted if authentication is not required
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: retry.DefaultClient,
 		Cache:  auth.NewCache(),
 		CredentialFunc: credentials.StaticCredentialFunc(reg, credentials.Credential{
@@ -215,7 +215,7 @@ func Example_attachBlobToRemoteRepository() {
 		panic(err)
 	}
 	// Note: The below code can be omitted if authentication is not required.
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: retry.DefaultClient,
 		Cache:  auth.NewCache(),
 		CredentialFunc: credentials.StaticCredentialFunc(registry, credentials.Credential{

--- a/internal/registryutil/proxy_test.go
+++ b/internal/registryutil/proxy_test.go
@@ -82,7 +82,7 @@ func TestProxy_FetchReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	s := registryutil.NewProxy(repo, cas.NewMemory())
 	ctx := context.Background()

--- a/registry/remote/auth.go
+++ b/registry/remote/auth.go
@@ -68,10 +68,10 @@ func Logout(ctx context.Context, store credentials.Store, registryName string) e
 	return nil
 }
 
-// GetCredentialFunc returns a CredentialFunc that retrieves credentials from
+// NewCredentialFunc returns a CredentialFunc that retrieves credentials from
 // the given store. If store is nil, the returned function always returns
 // EmptyCredential without error.
-func GetCredentialFunc(store credentials.Store) credentials.CredentialFunc {
+func NewCredentialFunc(store credentials.Store) credentials.CredentialFunc {
 	if store == nil {
 		return func(context.Context, string) (credentials.Credential, error) {
 			return credentials.EmptyCredential, nil

--- a/registry/remote/auth_test.go
+++ b/registry/remote/auth_test.go
@@ -205,14 +205,14 @@ func Test_mapHostname(t *testing.T) {
 	}
 }
 
-func TestGetCredentialFunc_NilStore(t *testing.T) {
-	fn := GetCredentialFunc(nil)
+func TestNewCredentialFunc_NilStore(t *testing.T) {
+	fn := NewCredentialFunc(nil)
 	got, err := fn(context.Background(), "localhost:5000")
 	if err != nil {
-		t.Fatalf("GetCredentialFunc(nil) returned error: %v", err)
+		t.Fatalf("NewCredentialFunc(nil) returned error: %v", err)
 	}
 	if got != credentials.EmptyCredential {
-		t.Errorf("GetCredentialFunc(nil) = %v, want EmptyCredential", got)
+		t.Errorf("NewCredentialFunc(nil) = %v, want EmptyCredential", got)
 	}
 }
 
@@ -223,9 +223,9 @@ func TestCredential(t *testing.T) {
 		"localhost:2333":              {Username: "test_user", Password: "test_word"},
 		"https://index.docker.io/v1/": {Username: "user", Password: "word"},
 	}
-	// create a test client using GetCredentialFunc
+	// create a test client using NewCredentialFunc
 	testClient := &auth.Client{}
-	testClient.CredentialFunc = GetCredentialFunc(s)
+	testClient.CredentialFunc = NewCredentialFunc(s)
 	tests := []struct {
 		name           string
 		registry       string
@@ -259,7 +259,7 @@ func TestCredential(t *testing.T) {
 				t.Errorf("could not get credential: %v", err)
 			}
 			if !reflect.DeepEqual(got, tt.wantCredential) {
-				t.Errorf("GetCredentialFunc() = %v, want %v", got, tt.wantCredential)
+				t.Errorf("NewCredentialFunc() = %v, want %v", got, tt.wantCredential)
 			}
 		})
 	}

--- a/registry/remote/credentials/example_test.go
+++ b/registry/remote/credentials/example_test.go
@@ -230,7 +230,7 @@ func ExampleCredential() {
 	}
 
 	client := auth.DefaultClient
-	client.CredentialFunc = remote.GetCredentialFunc(store)
+	client.CredentialFunc = remote.NewCredentialFunc(store)
 
 	request, err := http.NewRequest(http.MethodGet, "localhost:5000", nil)
 	if err != nil {

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -774,9 +774,9 @@ func Example_handleWarning() {
 	if err != nil {
 		panic(err)
 	}
-	// 1. specify HandleWarning
-	repo.HandleWarning = func(warning remote.Warning) {
-		fmt.Printf("Warning from %s: %s\n", repo.Reference.Repository, warning.Text)
+	// 1. specify HandleWarning on the Registry
+	repo.Registry.HandleWarning = func(warning remote.Warning) {
+		fmt.Printf("Warning from %s: %s\n", repo.RepositoryName, warning.Text)
 	}
 
 	ctx := context.Background()

--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -29,20 +29,6 @@ import (
 // for pinging Referrers API.
 const zeroDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
-// referrersState represents the state of Referrers API.
-type referrersState = int32
-
-const (
-	// referrersStateUnknown represents an unknown state of Referrers API.
-	referrersStateUnknown referrersState = iota
-	// referrersStateSupported represents that the repository is known to
-	// support Referrers API.
-	referrersStateSupported
-	// referrersStateUnsupported represents that the repository is known to
-	// not support Referrers API.
-	referrersStateUnsupported
-)
-
 // referrerOperation represents an operation on a referrer.
 type referrerOperation = int32
 
@@ -60,8 +46,9 @@ type referrerChange struct {
 }
 
 var (
-	// ErrReferrersCapabilityAlreadySet is returned by SetReferrersCapability()
-	// when the Referrers API capability has been already set.
+	// ErrReferrersCapabilityAlreadySet is reserved to signal that the referrers
+	// capability of a repository has already been set to a conflicting value.
+	// The capability is fixed once set; the first value wins.
 	ErrReferrersCapabilityAlreadySet = errors.New("referrers capability cannot be changed once set")
 
 	// errNoReferrerUpdate is returned by applyReferrerChanges() when there

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -28,17 +28,40 @@ import (
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/auth"
 	"github.com/oras-project/oras-go/v3/registry/remote/internal/errutil"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 )
-
-// RepositoryOptions is an alias of Repository to avoid name conflicts.
-// It also hides all methods associated with Repository.
-type RepositoryOptions Repository
 
 // Registry is an HTTP client to a remote registry.
 type Registry struct {
-	// RepositoryOptions contains common options for Registry and Repository.
-	// It is also used as a template for derived repositories.
-	RepositoryOptions
+	// Client is the underlying HTTP client used to access the remote registry.
+	// If nil, auth.DefaultClient is used.
+	Client Client
+
+	// Reference contains registry host information.
+	Reference registry.Reference
+
+	// PlainHTTP signals the transport to access the registry via HTTP
+	// instead of HTTPS.
+	PlainHTTP bool
+
+	// HandleWarning handles the warning returned by the remote server.
+	// Callers SHOULD deduplicate warnings from multiple associated responses.
+	//
+	// References:
+	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#warnings
+	//   - https://www.rfc-editor.org/rfc/rfc7234#section-5.5
+	HandleWarning func(warning Warning)
+
+	// Policy is an optional policy evaluator for allow/deny decisions.
+	// If nil, no policy enforcement is performed.
+	// Reference: https://man.archlinux.org/man/containers-policy.json.5.en
+	Policy *policy.Evaluator
+
+	// MaxMetadataBytes specifies a limit on how many response bytes are allowed
+	// in the server's response to the metadata APIs, such as catalog list, tag
+	// list, and referrers list.
+	// If less than or equal to zero, a default (currently 4MiB) is used.
+	MaxMetadataBytes int64
 
 	// RepositoryListPageSize specifies the page size when invoking the catalog
 	// API.
@@ -46,11 +69,36 @@ type Registry struct {
 	// Reference: https://distribution.github.io/distribution/spec/api/#catalog
 	RepositoryListPageSize int
 
-	// RepositoryListMaxPages limits the total number of pages fetched during
-	// repository listing, bounding server-driven pagination so a malicious or
-	// misbehaving registry cannot force unbounded requests.
-	// If zero, repository listing is unlimited.
+	// ManifestMediaTypes is the default for repositories.
+	// Used in `Accept` header for resolving manifests from references.
+	// It is also used in identifying manifests and blobs from descriptors.
+	// If an empty list is present, default manifest media types are used.
+	ManifestMediaTypes []string
+
+	// TagListPageSize is the default for repositories.
+	// If zero, the page size is determined by the remote registry.
+	TagListPageSize int
+
+	// ReferrerListPageSize is the default for repositories.
+	// If zero, the page size is determined by the remote registry.
+	ReferrerListPageSize int
+
+	// RepositoryListMaxPages is the maximum number of pages to fetch during
+	// catalog listing. Zero means unlimited.
 	RepositoryListMaxPages int
+
+	// TagListMaxPages is the default maximum number of pages to fetch during
+	// tag listing. Zero means unlimited.
+	TagListMaxPages int
+
+	// ReferrerListMaxPages is the default maximum number of pages to fetch
+	// during referrer listing. Zero means unlimited.
+	ReferrerListMaxPages int
+
+	// SkipReferrersGC is the default for repositories.
+	// If false, the old referrers index will be deleted after the new one
+	// is successfully uploaded.
+	SkipReferrersGC bool
 }
 
 // NewRegistry creates a client to the remote registry with the specified domain
@@ -64,19 +112,22 @@ func NewRegistry(name string) (*Registry, error) {
 		return nil, err
 	}
 	return &Registry{
-		RepositoryOptions: RepositoryOptions{
-			Reference: ref,
-		},
+		Reference: ref,
 	}, nil
 }
 
 // client returns an HTTP client used to access the remote registry.
-// A default HTTP client is return if the client is not configured.
+// A default HTTP client is returned if the client is not configured.
 func (r *Registry) client() Client {
 	if r.Client == nil {
 		return auth.DefaultClient
 	}
 	return r.Client
+}
+
+// maxMetadataBytes returns the maximum metadata bytes limit.
+func (r *Registry) maxMetadataBytes() int64 {
+	return r.MaxMetadataBytes
 }
 
 // do sends an HTTP request and returns an HTTP response using the HTTP client
@@ -136,9 +187,10 @@ func (r *Registry) Repositories(ctx context.Context, last string, fn func(repos 
 	ctx = auth.AppendScopesForHost(ctx, r.Reference.Host(), auth.ScopeRegistryCatalog)
 	url := buildRegistryCatalogURL(r.PlainHTTP, r.Reference)
 	var err error
+	maxPages := r.RepositoryListMaxPages
 	for page := 0; err == nil; page++ {
-		if r.RepositoryListMaxPages > 0 && page >= r.RepositoryListMaxPages {
-			return fmt.Errorf("repository listing exceeded %d pages: %w", r.RepositoryListMaxPages, errdef.ErrTooManyPages)
+		if maxPages > 0 && page >= maxPages {
+			return fmt.Errorf("repository listing exceeded %d pages: %w", maxPages, errdef.ErrTooManyPages)
 		}
 		url, err = r.repositories(ctx, last, fn, url)
 		// clear `last` for subsequent pages
@@ -178,7 +230,7 @@ func (r *Registry) repositories(ctx context.Context, last string, fn func(repos 
 	var page struct {
 		Repositories []string `json:"repositories"`
 	}
-	lr := limitReader(resp.Body, r.MaxMetadataBytes)
+	lr := limitReader(resp.Body, r.maxMetadataBytes())
 	if err := json.NewDecoder(lr).Decode(&page); err != nil {
 		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
 	}
@@ -191,9 +243,20 @@ func (r *Registry) repositories(ctx context.Context, last string, fn func(repos 
 
 // Repository returns a repository reference by the given name.
 func (r *Registry) Repository(ctx context.Context, name string) (registry.Repository, error) {
+	return r.newRepository(name)
+}
+
+// newRepository creates a new Repository with the given name.
+func (r *Registry) newRepository(name string) (*Repository, error) {
 	ref := registry.Reference{
 		Registry:   r.Reference.Registry,
 		Repository: name,
 	}
-	return newRepositoryWithOptions(ref, &r.RepositoryOptions)
+	if err := ref.ValidateRepository(); err != nil {
+		return nil, err
+	}
+	return &Repository{
+		Registry:       r,
+		RepositoryName: name,
+	}, nil
 }

--- a/registry/remote/registry_test.go
+++ b/registry/remote/registry_test.go
@@ -31,15 +31,7 @@ import (
 	"testing"
 
 	"github.com/oras-project/oras-go/v3/errdef"
-	"github.com/oras-project/oras-go/v3/registry"
 )
-
-func TestRegistryInterface(t *testing.T) {
-	var reg any = &Registry{}
-	if _, ok := reg.(registry.Registry); !ok {
-		t.Error("&Registry{} does not conform registry.Registry")
-	}
-}
 
 func TestRegistry_TLS(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -282,10 +274,12 @@ func TestRegistry_Repository(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Registry.Repository() error = %v", err)
 	}
-	reg.Reference.Repository = "hello-world"
-	want := (*Repository)(&reg.RepositoryOptions)
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Registry.Repository() = %v, want %v", got, want)
+	repo := got.(*Repository)
+	if repo.RepositoryName != "hello-world" {
+		t.Errorf("Repository.RepositoryName = %v, want %v", repo.RepositoryName, "hello-world")
+	}
+	if repo.Registry != reg {
+		t.Errorf("Repository.Registry = %v, want %v", repo.Registry, reg)
 	}
 }
 

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -44,8 +44,9 @@ import (
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/auth"
 	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
-	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 	"github.com/oras-project/oras-go/v3/registry/remote/internal/errutil"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 const (
@@ -95,30 +96,27 @@ type Client interface {
 
 // Repository is an HTTP client to a remote repository.
 type Repository struct {
-	// Client is the underlying HTTP client used to access the remote registry.
-	// If nil, auth.DefaultClient is used.
-	Client Client
+	// Registry is the parent registry. Must not be nil.
+	// Registry holds shared configuration like Client, PlainHTTP, Policy, etc.
+	Registry *Registry
 
-	// Reference references the remote repository.
-	Reference registry.Reference
+	// RepositoryName is the name within the registry (e.g., "library/alpine").
+	RepositoryName string
 
-	// PlainHTTP signals the transport to access the remote repository via HTTP
-	// instead of HTTPS.
-	PlainHTTP bool
-
-	// ManifestMediaTypes is used in `Accept` header for resolving manifests
-	// from references. It is also used in identifying manifests and blobs from
-	// descriptors. If an empty list is present, default manifest media types
-	// are used.
+	// ManifestMediaTypes overrides Registry default if set.
+	// Used in `Accept` header for resolving manifests from references.
+	// It is also used in identifying manifests and blobs from descriptors.
+	// If an empty list is present, default manifest media types are used.
 	ManifestMediaTypes []string
 
-	// TagListPageSize specifies the page size when invoking the tag list API.
+	// TagListPageSize overrides Registry default if set.
+	// Specifies the page size when invoking the tag list API.
 	// If zero, the page size is determined by the remote registry.
 	// Reference: https://distribution.github.io/distribution/spec/api/#tags
 	TagListPageSize int
 
-	// ReferrerListPageSize specifies the page size when invoking the Referrers
-	// API.
+	// ReferrerListPageSize overrides Registry default if set.
+	// Specifies the page size when invoking the Referrers API.
 	// If zero, the page size is determined by the remote registry.
 	//
 	// NOTE: Pagination for the Referrers API is not defined in the distribution
@@ -128,25 +126,20 @@ type Repository struct {
 	// Reference: https://github.com/oras-project/oras-go/issues/841
 	ReferrerListPageSize int
 
-	// TagListMaxPages limits the total number of pages fetched during tag
-	// listing, bounding server-driven pagination so a malicious or misbehaving
-	// registry cannot force unbounded requests.
-	// If zero, tag listing is unlimited.
+	// TagListMaxPages overrides Registry default if > 0.
+	// Limits the total number of pages fetched during tag listing.
+	// If 0, Registry.TagListMaxPages is used. If that is also 0, there is no
+	// limit.
 	TagListMaxPages int
 
-	// ReferrerListMaxPages limits the total number of pages fetched during
-	// referrer listing, bounding server-driven pagination so a malicious or
-	// misbehaving registry cannot force unbounded requests.
-	// If zero, referrer listing is unlimited.
+	// ReferrerListMaxPages overrides Registry default if > 0.
+	// Limits the total number of pages fetched during referrer listing.
+	// Zero means to use Registry.ReferrerListMaxPages. Referrer listing is
+	// unlimited only if the effective Registry/default value is also zero.
 	ReferrerListMaxPages int
 
-	// MaxMetadataBytes specifies a limit on how many response bytes are allowed
-	// in the server's response to the metadata APIs, such as catalog list, tag
-	// list, and referrers list.
-	// If less than or equal to zero, a default (currently 4MiB) is used.
-	MaxMetadataBytes int64
-
-	// SkipReferrersGC specifies whether to delete the dangling referrers
+	// SkipReferrersGC overrides Registry default if set.
+	// Specifies whether to delete the dangling referrers
 	// index when referrers tag schema is utilized.
 	//  - If false, the old referrers index will be deleted after the new one
 	//    is successfully uploaded.
@@ -157,28 +150,13 @@ type Repository struct {
 	//  - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-manifests
 	SkipReferrersGC bool
 
-	// HandleWarning handles the warning returned by the remote server.
-	// Callers SHOULD deduplicate warnings from multiple associated responses.
-	//
-	// References:
-	//   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#warnings
-	//   - https://www.rfc-editor.org/rfc/rfc7234#section-5.5
-	HandleWarning func(warning Warning)
-
-	// Policy is an optional policy evaluator for allow/deny decisions.
-	// If nil, no policy enforcement is performed.
-	// Policies can be loaded from a file via [policy.Load] or constructed
-	// programmatically via [policy.NewPolicy]. The default file-based loading
-	// ([policy.LoadDefault]) uses platform-specific paths; see the policy
-	// package documentation for cross-platform details.
-	// Reference: https://man.archlinux.org/man/containers-policy.json.5.en
-	Policy *policy.Evaluator
-
 	// NOTE: Must keep fields in sync with clone().
 
-	// referrersState represents that if the repository supports Referrers API.
-	// default: referrersStateUnknown
-	referrersState referrersState
+	// referrersState indicates whether the repository supports the Referrers
+	// API. It stores a properties.ReferrersAPI value.
+	// default: properties.ReferrersAPIUnknown
+	// Must be accessed atomically.
+	referrersState int32
 
 	// referrersPingLock locks the pingReferrers() method and allows only
 	// one go-routine to send the request.
@@ -190,100 +168,203 @@ type Repository struct {
 }
 
 // NewRepository creates a client to the remote repository identified by a
-// reference.
+// reference. A default Registry is created internally.
 // Example: localhost:5000/hello-world
 func NewRepository(reference string) (*Repository, error) {
 	ref, err := registry.ParseReference(reference)
 	if err != nil {
 		return nil, err
 	}
+
+	// Create a default Registry
+	reg := &Registry{
+		Reference: registry.Reference{
+			Registry: ref.Registry,
+		},
+	}
+
 	return &Repository{
-		Reference: ref,
+		Registry:       reg,
+		RepositoryName: ref.Repository,
 	}, nil
 }
 
-// newRepositoryWithOptions returns a Repository with the given Reference and
-// RepositoryOptions.
-//
-// RepositoryOptions are part of the Registry struct and set its defaults.
-// RepositoryOptions shares the same struct definition as Repository, which
-// contains unexported state that must not be copied to multiple Repositories.
-// To handle this we explicitly copy only the fields that we want to reproduce.
-func newRepositoryWithOptions(ref registry.Reference, opts *RepositoryOptions) (*Repository, error) {
-	if err := ref.ValidateRepository(); err != nil {
-		return nil, err
+// Reference returns the full registry.Reference for this repository.
+func (r *Repository) Reference() registry.Reference {
+	ref := registry.Reference{Repository: r.RepositoryName}
+	if r.Registry != nil {
+		ref.Registry = r.Registry.Reference.Registry
 	}
-	repo := (*Repository)(opts).clone()
-	repo.Reference = ref
-	return repo, nil
+	return ref
 }
 
 // clone makes a copy of the Repository being careful not to copy non-copyable fields (sync.Mutex and syncutil.Pool types)
 func (r *Repository) clone() *Repository {
 	return &Repository{
-		Client:               r.Client,
-		Reference:            r.Reference,
-		PlainHTTP:            r.PlainHTTP,
+		Registry:             r.Registry,
+		RepositoryName:       r.RepositoryName,
 		ManifestMediaTypes:   slices.Clone(r.ManifestMediaTypes),
 		TagListPageSize:      r.TagListPageSize,
 		ReferrerListPageSize: r.ReferrerListPageSize,
 		TagListMaxPages:      r.TagListMaxPages,
 		ReferrerListMaxPages: r.ReferrerListMaxPages,
-		MaxMetadataBytes:     r.MaxMetadataBytes,
 		SkipReferrersGC:      r.SkipReferrersGC,
-		HandleWarning:        r.HandleWarning,
-		Policy:               r.Policy,
 	}
+}
+
+// client returns an HTTP client used to access the remote repository.
+// A default HTTP client is returned if the client is not configured.
+func (r *Repository) client() Client {
+	if r.Registry == nil || r.Registry.Client == nil {
+		return auth.DefaultClient
+	}
+	return r.Registry.Client
+}
+
+// plainHTTP returns whether plain HTTP should be used.
+func (r *Repository) plainHTTP() bool {
+	if r.Registry == nil {
+		return false
+	}
+	return r.Registry.PlainHTTP
+}
+
+// maxMetadataBytes returns the maximum metadata bytes limit.
+func (r *Repository) maxMetadataBytes() int64 {
+	if r.Registry == nil {
+		return 0
+	}
+	return r.Registry.MaxMetadataBytes
+}
+
+// handleWarning returns the warning handler function.
+func (r *Repository) handleWarning() func(warning Warning) {
+	if r.Registry == nil {
+		return nil
+	}
+	return r.Registry.HandleWarning
+}
+
+// policy returns the policy evaluator.
+func (r *Repository) policy() *policy.Evaluator {
+	if r.Registry == nil {
+		return nil
+	}
+	return r.Registry.Policy
+}
+
+// tagListPageSize returns the effective tag list page size.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) tagListPageSize() int {
+	if r.TagListPageSize > 0 {
+		return r.TagListPageSize
+	}
+	if r.Registry != nil {
+		return r.Registry.TagListPageSize
+	}
+	return 0
+}
+
+// referrerListPageSize returns the effective referrer list page size.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) referrerListPageSize() int {
+	if r.ReferrerListPageSize > 0 {
+		return r.ReferrerListPageSize
+	}
+	if r.Registry != nil {
+		return r.Registry.ReferrerListPageSize
+	}
+	return 0
+}
+
+// tagListMaxPages returns the effective maximum number of tag list pages.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) tagListMaxPages() int {
+	if r.TagListMaxPages > 0 {
+		return r.TagListMaxPages
+	}
+	if r.Registry != nil {
+		return r.Registry.TagListMaxPages
+	}
+	return 0
+}
+
+// referrerListMaxPages returns the effective maximum number of referrer list pages.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) referrerListMaxPages() int {
+	if r.ReferrerListMaxPages > 0 {
+		return r.ReferrerListMaxPages
+	}
+	if r.Registry != nil {
+		return r.Registry.ReferrerListMaxPages
+	}
+	return 0
+}
+
+// manifestMediaTypes returns the effective manifest media types.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) manifestMediaTypes() []string {
+	if len(r.ManifestMediaTypes) > 0 {
+		return r.ManifestMediaTypes
+	}
+	if r.Registry != nil {
+		return r.Registry.ManifestMediaTypes
+	}
+	return nil
+}
+
+// skipReferrersGC returns the effective skip referrers GC setting.
+// Repository-level setting takes precedence over Registry default.
+func (r *Repository) skipReferrersGC() bool {
+	if r.SkipReferrersGC {
+		return true
+	}
+	if r.Registry != nil {
+		return r.Registry.SkipReferrersGC
+	}
+	return false
 }
 
 // SetReferrersCapability indicates the Referrers API capability of the remote
 // repository. true: capable; false: not capable.
 //
-// SetReferrersCapability is valid only when it is called for the first time.
-// SetReferrersCapability returns ErrReferrersCapabilityAlreadySet if the
-// Referrers API capability has been already set.
+// SetReferrersCapability has no effect if the capability has already been set
+// to the same value. If the capability has been set to a conflicting value it
+// is silently ignored; the first value set wins.
 //   - When the capability is set to true, the Referrers() function will always
 //     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - When the capability is set to false, the Referrers() function will always
 //     request the Referrers Tag. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#referrers-tag-schema
 //   - When the capability is not set, the Referrers() function will automatically
 //     determine which API to use.
-func (r *Repository) SetReferrersCapability(capable bool) error {
-	var state referrersState
+func (r *Repository) SetReferrersCapability(capable bool) {
+	state := properties.ReferrersAPIUnsupported
 	if capable {
-		state = referrersStateSupported
-	} else {
-		state = referrersStateUnsupported
+		state = properties.ReferrersAPISupported
 	}
-	if swapped := atomic.CompareAndSwapInt32(&r.referrersState, referrersStateUnknown, state); !swapped {
-		if fact := r.loadReferrersState(); fact != state {
-			return fmt.Errorf("%w: current capability = %v, new capability = %v",
-				ErrReferrersCapabilityAlreadySet,
-				fact == referrersStateSupported,
-				capable)
-		}
-	}
-	return nil
+	// first value set wins; a conflicting later set is silently ignored.
+	atomic.CompareAndSwapInt32(&r.referrersState, int32(properties.ReferrersAPIUnknown), int32(state))
 }
 
-// setReferrersState atomically loads r.referrersState.
-func (r *Repository) loadReferrersState() referrersState {
-	return atomic.LoadInt32(&r.referrersState)
+// ReferrersCapability reports the repository's current Referrers API
+// capability. The value is either what was configured via
+// SetReferrersCapability / registry properties, or the result of
+// auto-detection performed during a Referrers call. It returns
+// properties.ReferrersAPIUnknown when the capability has not been determined.
+func (r *Repository) ReferrersCapability() properties.ReferrersAPI {
+	return r.loadReferrersState()
 }
 
-// client returns an HTTP client used to access the remote repository.
-// A default HTTP client is return if the client is not configured.
-func (r *Repository) client() Client {
-	if r.Client == nil {
-		return auth.DefaultClient
-	}
-	return r.Client
+// loadReferrersState atomically loads r.referrersState.
+func (r *Repository) loadReferrersState() properties.ReferrersAPI {
+	return properties.ReferrersAPI(atomic.LoadInt32(&r.referrersState))
 }
 
 // do sends an HTTP request and returns an HTTP response using the HTTP client
 // returned by r.client().
 func (r *Repository) do(req *http.Request) (*http.Response, error) {
-	if r.HandleWarning == nil {
+	handler := r.handleWarning()
+	if handler == nil {
 		return r.client().Do(req)
 	}
 
@@ -291,13 +372,13 @@ func (r *Repository) do(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	handleWarningHeaders(resp.Header.Values(headerWarning), r.HandleWarning)
+	handleWarningHeaders(resp.Header.Values(headerWarning), handler)
 	return resp, nil
 }
 
 // blobStore detects the blob store for the given descriptor.
 func (r *Repository) blobStore(desc ocispec.Descriptor) registry.BlobStore {
-	if isManifest(r.ManifestMediaTypes, desc) {
+	if isManifest(r.manifestMediaTypes(), desc) {
 		return r.Manifests()
 	}
 	return r.Blobs()
@@ -328,22 +409,25 @@ func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 	if ctx.Value(policyCheckedKey{}) != nil {
 		return nil
 	}
-	if r.Policy == nil {
+
+	pol := r.policy()
+	if pol == nil {
 		return nil
 	}
 
-	ref := r.Reference.String()
+	repoRef := r.Reference()
+	ref := repoRef.String()
 	if reference != "" {
 		ref = reference
 	}
 
 	imageRef := policy.ImageReference{
 		Transport: policy.TransportNameDocker,
-		Scope:     r.Reference.Registry + "/" + r.Reference.Repository,
+		Scope:     repoRef.Registry + "/" + repoRef.Repository,
 		Reference: ref,
 	}
 
-	allowed, err := r.Policy.IsImageAllowed(ctx, imageRef)
+	allowed, err := pol.IsImageAllowed(ctx, imageRef)
 	if err != nil {
 		return fmt.Errorf("policy check failed: %w", err)
 	}
@@ -358,7 +442,8 @@ func (r *Repository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.R
 	if err := r.checkPolicy(ctx, ""); err != nil {
 		return nil, err
 	}
-	return r.blobStore(target).Fetch(withPolicyChecked(ctx), target)
+	ctx = withPolicyChecked(ctx)
+	return r.blobStore(target).Fetch(ctx, target)
 }
 
 // Push pushes the content, matching the expected descriptor.
@@ -382,7 +467,11 @@ func (r *Repository) Mount(ctx context.Context, desc ocispec.Descriptor, fromRep
 	if err := r.checkPolicy(ctx, ""); err != nil {
 		return err
 	}
-	return r.Blobs().(registry.Mounter).Mount(withPolicyChecked(ctx), desc, fromRepo, getContent)
+	mounter, ok := r.Blobs().(registry.Mounter)
+	if !ok {
+		return errors.New("blob store does not support mounting")
+	}
+	return mounter.Mount(withPolicyChecked(ctx), desc, fromRepo, getContent)
 }
 
 // Exists returns true if the described content exists.
@@ -390,7 +479,8 @@ func (r *Repository) Exists(ctx context.Context, target ocispec.Descriptor) (boo
 	if err := r.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	return r.blobStore(target).Exists(withPolicyChecked(ctx), target)
+	ctx = withPolicyChecked(ctx)
+	return r.blobStore(target).Exists(ctx, target)
 }
 
 // Delete removes the content identified by the descriptor.
@@ -418,7 +508,8 @@ func (r *Repository) Resolve(ctx context.Context, reference string) (ocispec.Des
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	return r.Manifests().Resolve(withPolicyChecked(ctx), reference)
+	ctx = withPolicyChecked(ctx)
+	return r.Manifests().Resolve(ctx, reference)
 }
 
 // Tag tags a manifest descriptor with a reference string.
@@ -443,11 +534,12 @@ func (r *Repository) FetchReference(ctx context.Context, reference string) (ocis
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	return r.Manifests().FetchReference(withPolicyChecked(ctx), reference)
+	ctx = withPolicyChecked(ctx)
+	return r.Manifests().FetchReference(ctx, reference)
 }
 
 // ParseReference resolves a tag or a digest reference to a fully qualified
-// reference from a base reference r.Reference.
+// reference from a base reference r.Reference().
 // Tag, digest, or fully qualified references are accepted as input.
 //
 // If reference is a fully qualified reference, then ParseReference parses it
@@ -455,11 +547,12 @@ func (r *Repository) FetchReference(ctx context.Context, reference string) (ocis
 // the same base reference with the Repository r, ParseReference returns a
 // wrapped error ErrInvalidReference.
 func (r *Repository) ParseReference(reference string) (registry.Reference, error) {
+	repoRef := r.Reference()
 	ref, err := registry.ParseReference(reference)
 	if err != nil {
 		ref = registry.Reference{
-			Registry:   r.Reference.Registry,
-			Repository: r.Reference.Repository,
+			Registry:   repoRef.Registry,
+			Repository: repoRef.Repository,
 			Reference:  reference,
 		}
 
@@ -475,10 +568,10 @@ func (r *Repository) ParseReference(reference string) (registry.Reference, error
 		if err != nil {
 			return registry.Reference{}, err
 		}
-	} else if ref.Registry != r.Reference.Registry || ref.Repository != r.Reference.Repository {
+	} else if ref.Registry != repoRef.Registry || ref.Repository != repoRef.Repository {
 		return registry.Reference{}, fmt.Errorf(
 			"%w: mismatch between received %q and expected %q",
-			errdef.ErrInvalidReference, ref, r.Reference,
+			errdef.ErrInvalidReference, ref, repoRef,
 		)
 	}
 
@@ -502,12 +595,14 @@ func (r *Repository) Tags(ctx context.Context, last string, fn func(tags []strin
 	if err := r.checkPolicy(ctx, ""); err != nil {
 		return err
 	}
-	ctx = auth.AppendRepositoryScope(ctx, r.Reference, auth.ActionPull)
-	url := buildRepositoryTagListURL(r.PlainHTTP, r.Reference)
+	repoRef := r.Reference()
+	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull)
+	url := buildRepositoryTagListURL(r.plainHTTP(), repoRef)
 	var err error
+	maxPages := r.tagListMaxPages()
 	for page := 0; err == nil; page++ {
-		if r.TagListMaxPages > 0 && page >= r.TagListMaxPages {
-			return fmt.Errorf("tag listing exceeded %d pages: %w", r.TagListMaxPages, errdef.ErrTooManyPages)
+		if maxPages > 0 && page >= maxPages {
+			return fmt.Errorf("tag listing exceeded %d pages: %w", maxPages, errdef.ErrTooManyPages)
 		}
 		url, err = r.tags(ctx, last, fn, url)
 		// clear `last` for subsequent pages
@@ -525,10 +620,11 @@ func (r *Repository) tags(ctx context.Context, last string, fn func(tags []strin
 	if err != nil {
 		return "", err
 	}
-	if r.TagListPageSize > 0 || last != "" {
+	pageSize := r.tagListPageSize()
+	if pageSize > 0 || last != "" {
 		q := req.URL.Query()
-		if r.TagListPageSize > 0 {
-			q.Set("n", strconv.Itoa(r.TagListPageSize))
+		if pageSize > 0 {
+			q.Set("n", strconv.Itoa(pageSize))
 		}
 		if last != "" {
 			q.Set("last", last)
@@ -547,7 +643,7 @@ func (r *Repository) tags(ctx context.Context, last string, fn func(tags []strin
 	var page struct {
 		Tags []string `json:"tags"`
 	}
-	lr := limitReader(resp.Body, r.MaxMetadataBytes)
+	lr := limitReader(resp.Body, r.maxMetadataBytes())
 	if err := json.NewDecoder(lr).Decode(&page); err != nil {
 		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
 	}
@@ -566,6 +662,7 @@ func (r *Repository) Predecessors(ctx context.Context, desc ocispec.Descriptor) 
 	if err := r.checkPolicy(ctx, ""); err != nil {
 		return nil, err
 	}
+	ctx = withPolicyChecked(ctx)
 	var res []ocispec.Descriptor
 	if err := r.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
 		res = append(res, referrers...)
@@ -589,14 +686,14 @@ func (r *Repository) Referrers(ctx context.Context, desc ocispec.Descriptor, art
 		return err
 	}
 	state := r.loadReferrersState()
-	if state == referrersStateUnsupported {
+	if state == properties.ReferrersAPIUnsupported {
 		// The repository is known to not support Referrers API, fallback to
 		// referrers tag schema.
 		return r.referrersByTagSchema(ctx, desc, artifactType, fn)
 	}
 
 	err := r.referrersByAPI(ctx, desc, artifactType, fn)
-	if state == referrersStateSupported {
+	if state == properties.ReferrersAPISupported {
 		// The repository is known to support Referrers API, no fallback.
 		return err
 	}
@@ -620,15 +717,17 @@ func (r *Repository) Referrers(ctx context.Context, desc ocispec.Descriptor, art
 // fn is called for the referrers result. If artifactType is not empty,
 // only referrers of the same artifact type are fed to fn.
 func (r *Repository) referrersByAPI(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
-	ref := r.Reference
+	repoRef := r.Reference()
+	ref := repoRef
 	ref.Reference = desc.Digest.String()
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
 
-	url := buildReferrersURL(r.PlainHTTP, ref, artifactType)
+	url := buildReferrersURL(r.plainHTTP(), ref, artifactType)
 	var err error
+	maxPages := r.referrerListMaxPages()
 	for page := 0; err == nil; page++ {
-		if r.ReferrerListMaxPages > 0 && page >= r.ReferrerListMaxPages {
-			return fmt.Errorf("referrer listing exceeded %d pages: %w", r.ReferrerListMaxPages, errdef.ErrTooManyPages)
+		if maxPages > 0 && page >= maxPages {
+			return fmt.Errorf("referrer listing exceeded %d pages: %w", maxPages, errdef.ErrTooManyPages)
 		}
 		url, err = r.referrersPageByAPI(ctx, artifactType, fn, url)
 	}
@@ -649,9 +748,10 @@ func (r *Repository) referrersPageByAPI(ctx context.Context, artifactType string
 	if err != nil {
 		return "", err
 	}
-	if r.ReferrerListPageSize > 0 {
+	pageSize := r.referrerListPageSize()
+	if pageSize > 0 {
 		q := req.URL.Query()
-		q.Set("n", strconv.Itoa(r.ReferrerListPageSize))
+		q.Set("n", strconv.Itoa(pageSize))
 		req.URL.RawQuery = q.Encode()
 	}
 
@@ -680,7 +780,7 @@ func (r *Repository) referrersPageByAPI(ctx context.Context, artifactType string
 	}
 
 	var index ocispec.Index
-	lr := limitReader(resp.Body, r.MaxMetadataBytes)
+	lr := limitReader(resp.Body, r.maxMetadataBytes())
 	if err := json.NewDecoder(lr).Decode(&index); err != nil {
 		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
 	}
@@ -742,7 +842,7 @@ func (r *Repository) referrersFromIndex(ctx context.Context, referrersTag string
 	}
 	defer rc.Close()
 
-	if err := limitSize(desc, r.MaxMetadataBytes); err != nil {
+	if err := limitSize(desc, r.maxMetadataBytes()); err != nil {
 		return ocispec.Descriptor{}, nil, fmt.Errorf("failed to read referrers index from referrers tag %s: %w", referrersTag, err)
 	}
 	var index ocispec.Index
@@ -756,9 +856,9 @@ func (r *Repository) referrersFromIndex(ctx context.Context, referrersTag string
 // pingReferrers returns true if the Referrers API is available for r.
 func (r *Repository) pingReferrers(ctx context.Context) (bool, error) {
 	switch r.loadReferrersState() {
-	case referrersStateSupported:
+	case properties.ReferrersAPISupported:
 		return true, nil
-	case referrersStateUnsupported:
+	case properties.ReferrersAPIUnsupported:
 		return false, nil
 	}
 
@@ -768,17 +868,18 @@ func (r *Repository) pingReferrers(ctx context.Context) (bool, error) {
 	defer r.referrersPingLock.Unlock()
 
 	switch r.loadReferrersState() {
-	case referrersStateSupported:
+	case properties.ReferrersAPISupported:
 		return true, nil
-	case referrersStateUnsupported:
+	case properties.ReferrersAPIUnsupported:
 		return false, nil
 	}
 
-	ref := r.Reference
+	repoRef := r.Reference()
+	ref := repoRef
 	ref.Reference = zeroDigest
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
 
-	url := buildReferrersURL(r.PlainHTTP, ref, "")
+	url := buildReferrersURL(r.plainHTTP(), ref, "")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return false, err
@@ -809,14 +910,15 @@ func (r *Repository) pingReferrers(ctx context.Context) (bool, error) {
 // delete removes the content identified by the descriptor in the entity "blobs"
 // or "manifests".
 func (r *Repository) delete(ctx context.Context, target ocispec.Descriptor, isManifest bool) error {
-	ref := r.Reference
+	repoRef := r.Reference()
+	ref := repoRef
 	ref.Reference = target.Digest.String()
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
 	buildURL := buildRepositoryBlobURL
 	if isManifest {
 		buildURL = buildRepositoryManifestURL
 	}
-	url := buildURL(r.PlainHTTP, ref)
+	url := buildURL(r.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err
@@ -848,10 +950,11 @@ func (s *blobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return nil, err
 	}
-	ref := s.repo.Reference
+	repoRef := s.repo.Reference()
+	ref := repoRef
 	ref.Reference = target.Digest.String()
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -898,14 +1001,15 @@ func (s *blobStore) Mount(ctx context.Context, desc ocispec.Descriptor, fromRepo
 	}
 	// pushing usually requires both pull and push actions.
 	// Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-	ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionPush)
+	repoRef := s.repo.Reference()
+	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull, auth.ActionPush)
 
 	// We also need pull access to the source repo.
-	fromRef := s.repo.Reference
+	fromRef := repoRef
 	fromRef.Repository = fromRepo
 	ctx = auth.AppendRepositoryScope(ctx, fromRef, auth.ActionPull)
 
-	url := buildRepositoryBlobMountURL(s.repo.PlainHTTP, s.repo.Reference, desc.Digest, fromRepo)
+	url := buildRepositoryBlobMountURL(s.repo.plainHTTP(), repoRef, desc.Digest, fromRepo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return err
@@ -955,7 +1059,7 @@ func (s *blobStore) Mount(ctx context.Context, desc ocispec.Descriptor, fromRepo
 // registry.
 func (s *blobStore) sibling(otherRepoName string) *blobStore {
 	otherRepo := s.repo.clone()
-	otherRepo.Reference.Repository = otherRepoName
+	otherRepo.RepositoryName = otherRepoName
 	return &blobStore{
 		repo: otherRepo,
 	}
@@ -979,8 +1083,9 @@ func (s *blobStore) Push(ctx context.Context, expected ocispec.Descriptor, conte
 	// start an upload
 	// pushing usually requires both pull and push actions.
 	// Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-	ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionPush)
-	url := buildRepositoryBlobUploadURL(s.repo.PlainHTTP, s.repo.Reference)
+	repoRef := s.repo.Reference()
+	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull, auth.ActionPush)
+	url := buildRepositoryBlobUploadURL(s.repo.plainHTTP(), repoRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return err
@@ -1086,7 +1191,7 @@ func (s *blobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
+	_, err := s.Resolve(ctx, target.Digest.String())
 	if err == nil {
 		return true, nil
 	}
@@ -1118,7 +1223,7 @@ func (s *blobStore) Resolve(ctx context.Context, reference string) (ocispec.Desc
 		return ocispec.Descriptor{}, err
 	}
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -1156,7 +1261,7 @@ func (s *blobStore) FetchReference(ctx context.Context, reference string) (desc 
 	}
 
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
@@ -1231,10 +1336,11 @@ func (s *manifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (r
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return nil, err
 	}
-	ref := s.repo.Reference
+	repoRef := s.repo.Reference()
+	ref := repoRef
 	ref.Reference = target.Digest.String()
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -1289,7 +1395,7 @@ func (s *manifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
+	_, err := s.Resolve(ctx, target.Digest.String())
 	if err == nil {
 		return true, nil
 	}
@@ -1312,15 +1418,15 @@ func (s *manifestStore) Delete(ctx context.Context, target ocispec.Descriptor) e
 func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.Descriptor) error {
 	switch target.MediaType {
 	case spec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
-		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
+		if state := s.repo.loadReferrersState(); state == properties.ReferrersAPISupported {
 			// referrers API is available, no client-side indexing needed
 			return s.repo.delete(ctx, target, true)
 		}
 
-		if err := limitSize(target, s.repo.MaxMetadataBytes); err != nil {
+		if err := limitSize(target, s.repo.maxMetadataBytes()); err != nil {
 			return err
 		}
-		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference, auth.ActionPull, auth.ActionDelete)
+		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference(), auth.ActionPull, auth.ActionDelete)
 		manifestJSON, err := content.FetchAll(ctx, s, target)
 		if err != nil {
 			return err
@@ -1374,12 +1480,12 @@ func (s *manifestStore) Resolve(ctx context.Context, reference string) (ocispec.
 		return ocispec.Descriptor{}, err
 	}
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	req.Header.Set("Accept", manifestAcceptHeader(s.repo.ManifestMediaTypes))
+	req.Header.Set("Accept", manifestAcceptHeader(s.repo.manifestMediaTypes()))
 
 	resp, err := s.repo.do(req)
 	if err != nil {
@@ -1409,12 +1515,12 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 	}
 
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	req.Header.Set("Accept", manifestAcceptHeader(s.repo.ManifestMediaTypes))
+	req.Header.Set("Accept", manifestAcceptHeader(s.repo.manifestMediaTypes()))
 
 	resp, err := s.repo.do(req)
 	if err != nil {
@@ -1478,12 +1584,13 @@ func (s *manifestStore) PushReference(ctx context.Context, expected ocispec.Desc
 
 // push pushes the manifest content, matching the expected descriptor.
 func (s *manifestStore) push(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
-	ref := s.repo.Reference
+	repoRef := s.repo.Reference()
+	ref := repoRef
 	ref.Reference = reference
 	// pushing usually requires both pull and push actions.
 	// Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
 	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
-	url := buildRepositoryManifestURL(s.repo.PlainHTTP, ref)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	// unwrap the content for optimizations of built-in types.
 	body := ioutil.UnwrapNopCloser(content)
 	if _, ok := body.(io.ReadCloser); ok {
@@ -1555,12 +1662,12 @@ func (s *manifestStore) checkOCISubjectHeader(resp *http.Response) {
 func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.Descriptor, r io.Reader, reference string) error {
 	switch expected.MediaType {
 	case spec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex:
-		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
+		if state := s.repo.loadReferrersState(); state == properties.ReferrersAPISupported {
 			// referrers API is available, no client-side indexing needed
 			return s.push(ctx, expected, r, reference)
 		}
 
-		if err := limitSize(expected, s.repo.MaxMetadataBytes); err != nil {
+		if err := limitSize(expected, s.repo.maxMetadataBytes()); err != nil {
 			return err
 		}
 		manifestJSON, err := content.ReadAll(r, expected)
@@ -1571,7 +1678,7 @@ func (s *manifestStore) pushWithIndexing(ctx context.Context, expected ocispec.D
 			return err
 		}
 		// check referrers API availability again after push
-		if state := s.repo.loadReferrersState(); state == referrersStateSupported {
+		if state := s.repo.loadReferrersState(); state == properties.ReferrersAPISupported {
 			// the subject has been processed the registry, no client-side
 			// indexing needed
 			return nil
@@ -1678,7 +1785,7 @@ func (s *manifestStore) updateReferrersIndex(ctx context.Context, subject ocispe
 		}
 
 		// 3. push the updated referrers list using referrers tag schema
-		if len(updatedReferrers) > 0 || s.repo.SkipReferrersGC {
+		if len(updatedReferrers) > 0 || s.repo.skipReferrersGC() {
 			// push a new index in either case:
 			// 1. the referrers list has been updated with a non-zero size
 			// 2. OR the updated referrers list is empty but referrers GC
@@ -1694,7 +1801,7 @@ func (s *manifestStore) updateReferrersIndex(ctx context.Context, subject ocispe
 		}
 
 		// 4. delete the dangling original referrers index, if applicable
-		if s.repo.SkipReferrersGC || oldIndexDesc == nil {
+		if s.repo.skipReferrersGC() || oldIndexDesc == nil {
 			return nil
 		}
 		if err := s.repo.delete(ctx, *oldIndexDesc, true); err != nil {
@@ -1780,7 +1887,7 @@ func (s *manifestStore) generateDescriptor(resp *http.Response, ref registry.Ref
 			// GET without server `Docker-Content-Digest` header forces the
 			// expensive calculation
 			var calculatedDigest digest.Digest
-			if calculatedDigest, err = calculateDigestFromResponse(resp, s.repo.MaxMetadataBytes); err != nil {
+			if calculatedDigest, err = calculateDigestFromResponse(resp, s.repo.maxMetadataBytes()); err != nil {
 				return ocispec.Descriptor{}, fmt.Errorf("failed to calculate digest on response body; %w", err)
 			}
 			contentDigest = calculatedDigest

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -17,6 +17,7 @@ package remote
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -39,9 +40,13 @@ func newRejectPolicyRepo(t *testing.T) *Repository {
 	if err != nil {
 		t.Fatalf("failed to create evaluator: %v", err)
 	}
-	return &Repository{
-		Reference: testReference,
+	reg := &Registry{
+		Reference: registry.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
+	}
+	return &Repository{
+		Registry:       reg,
+		RepositoryName: testReference.Repository,
 	}
 }
 
@@ -56,15 +61,13 @@ func assertPolicyDenied(t *testing.T, err error, operation string) {
 	}
 }
 
-var testDesc = ocispec.Descriptor{
-	MediaType: ocispec.MediaTypeImageManifest,
-	Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-	Size:      1234,
-}
-
 func TestRepository_PolicyEnforcement(t *testing.T) {
+	reg := &Registry{
+		Reference: registry.Reference{Registry: testReference.Registry},
+	}
 	repo := &Repository{
-		Reference: testReference,
+		Registry:       reg,
+		RepositoryName: testReference.Repository,
 	}
 
 	// Test without policy - should work
@@ -84,7 +87,7 @@ func TestRepository_PolicyEnforcement(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create evaluator: %v", err)
 		}
-		repo.Policy = evaluator
+		reg.Policy = evaluator
 
 		err = repo.checkPolicy(context.Background(), "")
 		if err == nil {
@@ -104,7 +107,7 @@ func TestRepository_PolicyEnforcement(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create evaluator: %v", err)
 		}
-		repo.Policy = evaluator
+		reg.Policy = evaluator
 
 		err = repo.checkPolicy(context.Background(), "")
 		if err != nil {
@@ -114,15 +117,16 @@ func TestRepository_PolicyEnforcement(t *testing.T) {
 }
 
 func TestRepository_PolicyCheckedContext(t *testing.T) {
+	// Verify that policyCheckedKey in context skips the check
 	repo := newRejectPolicyRepo(t)
 
-	// Without context key, should fail
+	// Without the key, policy should reject
 	err := repo.checkPolicy(context.Background(), "")
 	if err == nil {
 		t.Error("checkPolicy() should fail without policyCheckedKey")
 	}
 
-	// With context key, should be skipped
+	// With the key set, policy should be skipped
 	ctx := withPolicyChecked(context.Background())
 	err = repo.checkPolicy(ctx, "")
 	if err != nil {
@@ -131,12 +135,12 @@ func TestRepository_PolicyCheckedContext(t *testing.T) {
 }
 
 func TestRepository_PolicyScope(t *testing.T) {
+	// Verify that the scope is fully qualified (registry/repository)
 	pol := &policy.Policy{
 		Default: policy.PolicyRequirements{&policy.Reject{}},
 		Transports: map[policy.TransportName]policy.TransportScopes{
 			policy.TransportNameDocker: {
-				// Allow the fully-qualified scope
-				"localhost:5000/test/repo": policy.PolicyRequirements{&policy.InsecureAcceptAnything{}},
+				testReference.Registry + "/" + testReference.Repository: policy.PolicyRequirements{&policy.InsecureAcceptAnything{}},
 			},
 		},
 	}
@@ -144,12 +148,17 @@ func TestRepository_PolicyScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create evaluator: %v", err)
 	}
-	repo := &Repository{
-		Reference: testReference,
+
+	reg := &Registry{
+		Reference: registry.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
 	}
+	repo := &Repository{
+		Registry:       reg,
+		RepositoryName: testReference.Repository,
+	}
 
-	// Should succeed with fully-qualified scope match
+	// The fully-qualified scope should match, allowing access
 	err = repo.checkPolicy(context.Background(), "")
 	if err != nil {
 		t.Errorf("checkPolicy() should succeed with fully-qualified scope match, got: %v", err)
@@ -165,123 +174,186 @@ func TestRepository_Clone_Policy(t *testing.T) {
 		t.Fatalf("failed to create evaluator: %v", err)
 	}
 
-	original := &Repository{
-		Reference: testReference,
+	reg := &Registry{
+		Reference: registry.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
+	}
+	original := &Repository{
+		Registry:       reg,
+		RepositoryName: testReference.Repository,
 	}
 
 	cloned := original.clone()
 
-	if cloned.Policy != original.Policy {
-		t.Error("cloned repository should have the same policy evaluator")
+	if cloned.Registry.Policy != original.Registry.Policy {
+		t.Error("cloned repository should have the same policy evaluator via Registry")
 	}
 }
 
-// Tests for all Repository methods with reject policy.
-
 func TestRepository_Fetch_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	_, err := repo.Fetch(context.Background(), testDesc)
-	assertPolicyDenied(t, err, "Fetch")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	_, err := repo.Fetch(context.Background(), desc)
+	assertPolicyDenied(t, err, "Fetch()")
 }
 
 func TestRepository_Push_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Push(context.Background(), testDesc, strings.NewReader("test"))
-	assertPolicyDenied(t, err, "Push")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.Push(context.Background(), desc, strings.NewReader("test content"))
+	assertPolicyDenied(t, err, "Push()")
 }
 
 func TestRepository_Resolve_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
+
 	_, err := repo.Resolve(context.Background(), "latest")
-	assertPolicyDenied(t, err, "Resolve")
+	assertPolicyDenied(t, err, "Resolve()")
 }
 
 func TestRepository_Delete_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Delete(context.Background(), testDesc)
-	assertPolicyDenied(t, err, "Delete")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.Delete(context.Background(), desc)
+	assertPolicyDenied(t, err, "Delete()")
 }
 
 func TestRepository_Tag_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Tag(context.Background(), testDesc, "latest")
-	assertPolicyDenied(t, err, "Tag")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.Tag(context.Background(), desc, "v1.0")
+	assertPolicyDenied(t, err, "Tag()")
 }
 
 func TestRepository_PushReference_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.PushReference(context.Background(), testDesc, strings.NewReader("test"), "latest")
-	assertPolicyDenied(t, err, "PushReference")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.PushReference(context.Background(), desc, strings.NewReader("test content"), "v1.0")
+	assertPolicyDenied(t, err, "PushReference()")
 }
 
 func TestRepository_FetchReference_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
+
 	_, _, err := repo.FetchReference(context.Background(), "latest")
-	assertPolicyDenied(t, err, "FetchReference")
+	assertPolicyDenied(t, err, "FetchReference()")
 }
 
 func TestRepository_Exists_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	_, err := repo.Exists(context.Background(), testDesc)
-	assertPolicyDenied(t, err, "Exists")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	_, err := repo.Exists(context.Background(), desc)
+	assertPolicyDenied(t, err, "Exists()")
 }
 
 func TestRepository_Tags_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Tags(context.Background(), "", func(tags []string) error { return nil })
-	assertPolicyDenied(t, err, "Tags")
-}
 
-func TestRepository_Predecessors_PolicyCheck(t *testing.T) {
-	repo := newRejectPolicyRepo(t)
-	_, err := repo.Predecessors(context.Background(), testDesc)
-	assertPolicyDenied(t, err, "Predecessors")
+	err := repo.Tags(context.Background(), "", func(tags []string) error {
+		return nil
+	})
+	assertPolicyDenied(t, err, "Tags()")
 }
 
 func TestRepository_Referrers_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Referrers(context.Background(), testDesc, "", func(referrers []ocispec.Descriptor) error { return nil })
-	assertPolicyDenied(t, err, "Referrers")
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.Referrers(context.Background(), desc, "", func(referrers []ocispec.Descriptor) error {
+		return nil
+	})
+	assertPolicyDenied(t, err, "Referrers()")
 }
 
-// Tests for sub-store policy enforcement.
+func TestRepository_Predecessors_PolicyCheck(t *testing.T) {
+	repo := newRejectPolicyRepo(t)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	_, err := repo.Predecessors(context.Background(), desc)
+	assertPolicyDenied(t, err, "Predecessors()")
+}
+
+func TestRepository_Mount_PolicyCheck(t *testing.T) {
+	repo := newRejectPolicyRepo(t)
+	desc := ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.Mount(context.Background(), desc, "source/repo", nil)
+	assertPolicyDenied(t, err, "Mount()")
+}
 
 func TestRepository_ManifestStore_PushReference_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Manifests().PushReference(context.Background(), testDesc, strings.NewReader("test"), "latest")
-	assertPolicyDenied(t, err, "Manifests().PushReference")
-}
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
 
-func TestRepository_ManifestStore_Fetch_PolicyCheck(t *testing.T) {
-	repo := newRejectPolicyRepo(t)
-	_, err := repo.Manifests().Fetch(context.Background(), testDesc)
-	assertPolicyDenied(t, err, "Manifests().Fetch")
-}
-
-func TestRepository_ManifestStore_Resolve_PolicyCheck(t *testing.T) {
-	repo := newRejectPolicyRepo(t)
-	_, err := repo.Manifests().Resolve(context.Background(), "latest")
-	assertPolicyDenied(t, err, "Manifests().Resolve")
+	err := repo.Manifests().PushReference(context.Background(), desc, strings.NewReader("test content"), "v1.0")
+	assertPolicyDenied(t, err, "Manifests().PushReference()")
 }
 
 func TestRepository_BlobStore_Fetch_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	_, err := repo.Blobs().Fetch(context.Background(), testDesc)
-	assertPolicyDenied(t, err, "Blobs().Fetch")
-}
+	desc := ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
 
-func TestRepository_BlobStore_Push_PolicyCheck(t *testing.T) {
-	repo := newRejectPolicyRepo(t)
-	err := repo.Blobs().Push(context.Background(), testDesc, strings.NewReader("test"))
-	assertPolicyDenied(t, err, "Blobs().Push")
+	_, err := repo.Blobs().Fetch(context.Background(), desc)
+	assertPolicyDenied(t, err, "Blobs().Fetch()")
 }
 
 func TestRepository_ScopeSpecificPolicy(t *testing.T) {
+	// Test that scope-specific policies work correctly
 	pol := &policy.Policy{
 		Default: policy.PolicyRequirements{&policy.Reject{}},
 		Transports: map[policy.TransportName]policy.TransportScopes{
 			policy.TransportNameDocker: {
+				// Allow all docker repositories
 				"": policy.PolicyRequirements{&policy.InsecureAcceptAnything{}},
 			},
 		},
@@ -292,13 +364,27 @@ func TestRepository_ScopeSpecificPolicy(t *testing.T) {
 		t.Fatalf("failed to create evaluator: %v", err)
 	}
 
-	repo := &Repository{
-		Reference: testReference,
+	reg := &Registry{
+		Reference: registry.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
 	}
+	repo := &Repository{
+		Registry:       reg,
+		RepositoryName: testReference.Repository,
+	}
 
+	// Since the policy allows docker transport, checkPolicy should succeed
 	err = repo.checkPolicy(context.Background(), "")
 	if err != nil {
 		t.Errorf("checkPolicy() should succeed for allowed docker transport, got: %v", err)
 	}
+}
+
+// mockReadCloser is a simple mock for testing
+type mockReadCloser struct {
+	io.Reader
+}
+
+func (m *mockReadCloser) Close() error {
+	return nil
 }

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/auth"
 	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -163,8 +164,8 @@ func TestNewRepository(t *testing.T) {
 				}
 				t.Fatalf("NewRepository() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if got.Reference.String() != tt.reference {
-				t.Errorf("NewRepository() got = %v, want %v", got.Reference.String(), tt.reference)
+			if got.Reference().String() != tt.reference {
+				t.Errorf("NewRepository() got = %v, want %v", got.Reference().String(), tt.reference)
 			}
 		})
 	}
@@ -222,7 +223,7 @@ func TestRepository_Fetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	rc, err := repo.Fetch(ctx, blobDesc)
@@ -323,7 +324,7 @@ func TestRepository_Push(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = repo.Push(ctx, blobDesc, bytes.NewReader(blob))
@@ -388,7 +389,7 @@ func TestRepository_Mount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = repo.Mount(ctx, blobDesc, "test", nil)
@@ -468,7 +469,7 @@ func TestRepository_Mount_Fallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	t.Run("getContent is nil", func(t *testing.T) {
@@ -540,7 +541,7 @@ func TestRepository_Mount_Error(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	err = repo.Mount(context.Background(), blobDesc, "foo", nil)
 	if err == nil {
@@ -617,7 +618,7 @@ func TestRepository_Mount_Fallback_GetContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = repo.Mount(ctx, blobDesc, "test", func() (io.ReadCloser, error) {
@@ -671,7 +672,7 @@ func TestRepository_Mount_Fallback_GetContentError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	testErr := errors.New("test error")
@@ -737,7 +738,7 @@ func TestRepository_Exists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	exists, err := repo.Exists(ctx, blobDesc)
@@ -809,7 +810,7 @@ func TestRepository_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = repo.Delete(ctx, blobDesc)
@@ -878,7 +879,7 @@ func TestRepository_Resolve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	_, err = repo.Resolve(ctx, blobDesc.Digest.String())
@@ -980,7 +981,7 @@ func TestRepository_Tag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = repo.Tag(ctx, blobDesc, ref)
@@ -1045,7 +1046,7 @@ func TestRepository_PushReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 	err = repo.PushReference(ctx, indexDesc, bytes.NewReader(index), ref)
 	if err != nil {
@@ -1107,7 +1108,7 @@ func TestRepository_FetchReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	// test with blob digest
@@ -1245,7 +1246,7 @@ func TestRepository_Tags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.TagListPageSize = 4
 
 	ctx := context.Background()
@@ -1307,7 +1308,7 @@ func TestRepository_Tags_MaxPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.TagListMaxPages = 2
 
 	ctx := context.Background()
@@ -1410,7 +1411,7 @@ func TestRepository_Predecessors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 
 	ctx := context.Background()
@@ -1527,10 +1528,10 @@ func TestRepository_Referrers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	index := 0
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
@@ -1546,8 +1547,8 @@ func TestRepository_Referrers(t *testing.T) {
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test force attempt Referrers
@@ -1556,11 +1557,11 @@ func TestRepository_Referrers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 	repo.SetReferrersCapability(true)
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	index = 0
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
@@ -1576,8 +1577,8 @@ func TestRepository_Referrers(t *testing.T) {
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test force attempt tag schema
@@ -1586,19 +1587,19 @@ func TestRepository_Referrers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 	repo.SetReferrersCapability(false)
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -1653,7 +1654,7 @@ func TestRepository_Referrers_MaxPages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListMaxPages = 2
 	repo.SetReferrersCapability(true)
 
@@ -1739,9 +1740,9 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		if !reflect.DeepEqual(got, referrers) {
@@ -1751,8 +1752,8 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test force attempt Referrers
@@ -1761,18 +1762,18 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(true)
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test force attempt tag schema
@@ -1781,10 +1782,10 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(false)
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		if !reflect.DeepEqual(got, referrers) {
@@ -1794,8 +1795,8 @@ func TestRepository_Referrers_TagSchemaFallback(t *testing.T) {
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -1833,17 +1834,17 @@ func TestRepository_Referrers_TagSchemaFallback_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test force attempt tag schema
@@ -1852,18 +1853,18 @@ func TestRepository_Referrers_TagSchemaFallback_NotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(false)
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -1905,17 +1906,17 @@ func TestRepository_Referrers_TagSchemaFallback_ContentType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v", err)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -1951,17 +1952,17 @@ func TestRepository_Referrers_TagSchemaFallback_BadDigest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = nil, wantErr %v", true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -1998,17 +1999,17 @@ func TestRepository_Referrers_BadRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = nil, wantErr %v", true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 
 	// test force attempt Referrers
@@ -2017,18 +2018,18 @@ func TestRepository_Referrers_BadRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(true)
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = nil, wantErr %v", true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test force attempt tag schema
@@ -2037,18 +2038,18 @@ func TestRepository_Referrers_BadRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(false)
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = nil, wantErr %v", true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -2085,17 +2086,17 @@ func TestRepository_Referrers_RepositoryNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 
 	// test force attempt Referrers
@@ -2104,18 +2105,18 @@ func TestRepository_Referrers_RepositoryNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(true)
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err == nil {
 		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test force attempt tag schema
@@ -2124,18 +2125,18 @@ func TestRepository_Referrers_RepositoryNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(false)
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 	if err := repo.Referrers(ctx, manifestDesc, "", func(got []ocispec.Descriptor) error {
 		return nil
 	}); err != nil {
 		t.Errorf("Repository.Referrers() error = %v, wantErr %v", err, nil)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -2244,7 +2245,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 
 	ctx := context.Background()
@@ -2322,7 +2323,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 
 	ctx = context.Background()
@@ -2404,7 +2405,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 
 	ctx = context.Background()
@@ -2544,7 +2545,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.ReferrerListPageSize = 2
 
 	ctx := context.Background()
@@ -2654,7 +2655,7 @@ func TestRepository_Referrers_TagSchemaFallback_ClientFiltering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	ctx := context.Background()
 	if err := repo.Referrers(ctx, manifestDesc, "application/vnd.test", func(got []ocispec.Descriptor) error {
@@ -2723,7 +2724,7 @@ func TestRepository_BadDigest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewRepository() error = %v", err)
 			}
-			repo.PlainHTTP = true
+			repo.Registry.PlainHTTP = true
 			ctx := context.Background()
 			if err := repo.Push(ctx, desc, bytes.NewReader(data)); err != nil {
 				t.Errorf("Repository.Push() error = %v", err)
@@ -2756,7 +2757,7 @@ func TestRepository_BadDigest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewRepository() error = %v", err)
 			}
-			repo.PlainHTTP = true
+			repo.Registry.PlainHTTP = true
 			ctx := context.Background()
 
 			if _, err = repo.Exists(ctx, desc); err == nil {
@@ -2792,7 +2793,7 @@ func TestRepository_BadDigest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewRepository() error = %v", err)
 			}
-			repo.PlainHTTP = true
+			repo.Registry.PlainHTTP = true
 			store := repo.Blobs()
 			ctx := context.Background()
 
@@ -2828,7 +2829,7 @@ func TestRepository_BadDigest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewRepository() error = %v", err)
 			}
-			repo.PlainHTTP = true
+			repo.Registry.PlainHTTP = true
 			ctx := context.Background()
 
 			if _, err = repo.Blobs().Resolve(ctx, desc.Digest.String()); err == nil {
@@ -2872,7 +2873,7 @@ func Test_BlobStore_Fetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -2966,7 +2967,7 @@ func Test_BlobStore_Fetch_Seek(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3059,7 +3060,7 @@ func Test_BlobStore_Fetch_ZeroSizedBlob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3117,7 +3118,7 @@ func Test_BlobStore_Fetch_BadResponse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Blobs()
 		ctx := context.Background()
 
@@ -3155,7 +3156,7 @@ func Test_BlobStore_Fetch_BadResponse(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Blobs()
 		ctx := context.Background()
 
@@ -3212,7 +3213,7 @@ func Test_BlobStore_Push(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3264,7 +3265,7 @@ func Test_BlobStore_Push_CrossHostRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3309,7 +3310,7 @@ func Test_BlobStore_Exists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3369,7 +3370,7 @@ func Test_BlobStore_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3429,7 +3430,7 @@ func Test_BlobStore_Resolve(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Blobs()
 		ctx := context.Background()
 
@@ -3492,7 +3493,7 @@ func Test_BlobStore_Resolve(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Blobs()
 		ctx := context.Background()
 
@@ -3564,7 +3565,7 @@ func Test_BlobStore_FetchReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3687,7 +3688,7 @@ func Test_BlobStore_FetchReference_Seek(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	ctx := context.Background()
 
@@ -3865,7 +3866,7 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -3929,7 +3930,7 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -3972,7 +3973,7 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -4018,7 +4019,7 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -4066,7 +4067,7 @@ func Test_ManifestStore_Fetch(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -4115,7 +4116,7 @@ func Test_ManifestStore_Push(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
 
@@ -4219,9 +4220,9 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, artifactDesc, bytes.NewReader(artifactJSON))
 	if err != nil {
@@ -4230,8 +4231,8 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, artifactJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(artifactJSON))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test pushing image manifest with subject
@@ -4239,9 +4240,9 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
 	if err != nil {
@@ -4250,8 +4251,8 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, manifestJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test pushing image index with subject
@@ -4262,8 +4263,8 @@ func Test_ManifestStore_Push_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, indexJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 }
 
@@ -4347,10 +4348,10 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, artifactDesc, bytes.NewReader(artifactJSON))
 	if err != nil {
@@ -4362,8 +4363,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if !bytes.Equal(gotReferrerIndex, indexJSON_1) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_1))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test pushing artifact with subject when an old empty referrer list exists,
@@ -4428,10 +4429,10 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, artifactDesc, bytes.NewReader(artifactJSON))
 	if err != nil {
@@ -4446,8 +4447,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if !indexDeleted {
 		t.Errorf("indexDeleted = %v, want %v", indexDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test pushing image manifest with subject, referrer list should be updated
@@ -4530,9 +4531,9 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
 	if err != nil {
@@ -4547,8 +4548,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if !indexDeleted {
 		t.Errorf("indexDeleted = %v, want %v", indexDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test pushing image manifest with subject again, referrers list should not be changed
@@ -4584,9 +4585,9 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
 	if err != nil {
@@ -4599,8 +4600,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if !bytes.Equal(gotReferrerIndex, indexJSON_2) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_2))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// push image index with subject, referrer list should be updated
@@ -4682,9 +4683,9 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, indexManifestDesc, bytes.NewReader(indexManifestJSON))
 	if err != nil {
@@ -4699,8 +4700,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable(t *testing.T) {
 	if !indexDeleted {
 		t.Errorf("indexDeleted = %v, want %v", indexDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -4786,11 +4787,11 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable_SkipReferrersGC(t *testing.
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SkipReferrersGC = true
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
 	if err != nil {
@@ -4802,8 +4803,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable_SkipReferrersGC(t *testing.
 	if !bytes.Equal(gotReferrerIndex, indexJSON_1) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_1))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test pushing image manifest with subject when an old empty referrer list exists,
@@ -4862,11 +4863,11 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable_SkipReferrersGC(t *testing.
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SkipReferrersGC = true
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON))
 	if err != nil {
@@ -4878,8 +4879,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable_SkipReferrersGC(t *testing.
 	if !bytes.Equal(gotReferrerIndex, indexJSON_1) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_1))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// push image index with subject, referrer list should be updated, the old
@@ -4956,11 +4957,11 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable_SkipReferrersGC(t *testing.
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SkipReferrersGC = true
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.Push(ctx, indexManifestDesc, bytes.NewReader(indexManifestJSON))
 	if err != nil {
@@ -4972,8 +4973,8 @@ func Test_ManifestStore_Push_ReferrersAPIUnavailable_SkipReferrersGC(t *testing.
 	if !bytes.Equal(gotReferrerIndex, indexJSON_2) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_2))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -5014,7 +5015,7 @@ func Test_ManifestStore_Exists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
 
@@ -5084,7 +5085,7 @@ func Test_ManifestStore_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
 
@@ -5201,12 +5202,12 @@ func Test_ManifestStore_Delete_ReferrersAPIAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
 	// test deleting artifact with subject
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, artifactDesc)
 	if err != nil {
@@ -5217,8 +5218,8 @@ func Test_ManifestStore_Delete_ReferrersAPIAvailable(t *testing.T) {
 	}
 
 	// test deleting manifest with subject
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	err = store.Delete(ctx, manifestDesc)
 	if err != nil {
@@ -5229,8 +5230,8 @@ func Test_ManifestStore_Delete_ReferrersAPIAvailable(t *testing.T) {
 	}
 
 	// test deleting index with subject
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	err = store.Delete(ctx, indexDesc)
 	if err != nil {
@@ -5391,12 +5392,12 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, artifactDesc)
 	if err != nil {
@@ -5411,8 +5412,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	if !indexDeleted {
 		t.Errorf("Manifests.Delete() = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test deleting manifest with subject, referrers list should be updated
@@ -5469,11 +5470,11 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store = repo.Manifests()
 	ctx = context.Background()
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, manifestDesc)
 	if err != nil {
@@ -5485,8 +5486,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	if !indexDeleted {
 		t.Errorf("Manifests.Delete() = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test deleting index with a subject, referrers list should be updated
@@ -5531,11 +5532,11 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store = repo.Manifests()
 	ctx = context.Background()
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, indexManifestDesc)
 	if err != nil {
@@ -5547,8 +5548,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable(t *testing.T) {
 	if !indexDeleted {
 		t.Errorf("Manifests.Delete() = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -5670,13 +5671,13 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_SkipReferrersGC(t *testin
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SkipReferrersGC = true
 	store := repo.Manifests()
 	ctx := context.Background()
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, manifestDesc)
 	if err != nil {
@@ -5688,8 +5689,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_SkipReferrersGC(t *testin
 	if !bytes.Equal(gotReferrerIndex, indexJSON_2) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_2))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test deleting index with a subject, referrers list should be updated,
@@ -5742,13 +5743,13 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_SkipReferrersGC(t *testin
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SkipReferrersGC = true
 	store = repo.Manifests()
 	ctx = context.Background()
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, indexManifestDesc)
 	if err != nil {
@@ -5760,8 +5761,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_SkipReferrersGC(t *testin
 	if !bytes.Equal(gotReferrerIndex, indexJSON_3) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_3))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -5817,11 +5818,11 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, artifactDesc)
 	if err != nil {
@@ -5830,8 +5831,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 	if !manifestDeleted {
 		t.Errorf("Manifests.Delete() = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test inconsistent state: empty referrers list
@@ -5880,11 +5881,11 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store = repo.Manifests()
 	ctx = context.Background()
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, artifactDesc)
 	if err != nil {
@@ -5893,8 +5894,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 	if !manifestDeleted {
 		t.Errorf("Manifests.Delete() = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test inconsistent state: current referrer is not in referrers list
@@ -5945,11 +5946,11 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store = repo.Manifests()
 	ctx = context.Background()
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = store.Delete(ctx, artifactDesc)
 	if err != nil {
@@ -5958,8 +5959,8 @@ func Test_ManifestStore_Delete_ReferrersAPIUnavailable_InconsistentIndex(t *test
 	if !manifestDeleted {
 		t.Errorf("Manifests.Delete() = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -6005,7 +6006,7 @@ func Test_ManifestStore_Resolve(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -6086,7 +6087,7 @@ func Test_ManifestStore_Resolve(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 		store := repo.Manifests()
 		ctx := context.Background()
 
@@ -6163,7 +6164,7 @@ func Test_ManifestStore_FetchReference(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Manifests()
 	ctx := context.Background()
 
@@ -6321,7 +6322,7 @@ func Test_ManifestStore_Tag(t *testing.T) {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
 	store := repo.Manifests()
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 
 	err = store.Tag(ctx, blobDesc, ref)
@@ -6387,7 +6388,7 @@ func Test_ManifestStore_PushReference(t *testing.T) {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
 	store := repo.Manifests()
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 	err = store.PushReference(ctx, indexDesc, bytes.NewReader(index), ref)
 	if err != nil {
@@ -6505,9 +6506,9 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.PushReference(ctx, artifactDesc, bytes.NewReader(artifactJSON), artifactRef)
 	if err != nil {
@@ -6516,8 +6517,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, artifactJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(artifactJSON))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test pushing image manifest with subject
@@ -6525,9 +6526,9 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.PushReference(ctx, manifestDesc, bytes.NewReader(manifestJSON), manifestRef)
 	if err != nil {
@@ -6536,8 +6537,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, manifestJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(manifestJSON))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test pushing image index with subject
@@ -6548,8 +6549,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIAvailable(t *testing.T) {
 	if !bytes.Equal(gotManifest, indexJSON) {
 		t.Errorf("Manifests.Push() = %v, want %v", string(gotManifest), string(indexJSON))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 }
 
@@ -6634,10 +6635,10 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.PushReference(ctx, artifactDesc, bytes.NewReader(artifactJSON), artifactRef)
 	if err != nil {
@@ -6649,8 +6650,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if !bytes.Equal(gotReferrerIndex, indexJSON_1) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_1))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test pushing image manifest with subject, referrers list should be updated
@@ -6735,9 +6736,9 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.PushReference(ctx, manifestDesc, bytes.NewReader(manifestJSON), manifestRef)
 	if err != nil {
@@ -6752,8 +6753,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if !manifestDeleted {
 		t.Errorf("manifestDeleted = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// test pushing image manifest with subject again, referrers list should not be changed
@@ -6789,9 +6790,9 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.PushReference(ctx, manifestDesc, bytes.NewReader(manifestJSON), manifestRef)
 	if err != nil {
@@ -6804,8 +6805,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if !bytes.Equal(gotReferrerIndex, indexJSON_2) {
 		t.Errorf("got referrers index = %v, want %v", string(gotReferrerIndex), string(indexJSON_2))
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 
 	// push image index with subject, referrer list should be updated
@@ -6888,9 +6889,9 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	err = repo.PushReference(ctx, indexManifestDesc, bytes.NewReader(indexManifestJSON), indexManifestRef)
 	if err != nil {
@@ -6905,8 +6906,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 	if !manifestDeleted {
 		t.Errorf("manifestDeleted = %v, want %v", manifestDeleted, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -7027,7 +7028,7 @@ func (t *testTransport) RoundTrip(originalReq *http.Request) (*http.Response, er
 // Test_BlobStore_Push_Port443
 func blobStore_Push_Port443_create_store(uri *url.URL, testRegistry string) (registry.BlobStore, error) {
 	repo, err := NewRepository(testRegistry + "/test")
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: &http.Client{
 			Transport: &testTransport{
 				proxyHost:           uri.Host,
@@ -7037,7 +7038,7 @@ func blobStore_Push_Port443_create_store(uri *url.URL, testRegistry string) (reg
 		},
 		Cache: auth.NewCache(),
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	store := repo.Blobs()
 	return store, err
 }
@@ -7121,7 +7122,7 @@ func blobStore_Push_Port443_HTTPS_create_store(uri *url.URL, testRegistry string
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 	}
-	repo.Client = &auth.Client{
+	repo.Registry.Client = &auth.Client{
 		Client: &http.Client{
 			Transport: &testTransport{
 				proxyHost:           uri.Host,
@@ -7131,7 +7132,7 @@ func blobStore_Push_Port443_HTTPS_create_store(uri *url.URL, testRegistry string
 		},
 		Cache: auth.NewCache(),
 	}
-	repo.PlainHTTP = false
+	repo.Registry.PlainHTTP = false
 	store := repo.Blobs()
 	return store, err
 }
@@ -7314,7 +7315,7 @@ func TestRepository_Tags_WithLastParam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.TagListPageSize = 4
 	last := "n"
 	startInd := indexOf(last, tagSet) + 1
@@ -7568,8 +7569,12 @@ func TestRepository_ParseReference(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			reg := &Registry{
+				Reference: registry.Reference{Registry: tt.repoRef.Registry},
+			}
 			r := &Repository{
-				Reference: tt.repoRef,
+				Registry:       reg,
+				RepositoryName: tt.repoRef.Repository,
 			}
 			got, err := r.ParseReference(tt.args.reference)
 			if !errors.Is(err, tt.wantErr) {
@@ -7589,24 +7594,20 @@ func TestRepository_SetReferrersCapability(t *testing.T) {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
 	// initial state
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 
-	// valid first time set
-	if err := repo.SetReferrersCapability(true); err != nil {
-		t.Errorf("Repository.SetReferrersCapability() error = %v", err)
-	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	// first set
+	repo.SetReferrersCapability(true)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
-	// invalid second time set, state should be no changed
-	if err := repo.SetReferrersCapability(false); !errors.Is(err, ErrReferrersCapabilityAlreadySet) {
-		t.Errorf("Repository.SetReferrersCapability() error = %v, wantErr %v", err, ErrReferrersCapabilityAlreadySet)
-	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	// conflicting second set is silently ignored; state should be unchanged
+	repo.SetReferrersCapability(false)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v (conflicting set should be ignored)", state, properties.ReferrersAPISupported)
 	}
 }
 
@@ -7730,11 +7731,11 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 
 		// 1st call
-		if state := repo.loadReferrersState(); state != referrersStateUnknown {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 		}
 		got, err := repo.pingReferrers(ctx)
 		if err != nil {
@@ -7743,16 +7744,16 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if got != true {
 			t.Errorf("Repository.pingReferrers() = %v, want %v", got, true)
 		}
-		if state := repo.loadReferrersState(); state != referrersStateSupported {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 		}
 		if count != 1 {
 			t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 		}
 
 		// 2nd call
-		if state := repo.loadReferrersState(); state != referrersStateSupported {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 		}
 		got, err = repo.pingReferrers(ctx)
 		if err != nil {
@@ -7761,8 +7762,8 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if got != true {
 			t.Errorf("Repository.pingReferrers() = %v, want %v", got, true)
 		}
-		if state := repo.loadReferrersState(); state != referrersStateSupported {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 		}
 		if count != 1 {
 			t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
@@ -7793,11 +7794,11 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 
 		// 1st call
-		if state := repo.loadReferrersState(); state != referrersStateUnknown {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 		}
 		got, err := repo.pingReferrers(ctx)
 		if err != nil {
@@ -7806,16 +7807,16 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if got != false {
 			t.Errorf("Repository.pingReferrers() = %v, want %v", got, false)
 		}
-		if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 		}
 		if count != 1 {
 			t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 		}
 
 		// 2nd call
-		if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 		}
 		got, err = repo.pingReferrers(ctx)
 		if err != nil {
@@ -7824,8 +7825,8 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if got != false {
 			t.Errorf("Repository.pingReferrers() = %v, want %v", got, false)
 		}
-		if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+		if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+			t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 		}
 		if count != 1 {
 			t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
@@ -7857,7 +7858,7 @@ func TestRepository_pingReferrers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("NewRepository() error = %v", err)
 		}
-		repo.PlainHTTP = true
+		repo.Registry.PlainHTTP = true
 
 		got, err := repo.pingReferrers(ctx)
 		if err != nil {
@@ -7894,15 +7895,15 @@ func TestRepository_pingReferrers_RepositoryNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	repo.Registry.PlainHTTP = true
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	if _, err = repo.pingReferrers(ctx); err == nil {
 		t.Fatalf("Repository.pingReferrers() error = %v, wantErr %v", err, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 
 	// test referrers state supported
@@ -7910,10 +7911,10 @@ func TestRepository_pingReferrers_RepositoryNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(true)
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 	got, err := repo.pingReferrers(ctx)
 	if err != nil {
@@ -7922,8 +7923,8 @@ func TestRepository_pingReferrers_RepositoryNotFound(t *testing.T) {
 	if got != true {
 		t.Errorf("Repository.pingReferrers() = %v, want %v", got, true)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 
 	// test referrers state unsupported
@@ -7931,10 +7932,10 @@ func TestRepository_pingReferrers_RepositoryNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 	repo.SetReferrersCapability(false)
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 	got, err = repo.pingReferrers(ctx)
 	if err != nil {
@@ -7943,8 +7944,8 @@ func TestRepository_pingReferrers_RepositoryNotFound(t *testing.T) {
 	if got != false {
 		t.Errorf("Repository.pingReferrers() = %v, want %v", got, false)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateUnsupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnsupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnsupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnsupported)
 	}
 }
 
@@ -7974,13 +7975,13 @@ func TestRepository_pingReferrers_Concurrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	repo.PlainHTTP = true
+	repo.Registry.PlainHTTP = true
 
 	concurrency := 64
 	eg, egCtx := errgroup.WithContext(ctx)
 
-	if state := repo.loadReferrersState(); state != referrersStateUnknown {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateUnknown)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPIUnknown {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPIUnknown)
 	}
 	for range concurrency {
 		eg.Go(func() func() error {
@@ -8003,8 +8004,8 @@ func TestRepository_pingReferrers_Concurrent(t *testing.T) {
 	if got := atomic.LoadInt32(&count); got != 1 {
 		t.Errorf("count(Repository.pingReferrers()) = %v, want %v", count, 1)
 	}
-	if state := repo.loadReferrersState(); state != referrersStateSupported {
-		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, referrersStateSupported)
+	if state := repo.loadReferrersState(); state != properties.ReferrersAPISupported {
+		t.Errorf("Repository.loadReferrersState() = %v, want %v", state, properties.ReferrersAPISupported)
 	}
 }
 
@@ -8065,7 +8066,7 @@ func TestRepository_do(t *testing.T) {
 		t.Fatal("NewRepository() error =", err)
 	}
 	var gotWarnings []Warning
-	repo.HandleWarning = func(warning Warning) {
+	repo.Registry.HandleWarning = func(warning Warning) {
 		gotWarnings = append(gotWarnings, warning)
 	}
 
@@ -8120,32 +8121,33 @@ func TestRepository_do(t *testing.T) {
 	}
 }
 
-func TestRepository_newRepositoryWithOptions(t *testing.T) {
-	t.Run("valid reference and options", func(t *testing.T) {
-		ref := registry.Reference{
-			Registry:   "registry.example.com",
-			Repository: "test",
-			Reference:  "latest",
-		}
-		opts := &RepositoryOptions{
-			PlainHTTP: true,
-		}
-		repo, err := newRepositoryWithOptions(ref, opts)
+func TestRegistry_newRepository(t *testing.T) {
+	t.Run("valid reference and registry", func(t *testing.T) {
+		reg, err := NewRegistry("registry.example.com")
 		if err != nil {
-			t.Fatalf("newRepositoryWithOptions() error = %v", err)
+			t.Fatalf("NewRegistry() error = %v", err)
 		}
-		if repo.PlainHTTP != opts.PlainHTTP {
-			t.Errorf("Repository.PlainHTTP = %v, want %v", repo.PlainHTTP, opts.PlainHTTP)
+		reg.PlainHTTP = true
+
+		repo, err := reg.newRepository("test")
+		if err != nil {
+			t.Fatalf("Registry.newRepository() error = %v", err)
 		}
-		if !reflect.DeepEqual(repo.Reference, ref) {
-			t.Errorf("Repository.Reference = %v, want %v", repo.Reference, ref)
+		if repo.Registry.PlainHTTP != reg.PlainHTTP {
+			t.Errorf("Repository.Registry.PlainHTTP = %v, want %v", repo.Registry.PlainHTTP, reg.PlainHTTP)
+		}
+		if repo.RepositoryName != "test" {
+			t.Errorf("Repository.RepositoryName = %v, want %v", repo.RepositoryName, "test")
 		}
 	})
 
-	t.Run("invalid reference", func(t *testing.T) {
-		ref := registry.Reference{}
-		if _, err := newRepositoryWithOptions(ref, nil); err == nil {
-			t.Error("newRepositoryWithOptions() error = nil, wantErr")
+	t.Run("invalid repository name", func(t *testing.T) {
+		reg, err := NewRegistry("registry.example.com")
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+		if _, err := reg.newRepository(""); err == nil {
+			t.Error("Registry.newRepository() error = nil, wantErr")
 		}
 	})
 }
@@ -8158,8 +8160,12 @@ func TestRepository_clone(t *testing.T) {
 
 	crepo := repo.clone()
 
-	if repo.Reference != crepo.Reference {
-		t.Fatal("references should be the same")
+	if repo.Registry != crepo.Registry {
+		t.Fatal("Registry should be the same")
+	}
+
+	if repo.RepositoryName != crepo.RepositoryName {
+		t.Fatal("RepositoryName should be the same")
 	}
 
 	if !reflect.DeepEqual(&repo.referrersPingLock, &crepo.referrersPingLock) {
@@ -8212,7 +8218,8 @@ func TestManifestStore_ParseReference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo := &Repository{}
+			reg := &Registry{}
+			repo := &Repository{Registry: reg}
 			s := &manifestStore{repo: repo}
 			got, err := s.ParseReference(tt.reference)
 			if (err != nil) != tt.wantErr {
@@ -8406,9 +8413,12 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			reg := &Registry{
+				MaxMetadataBytes: 1024,
+			}
 			s := &manifestStore{
 				repo: &Repository{
-					MaxMetadataBytes: 1024,
+					Registry: reg,
 				},
 			}
 			got, err := s.generateDescriptor(tt.resp, tt.ref, tt.httpMethod)

--- a/registry/remote/warning.go
+++ b/registry/remote/warning.go
@@ -18,8 +18,10 @@ package remote
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const (
@@ -63,6 +65,21 @@ type WarningValue struct {
 type Warning struct {
 	// WarningValue is the value of the warning header.
 	WarningValue
+}
+
+// NewWarningLogger returns a HandleWarning function that logs each unique
+// warning from the given registry exactly once at slog.LevelWarn. Duplicate
+// warnings (same WarningValue) are silently dropped, which prevents the same
+// deprecation notice from flooding the log during operations that issue many
+// HTTP requests (e.g. parallel blob fetches). The returned function is safe
+// for concurrent use.
+func NewWarningLogger(registry string, logger *slog.Logger) func(Warning) {
+	var seen sync.Map
+	return func(w Warning) {
+		if _, loaded := seen.LoadOrStore(w.WarningValue, struct{}{}); !loaded {
+			logger.Warn(w.Text, "registry", registry)
+		}
+	}
 }
 
 // parseWarningHeader parses the warning header into WarningValue.

--- a/registry/remote/warning_test.go
+++ b/registry/remote/warning_test.go
@@ -16,8 +16,12 @@ limitations under the License.
 package remote
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -154,5 +158,87 @@ func Test_parseWarningHeader(t *testing.T) {
 				t.Errorf("parseWarningHeader() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func makeTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+func warn(text string) Warning {
+	return Warning{WarningValue: WarningValue{Code: 299, Agent: "-", Text: text}}
+}
+
+func TestNewWarningLogger_LogsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	fn := NewWarningLogger("registry.example.com", makeTestLogger(&buf))
+
+	fn(warn("deprecated API"))
+	fn(warn("deprecated API")) // duplicate — must be suppressed
+
+	if got := strings.Count(buf.String(), "deprecated API"); got != 1 {
+		t.Errorf("expected 1 log line, got %d", got)
+	}
+}
+
+func TestNewWarningLogger_DifferentWarningsAllLogged(t *testing.T) {
+	var buf bytes.Buffer
+	fn := NewWarningLogger("registry.example.com", makeTestLogger(&buf))
+
+	fn(warn("first warning"))
+	fn(warn("second warning"))
+
+	out := buf.String()
+	if !strings.Contains(out, "first warning") {
+		t.Error("expected first warning to be logged")
+	}
+	if !strings.Contains(out, "second warning") {
+		t.Error("expected second warning to be logged")
+	}
+}
+
+func TestNewWarningLogger_IncludesRegistry(t *testing.T) {
+	var buf bytes.Buffer
+	fn := NewWarningLogger("myregistry.example.com", makeTestLogger(&buf))
+
+	fn(warn("some notice"))
+
+	if !strings.Contains(buf.String(), "myregistry.example.com") {
+		t.Error("expected registry name in log output")
+	}
+}
+
+func TestNewWarningLogger_IndependentInstances(t *testing.T) {
+	// Two loggers for the same registry must deduplicate independently —
+	// each has its own seen map, so both log the warning once.
+	var buf bytes.Buffer
+	logger := makeTestLogger(&buf)
+	fn1 := NewWarningLogger("registry.example.com", logger)
+	fn2 := NewWarningLogger("registry.example.com", logger)
+
+	fn1(warn("shared warning"))
+	fn2(warn("shared warning"))
+
+	if got := strings.Count(buf.String(), "shared warning"); got != 2 {
+		t.Errorf("expected 2 log lines (one per instance), got %d", got)
+	}
+}
+
+func TestNewWarningLogger_Concurrent(t *testing.T) {
+	var buf bytes.Buffer
+	fn := NewWarningLogger("registry.example.com", makeTestLogger(&buf))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fn(warn("concurrent warning"))
+		}()
+	}
+	wg.Wait()
+
+	if got := strings.Count(buf.String(), "concurrent warning"); got != 1 {
+		t.Errorf("expected exactly 1 log line despite concurrent calls, got %d", got)
 	}
 }


### PR DESCRIPTION
## What

Restructures `remote.Registry` / `remote.Repository` so that shared
configuration lives on the parent `Registry` and each `Repository` references
it via a new `Registry *Registry` pointer:

```go
repo.Registry.PlainHTTP = true
```

`Client`, `Reference`, `PlainHTTP`, `Policy`, the warning handler, and the
metadata limits move from `Repository` to `Registry`. `Repository` keeps
per-repository overrides (media types, page sizes, max pages, `SkipReferrersGC`)
and reads shared settings through unexported accessors (`client()`,
`plainHTTP()`, `policy()`, `handleWarning()`, `maxMetadataBytes()`).

`Repository.Reference` is now a **method** (`Reference()`), not a field.

## Why

This is the foundational layer of the v3 work in #1130, carved out as a
standalone, reviewable base. The mirror fallback, config-driven builder, and
signature verification features all build on this parent-`Registry` model, so
landing it on its own first keeps those follow-up PRs small and focused.

## Scope

Foundation only — deliberately **excludes** the pieces from #1130 that depend
on other in-flight PRs:

- `builder.go` (config-driven `ClientBuilder`) — depends on the config/properties work
- `mirror.go` and read-path fallback hooks — tracked in #1280
- signature verification — tracked in #1279

## Breaking change

`Repository.Client`, `Repository.PlainHTTP`, and related config fields are
removed; `Repository.Reference` becomes a method. Configure shared settings on
`Repository.Registry` instead.

## Testing

`go build ./...` and `go test ./...` pass (33 packages, no failures);
`gofmt`/`go vet` clean on all changed files.
