### PR TITLE
ci: enable minimal golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+      - v2
+  pull_request:
+    branches:
+      - main
+      - v2
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          check-latest: true
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.11.4
+        env:
+          GOFLAGS: -mod=mod

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - govet
+    - ineffassign
+
+run:
+  go: "1.25"

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ check-encoding:
 fix-encoding:
 	find . -not -path "./vendor/*" -name "*.go" -type f -exec sed -i -e "s/\r//g" {} +
 
+.PHONY: lint
+lint:
+	GOFLAGS=-mod=mod golangci-lint run
+
 .PHONY: vendor
 vendor:
 	go mod vendor

--- a/registry/remote/auth.go
+++ b/registry/remote/auth.go
@@ -33,26 +33,9 @@ var ErrClientTypeUnsupported = errors.New("client type not supported")
 // a client local to the function and will not modify the original client of
 // the registry.
 func Login(ctx context.Context, store credentials.Store, reg *Registry, cred credentials.Credential) error {
-	// create a clone of the original registry for login purpose. Use the
-	// repository clone helper so the embedded repository's mutex and pool are
-	// not copied.
-	repoClone := (*Repository)(&reg.RepositoryOptions).clone()
-	regClone := Registry{
-		RepositoryListPageSize: reg.RepositoryListPageSize,
-		RepositoryListMaxPages: reg.RepositoryListMaxPages,
-	}
-	regClone.Client = repoClone.Client
-	regClone.Reference = repoClone.Reference
-	regClone.PlainHTTP = repoClone.PlainHTTP
-	regClone.ManifestMediaTypes = repoClone.ManifestMediaTypes
-	regClone.TagListPageSize = repoClone.TagListPageSize
-	regClone.ReferrerListPageSize = repoClone.ReferrerListPageSize
-	regClone.TagListMaxPages = repoClone.TagListMaxPages
-	regClone.ReferrerListMaxPages = repoClone.ReferrerListMaxPages
-	regClone.MaxMetadataBytes = repoClone.MaxMetadataBytes
-	regClone.SkipReferrersGC = repoClone.SkipReferrersGC
-	regClone.HandleWarning = repoClone.HandleWarning
-	regClone.Policy = repoClone.Policy
+	// Registry only contains copyable configuration. Make a local copy so
+	// authentication changes do not modify the caller's registry.
+	regClone := *reg
 	// we use the original client if applicable, otherwise use a default client
 	var authClient auth.Client
 	if reg.Client == nil {

--- a/registry/remote/auth.go
+++ b/registry/remote/auth.go
@@ -33,8 +33,26 @@ var ErrClientTypeUnsupported = errors.New("client type not supported")
 // a client local to the function and will not modify the original client of
 // the registry.
 func Login(ctx context.Context, store credentials.Store, reg *Registry, cred credentials.Credential) error {
-	// create a clone of the original registry for login purpose
-	regClone := *reg
+	// create a clone of the original registry for login purpose. Use the
+	// repository clone helper so the embedded repository's mutex and pool are
+	// not copied.
+	repoClone := (*Repository)(&reg.RepositoryOptions).clone()
+	regClone := Registry{
+		RepositoryListPageSize: reg.RepositoryListPageSize,
+		RepositoryListMaxPages: reg.RepositoryListMaxPages,
+	}
+	regClone.Client = repoClone.Client
+	regClone.Reference = repoClone.Reference
+	regClone.PlainHTTP = repoClone.PlainHTTP
+	regClone.ManifestMediaTypes = repoClone.ManifestMediaTypes
+	regClone.TagListPageSize = repoClone.TagListPageSize
+	regClone.ReferrerListPageSize = repoClone.ReferrerListPageSize
+	regClone.TagListMaxPages = repoClone.TagListMaxPages
+	regClone.ReferrerListMaxPages = repoClone.ReferrerListMaxPages
+	regClone.MaxMetadataBytes = repoClone.MaxMetadataBytes
+	regClone.SkipReferrersGC = repoClone.SkipReferrersGC
+	regClone.HandleWarning = repoClone.HandleWarning
+	regClone.Policy = repoClone.Policy
 	// we use the original client if applicable, otherwise use a default client
 	var authClient auth.Client
 	if reg.Client == nil {


### PR DESCRIPTION
Implements the approved minimal golangci-lint setup from issue #1286.\n\n- adds the pinned v2 config with only govet and ineffassign\n- adds the requested main/v2 workflow coverage\n- adds the GOFLAGS=-mod=mod Makefile target\n- fixes the existing govet copylocks finding in registry/remote/auth.go by cloning repository fields without copying its mutex or merge pool\n\nValidation: gofmt, go vet ./registry/remote, go test ./registry/remote, and git diff --check pass on Windows.