### PR TITLE
feat: Issue Resolved # 1305

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.25'
           check-latest: true
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.11.4
         env:


### PR DESCRIPTION
## ci: pin GitHub Actions in lint.yml to commit digests

Closes #1305

### Description

`.github/workflows/lint.yml` was the only workflow in this repo still
referencing GitHub Actions by floating tag (`@v7`, `@v9`) instead of a
pinned commit digest. Every other workflow (`build.yml`,
`codeql-analysis.yml`, `license-checker.yml`, `release.yml`,
`stale.yml`) already pins to a full commit SHA with a trailing
`# vX.Y.Z` comment.

Tags are mutable — anyone who can push to the action's repo (or
anyone who compromises it) can move a tag to point at different code,
which then runs silently in CI with whatever token permissions the
job has. Pinning to an immutable commit SHA is the standard
mitigation, and it's what [OpenSSF Scorecard's `Pinned-Dependencies`
check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies),
[[SLSA](https://slsa.dev/)](https://slsa.dev/) build-integrity guidance, and
[GitHub's own security hardening
recommendation](https://docs.github.com/en/actions/security-for-github-actions/security-guidelines/security-hardening-for-github-actions#using-third-party-actions)
all ask for.

The trailing comment isn't cosmetic either: Dependabot's
`github-actions` ecosystem (already enabled in
`.github/dependabot.yml`) uses it to know which version a digest
corresponds to, so it can bump the SHA *and* rewrite the comment on
new releases. Left unpinned, `lint.yml` only gets tag-level updates
and misses out on digest tracking.

### Changes

- `actions/checkout@v7` → `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/setup-go@v7` → `actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0`
- `golangci/golangci-lint-action@v9` → `golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0`

No behavioral change — the resolved action versions are identical to
what the floating tags currently point to.

### Verification

- The `actions/checkout` and `actions/setup-go` digests are copied
  verbatim from `build.yml`, so `lint.yml` now agrees exactly with
  the rest of the repo's workflows.
- The `golangci-lint-action` digest was cross-checked against the
  action's [GitHub releases
  page](https://github.com/golangci/golangci-lint-action/releases) —
  `ba0d7d2` is the commit for the `v9.3.0` tag, the current tip of
  `v9` at the time of this PR.
- Confirmed `.github/workflows/lint.yml` still parses as valid YAML
  after the change.
- No `with:`, `env:`, or job-level config was touched — only the
  `uses:` lines.

### Type of change

- [x] CI / build tooling
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

### Checklist

- [x] I have read the contributing guidelines
- [x] My change requires no new tests (CI config only)
- [x] I have verified the digests against the upstream release/commit
      history for each action