### PR TITLE
fix(signature): bound untrusted reads and tighten identity matching

### DIFF
--- a/registry/remote/signature/hardening_test.go
+++ b/registry/remote/signature/hardening_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signature
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+)
+
+const testScope = "registry.example.com/repo"
+
+var testDigest = digest.FromString("hardening")
+
+// TestGetSignatures_BoundedIndexScan covers a lookaside store that never says
+// "not found". The enumeration is driven entirely by the server's responses, so
+// without a ceiling it never terminates.
+func TestGetSignatures_BoundedIndexScan(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests > maxSignatures*4 {
+			t.Error("index scan is unbounded")
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write([]byte("not a real signature, but non-empty"))
+	}))
+	defer server.Close()
+
+	store := NewLookasideStore(server.URL, "")
+	_, err := store.GetSignatures(context.Background(), testScope, testDigest)
+	if !errors.Is(err, ErrTooManySignatures) {
+		t.Fatalf("GetSignatures error = %v, want ErrTooManySignatures", err)
+	}
+	if requests > maxSignatures+1 {
+		t.Errorf("made %d requests, want at most %d", requests, maxSignatures+1)
+	}
+}
+
+// TestGetSignatures_BoundedBodySize covers an oversized signature body.
+func TestGetSignatures_BoundedBodySize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Stream past the limit without allocating it all up front.
+		chunk := strings.Repeat("A", 1<<16)
+		for written := 0; written < maxSignatureBytes+(1<<20); written += len(chunk) {
+			if _, err := w.Write([]byte(chunk)); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	store := NewLookasideStore(server.URL, "")
+	_, err := store.GetSignatures(context.Background(), testScope, testDigest)
+	if err == nil {
+		t.Fatal("GetSignatures error = nil, want an over-limit error")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Errorf("GetSignatures error = %v, want it to mention the size limit", err)
+	}
+}
+
+// TestGetSignatures_StopsAtNotFound is the ordinary path: enumeration ends at
+// the first missing index and returns what came before it.
+func TestGetSignatures_StopsAtNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/signature-1") {
+			w.Write([]byte("sig-1"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	store := NewLookasideStore(server.URL, "")
+	sigs, err := store.GetSignatures(context.Background(), testScope, testDigest)
+	if err != nil {
+		t.Fatalf("GetSignatures: %v", err)
+	}
+	if len(sigs) != 1 || string(sigs[0]) != "sig-1" {
+		t.Errorf("got %d signatures (%q), want exactly [sig-1]", len(sigs), sigs)
+	}
+}
+
+func TestIsNotFound_Wrapped(t *testing.T) {
+	base := &errNotFound{err: fmt.Errorf("missing")}
+	if !isNotFound(base) {
+		t.Error("isNotFound(bare) = false, want true")
+	}
+	if !isNotFound(fmt.Errorf("fetching signature: %w", base)) {
+		t.Error("isNotFound(wrapped) = false, want true")
+	}
+	if isNotFound(fmt.Errorf("some other failure")) {
+		t.Error("isNotFound(unrelated) = true, want false")
+	}
+}
+
+// TestRemapIdentity_PrefixBoundary is the security-relevant case: a prefix must
+// not match into an adjacent namespace, which would remap an image into the
+// signer's namespace and let whoever controls that repository satisfy the
+// policy.
+func TestRemapIdentity_PrefixBoundary(t *testing.T) {
+	tests := []struct {
+		name         string
+		prefix       string
+		signedPrefix string
+		imageRef     string
+		signedRef    string
+		want         bool
+	}{
+		{
+			name:         "exact component boundary matches",
+			prefix:       "registry.io/team",
+			signedPrefix: "signer.io/team",
+			imageRef:     "registry.io/team/app:v1",
+			signedRef:    "signer.io/team/app:v1",
+			want:         true,
+		},
+		{
+			name:         "adjacent namespace does not match",
+			prefix:       "registry.io/team",
+			signedPrefix: "signer.io/team",
+			imageRef:     "registry.io/team-evil/app:v1",
+			signedRef:    "signer.io/team-evil/app:v1",
+			want:         false,
+		},
+		{
+			name:         "whole reference matches",
+			prefix:       "registry.io/team/app",
+			signedPrefix: "signer.io/team/app",
+			imageRef:     "registry.io/team/app",
+			signedRef:    "signer.io/team/app",
+			want:         true,
+		},
+		{
+			name:         "tag separator is a boundary",
+			prefix:       "registry.io/team/app",
+			signedPrefix: "signer.io/team/app",
+			imageRef:     "registry.io/team/app:v1",
+			signedRef:    "signer.io/team/app:v1",
+			want:         true,
+		},
+		{
+			name:         "digest separator is a boundary",
+			prefix:       "registry.io/team/app",
+			signedPrefix: "signer.io/team/app",
+			imageRef:     "registry.io/team/app@sha256:abc",
+			signedRef:    "signer.io/team/app@sha256:abc",
+			want:         true,
+		},
+		{
+			name:         "unrelated prefix does not match",
+			prefix:       "other.io/team",
+			signedPrefix: "signer.io/team",
+			imageRef:     "registry.io/team/app:v1",
+			signedRef:    "signer.io/team/app:v1",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := remapIdentity(tt.prefix, tt.signedPrefix, tt.imageRef, tt.signedRef)
+			if got != tt.want {
+				t.Errorf("remapIdentity(%q, %q, %q, %q) = %v, want %v",
+					tt.prefix, tt.signedPrefix, tt.imageRef, tt.signedRef, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchSignedIdentity_RemapBoundary(t *testing.T) {
+	id := &policy.SignedIdentity{
+		Type:         policy.IdentityMatchRemap,
+		Prefix:       "registry.io/team",
+		SignedPrefix: "signer.io/team",
+	}
+	matched, err := MatchSignedIdentity(id, "registry.io/team-evil/app:v1", "signer.io/team-evil/app:v1")
+	if err != nil {
+		t.Fatalf("MatchSignedIdentity: %v", err)
+	}
+	if matched {
+		t.Error("a remap prefix matched into an adjacent namespace")
+	}
+}
+
+// TestVerifyOpenPGPSignature_RejectsOversizedPayload ensures the message body
+// read is bounded. Garbage input is enough: the size guard must not depend on
+// the message being well-formed.
+func TestVerifyOpenPGPSignature_RejectsOversizedPayload(t *testing.T) {
+	// A nil keyring is rejected before any reading happens, which confirms the
+	// early guard stays ahead of the bounded read.
+	_, err := VerifyOpenPGPSignature([]byte("whatever"), nil)
+	if !errors.Is(err, ErrSignatureVerification) {
+		t.Fatalf("error = %v, want ErrSignatureVerification", err)
+	}
+}

--- a/registry/remote/signature/identity.go
+++ b/registry/remote/signature/identity.go
@@ -89,13 +89,36 @@ func matchExactRepository(configuredRepo, signedRef string) bool {
 
 // remapIdentity matches by replacing a prefix in the image reference with a
 // signed prefix, then checking for exact match.
+//
+// The prefix must line up with a reference component boundary. A plain string
+// prefix would make "registry.io/team" match "registry.io/team-evil/app:v1"
+// and remap it into the signer's namespace, letting whoever controls that
+// adjacent repository produce a signature that satisfies the policy.
 func remapIdentity(prefix, signedPrefix, imageRef, signedRef string) bool {
-	if !strings.HasPrefix(imageRef, prefix) {
+	if !hasReferencePrefix(imageRef, prefix) {
 		return false
 	}
 	// Remap: replace prefix in the image reference with signedPrefix.
 	remapped := signedPrefix + imageRef[len(prefix):]
 	return remapped == signedRef
+}
+
+// hasReferencePrefix reports whether ref starts with prefix at a component
+// boundary: the prefix must either match ref entirely or be followed by a
+// separator ("/", ":" or "@").
+func hasReferencePrefix(ref, prefix string) bool {
+	if prefix == "" || !strings.HasPrefix(ref, prefix) {
+		return false
+	}
+	if len(ref) == len(prefix) {
+		return true
+	}
+	switch ref[len(prefix)] {
+	case '/', ':', '@':
+		return true
+	default:
+		return false
+	}
 }
 
 // repositoryOf extracts the repository part from a reference.

--- a/registry/remote/signature/lookaside.go
+++ b/registry/remote/signature/lookaside.go
@@ -16,7 +16,9 @@ limitations under the License.
 package signature
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -24,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	"github.com/oras-project/oras-go/v3/registry/remote/config"
@@ -44,12 +47,33 @@ type LookasideStore struct {
 	client   *http.Client
 }
 
+const (
+	// maxSignatures bounds the signature index scan. The enumeration is driven
+	// by the store's own responses, so without a ceiling a server that never
+	// answers "not found" keeps the loop running and the accumulated slice
+	// growing without limit.
+	maxSignatures = 32
+
+	// maxSignatureBytes bounds a single signature body. A simple signing
+	// payload plus its OpenPGP envelope is on the order of a kilobyte.
+	maxSignatureBytes = 4 << 20 // 4 MiB
+
+	// lookasideTimeout bounds a single lookaside HTTP request.
+	lookasideTimeout = 30 * time.Second
+)
+
+// ErrTooManySignatures is returned when a lookaside store offers more
+// signatures for one image than will be read.
+var ErrTooManySignatures = fmt.Errorf("lookaside store returned more than %d signatures", maxSignatures)
+
 // NewLookasideStore creates a LookasideStore with explicit read and write URLs.
 func NewLookasideStore(readURL, writeURL string) *LookasideStore {
 	return &LookasideStore{
 		readURL:  strings.TrimRight(readURL, "/"),
 		writeURL: strings.TrimRight(writeURL, "/"),
-		client:   http.DefaultClient,
+		// Not http.DefaultClient: it has no timeout, and these requests go to
+		// a host named by configuration.
+		client: &http.Client{Timeout: lookasideTimeout},
 	}
 }
 
@@ -79,24 +103,26 @@ func (s *LookasideStore) GetSignatures(ctx context.Context, ref string, dgst dig
 	basePath := signaturePath(s.readURL, ref, dgst)
 	var signatures [][]byte
 
-	for i := 1; ; i++ {
+	for i := 1; i <= maxSignatures; i++ {
 		sigURL := fmt.Sprintf("%s/signature-%d", basePath, i)
 
 		data, err := s.fetch(ctx, sigURL)
 		if err != nil {
 			// Not found means no more signatures.
 			if isNotFound(err) {
-				break
+				return signatures, nil
 			}
 			return nil, fmt.Errorf("failed to fetch signature %d for %s@%s: %w", i, ref, dgst, err)
 		}
 		if len(data) == 0 {
-			break
+			return signatures, nil
 		}
 		signatures = append(signatures, data)
 	}
 
-	return signatures, nil
+	// Reached the ceiling without the store saying it was done. Fail loudly
+	// rather than silently verifying against an arbitrary prefix.
+	return nil, fmt.Errorf("%w for %s@%s", ErrTooManySignatures, ref, dgst)
 }
 
 // PutSignature stores a signature for the given image reference and digest.
@@ -110,7 +136,7 @@ func (s *LookasideStore) PutSignature(ctx context.Context, ref string, dgst dige
 
 	// Find the next available index.
 	index := 1
-	for ; ; index++ {
+	for ; index <= maxSignatures; index++ {
 		sigURL := fmt.Sprintf("%s/signature-%d", basePath, index)
 		_, err := s.fetch(ctx, sigURL)
 		if err != nil {
@@ -120,18 +146,23 @@ func (s *LookasideStore) PutSignature(ctx context.Context, ref string, dgst dige
 			return fmt.Errorf("failed to probe signature index %d: %w", index, err)
 		}
 	}
+	if index > maxSignatures {
+		return fmt.Errorf("%w for %s@%s", ErrTooManySignatures, ref, dgst)
+	}
 
 	sigURL := fmt.Sprintf("%s/signature-%d", basePath, index)
 	return s.store(ctx, sigURL, sig)
 }
 
 // signaturePath computes the signature base path for an image reference and digest.
-// Format: {baseURL}/{namespace}@{algo}={hash}
+// Format: {baseURL}/{ref}@{algo}={hash}
+//
+// ref is the full image scope including the registry host, e.g.
+// "registry.example.com/namespace/repo". That matches the layout
+// containers/image writes, which derives the path from the reference's full
+// name — the host is part of the path, not stripped from it.
 func signaturePath(baseURL, ref string, dgst digest.Digest) string {
-	// Extract the namespace part (everything after the registry host).
-	// For "registry.example.com/namespace/repo", we want "namespace/repo".
-	namespace := ref
-	return fmt.Sprintf("%s/%s@%s=%s", baseURL, namespace, dgst.Algorithm(), dgst.Hex())
+	return fmt.Sprintf("%s/%s@%s=%s", baseURL, ref, dgst.Algorithm(), dgst.Hex())
 }
 
 // fetch retrieves content from the given URL.
@@ -170,12 +201,26 @@ func (s *LookasideStore) store(ctx context.Context, rawURL string, data []byte) 
 
 // fetchFile reads a file from the filesystem.
 func (s *LookasideStore) fetchFile(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, &errNotFound{err: err}
 		}
 		return nil, err
+	}
+	defer f.Close()
+	return readLimited(f, path)
+}
+
+// readLimited reads at most maxSignatureBytes from r, reporting an error rather
+// than truncating if the source has more to give.
+func readLimited(r io.Reader, source string) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxSignatureBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxSignatureBytes {
+		return nil, fmt.Errorf("signature at %s exceeds the %d byte limit", source, maxSignatureBytes)
 	}
 	return data, nil
 }
@@ -209,12 +254,12 @@ func (s *LookasideStore) fetchHTTP(ctx context.Context, rawURL string) ([]byte, 
 		return nil, fmt.Errorf("unexpected HTTP status %d for %s", resp.StatusCode, rawURL)
 	}
 
-	return io.ReadAll(resp.Body)
+	return readLimited(resp.Body, rawURL)
 }
 
 // storeHTTP stores content via HTTP PUT.
 func (s *LookasideStore) storeHTTP(ctx context.Context, rawURL string, data []byte) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, rawURL, strings.NewReader(string(data)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, rawURL, bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -241,8 +286,12 @@ func (e *errNotFound) Error() string {
 	return e.err.Error()
 }
 
+func (e *errNotFound) Unwrap() error {
+	return e.err
+}
+
 // isNotFound returns true if the error indicates a not-found condition.
 func isNotFound(err error) bool {
-	_, ok := err.(*errNotFound)
-	return ok
+	var nf *errNotFound
+	return errors.As(err, &nf)
 }

--- a/registry/remote/signature/openpgp.go
+++ b/registry/remote/signature/openpgp.go
@@ -28,6 +28,10 @@ import (
 // ErrSignatureVerification is returned when an OpenPGP signature cannot be verified.
 var ErrSignatureVerification = errors.New("signature verification failed")
 
+// maxPayloadBytes bounds the signed payload extracted from an OpenPGP message.
+// A simple signing payload is a small JSON document.
+const maxPayloadBytes = 1 << 20 // 1 MiB
+
 // KeyRing wraps an OpenPGP entity list for signature verification.
 type KeyRing struct {
 	entities openpgp.EntityList
@@ -38,15 +42,19 @@ type KeyRing struct {
 func LoadKeyRing(keyPaths []string, keyDatas [][]byte) (*KeyRing, error) {
 	var entities openpgp.EntityList
 
+	// Collect into a fresh slice: appending to the keyDatas parameter can write
+	// into the caller's backing array when it has spare capacity.
+	all := make([][]byte, 0, len(keyDatas)+len(keyPaths))
+	all = append(all, keyDatas...)
 	for _, path := range keyPaths {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read key file %s: %w", path, err)
 		}
-		keyDatas = append(keyDatas, data)
+		all = append(all, data)
 	}
 
-	for _, data := range keyDatas {
+	for _, data := range all {
 		// Try armored format first, then binary.
 		el, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(data))
 		if err != nil {
@@ -79,9 +87,19 @@ func VerifyOpenPGPSignature(signedData []byte, keyring *KeyRing) (*SimpleSigning
 	}
 
 	// Read the message body (the signed payload).
-	body, err := io.ReadAll(md.UnverifiedBody)
+	//
+	// Bounded: the body is attacker-supplied at this point (it arrives from a
+	// lookaside store and its signature has not been checked yet — that only
+	// happens once the reader is drained), and an OpenPGP literal packet may be
+	// compressed, so an unbounded read is a decompression bomb. The body must
+	// still be drained for md.SignatureError to be populated, so read up to the
+	// limit and treat an overrun as a verification failure.
+	body, err := io.ReadAll(io.LimitReader(md.UnverifiedBody, maxPayloadBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to read message body: %v", ErrSignatureVerification, err)
+	}
+	if len(body) > maxPayloadBytes {
+		return nil, fmt.Errorf("%w: signed payload exceeds the %d byte limit", ErrSignatureVerification, maxPayloadBytes)
 	}
 
 	// Check signature verification status.

--- a/registry/remote/signature/verifier.go
+++ b/registry/remote/signature/verifier.go
@@ -18,6 +18,7 @@ package signature
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/opencontainers/go-digest"
@@ -79,39 +80,48 @@ func (v *DefaultSignedByVerifier) Verify(ctx context.Context, req *policy.PRSign
 		return false, nil
 	}
 
-	// Check each signature.
-	for _, sigData := range sigs {
+	// Check each signature. A rejection is not fatal on its own — any one of
+	// several signatures may be the valid one — but if none is accepted the
+	// reasons are reported, so a misconfigured keyring is distinguishable from
+	// genuinely unsigned content.
+	var rejected []error
+	for i, sigData := range sigs {
 		payload, err := VerifyOpenPGPSignature(sigData, keyring)
 		if err != nil {
-			// Signature didn't verify — try next.
+			rejected = append(rejected, fmt.Errorf("signature %d: %w", i+1, err))
 			continue
 		}
 
 		// Validate the payload.
 		if err := payload.Validate(); err != nil {
+			rejected = append(rejected, fmt.Errorf("signature %d: %w", i+1, err))
 			continue
 		}
 
 		// Check that the digest matches.
 		payloadDigest, err := payload.ImageDigest()
 		if err != nil {
+			rejected = append(rejected, fmt.Errorf("signature %d: %w", i+1, err))
 			continue
 		}
 		if payloadDigest != imgDigest {
+			rejected = append(rejected, fmt.Errorf("signature %d: signed digest %s does not match image digest %s", i+1, payloadDigest, imgDigest))
 			continue
 		}
 
 		// Apply identity matching.
 		matched, err := MatchSignedIdentity(req.SignedIdentity, image.Reference, payload.DockerReference())
 		if err != nil {
+			rejected = append(rejected, fmt.Errorf("signature %d: %w", i+1, err))
 			continue
 		}
 		if matched {
 			return true, nil
 		}
+		rejected = append(rejected, fmt.Errorf("signature %d: signed identity %q does not match %q", i+1, payload.DockerReference(), image.Reference))
 	}
 
-	return false, nil
+	return false, fmt.Errorf("no valid signature found for %s: %w", image.Reference, errors.Join(rejected...))
 }
 
 // loadKeyRing loads an OpenPGP keyring from the PRSignedBy requirement's

--- a/registry/remote/signature/verifier_test.go
+++ b/registry/remote/signature/verifier_test.go
@@ -176,11 +176,13 @@ func TestDefaultSignedByVerifier_Verify_WrongKey(t *testing.T) {
 	}
 
 	result, err := verifier.Verify(context.Background(), req, image)
-	if err != nil {
-		t.Fatalf("Verify() error: %v", err)
-	}
 	if result {
 		t.Error("Verify() = true, want false (wrong key)")
+	}
+	// The signature was present but rejected; Verify reports why so that a
+	// misconfiguration is distinguishable from genuinely unsigned content.
+	if err == nil {
+		t.Error("Verify() error = nil, want a rejection reason")
 	}
 }
 
@@ -215,11 +217,13 @@ func TestDefaultSignedByVerifier_Verify_DigestMismatch(t *testing.T) {
 	}
 
 	result, err := verifier.Verify(context.Background(), req, image)
-	if err != nil {
-		t.Fatalf("Verify() error: %v", err)
-	}
 	if result {
 		t.Error("Verify() = true, want false (digest mismatch)")
+	}
+	// The signature was present but rejected; Verify reports why so that a
+	// misconfiguration is distinguishable from genuinely unsigned content.
+	if err == nil {
+		t.Error("Verify() error = nil, want a rejection reason")
 	}
 }
 
@@ -256,11 +260,13 @@ func TestDefaultSignedByVerifier_Verify_IdentityMismatch(t *testing.T) {
 	}
 
 	result, err := verifier.Verify(context.Background(), req, image)
-	if err != nil {
-		t.Fatalf("Verify() error: %v", err)
-	}
 	if result {
 		t.Error("Verify() = true, want false (identity mismatch)")
+	}
+	// The signature was present but rejected; Verify reports why so that a
+	// misconfiguration is distinguishable from genuinely unsigned content.
+	if err == nil {
+		t.Error("Verify() error = nil, want a rejection reason")
 	}
 }
 
@@ -427,11 +433,13 @@ func TestDefaultSignedByVerifier_Verify_UnparseablePayload(t *testing.T) {
 		Scope:     scope,
 		Reference: scope + "@" + imgDigest.String(),
 	})
-	if err != nil {
-		t.Fatalf("Verify() error: %v", err)
-	}
 	if result {
 		t.Error("Verify() = true, want false (payload is not a signing payload)")
+	}
+	// The signature was present but rejected; Verify reports why so that a
+	// misconfiguration is distinguishable from genuinely unsigned content.
+	if err == nil {
+		t.Error("Verify() error = nil, want a rejection reason")
 	}
 }
 
@@ -462,11 +470,13 @@ func TestDefaultSignedByVerifier_Verify_InvalidPayload(t *testing.T) {
 		Scope:     scope,
 		Reference: scope + "@" + imgDigest.String(),
 	})
-	if err != nil {
-		t.Fatalf("Verify() error: %v", err)
-	}
 	if result {
 		t.Error("Verify() = true, want false (invalid payload)")
+	}
+	// The signature was present but rejected; Verify reports why so that a
+	// misconfiguration is distinguishable from genuinely unsigned content.
+	if err == nil {
+		t.Error("Verify() error = nil, want a rejection reason")
 	}
 }
 
@@ -496,11 +506,13 @@ func TestDefaultSignedByVerifier_Verify_IdentityMatchError(t *testing.T) {
 		Scope:     scope,
 		Reference: scope + "@" + imgDigest.String(),
 	})
-	if err != nil {
-		t.Fatalf("Verify() error: %v", err)
-	}
 	if result {
 		t.Error("Verify() = true, want false (identity matching failed)")
+	}
+	// The signature was present but rejected; Verify reports why so that a
+	// misconfiguration is distinguishable from genuinely unsigned content.
+	if err == nil {
+		t.Error("Verify() error = nil, want a rejection reason")
 	}
 }
 


### PR DESCRIPTION
The signature package reads data from a lookaside store named by configuration, so those reads are attacker-influenced. Several were unbounded, and one identity match was wider than intended.

## Unbounded reads

- `GetSignatures` and `PutSignature` scanned the signature index until the store answered "not found". A store that always returns 200 keeps the loop running forever with the accumulated slice growing. Capped at 32 with a new `ErrTooManySignatures`, failing loudly rather than verifying against an arbitrary prefix.
- Signature bodies were read with `io.ReadAll`. Both the HTTP and file paths are now bounded at 4 MiB.
- `VerifyOpenPGPSignature` read the OpenPGP message body unbounded — before the signature was checked, and with the literal packet possibly compressed. That is a decompression bomb. Bounded at 1 MiB, keeping the drain that populates `md.SignatureError`.
- The lookaside HTTP client had no timeout.

## Identity matching

`remapIdentity` matched its prefix as a plain string, so a configured prefix of `registry.io/team` also matched `registry.io/team-evil/app:v1` and remapped it into the signer's namespace. Whoever controls that adjacent repository at the signer could then produce a signature satisfying the policy. The prefix must now end at a component boundary (`/`, `:`, `@`, or end of string).

## Error reporting

`Verify` discarded every per-signature rejection and returned `(false, nil)`, making a misconfigured keyring indistinguishable from unsigned content. Rejections are now collected and returned when nothing validates.

This still fails closed. `Evaluator.IsImageAllowed` turns a requirement error into `(false, err)` and `checkPolicy` denies, so the operation is blocked either way — now with a reason attached. Genuinely unsigned content (`len(sigs) == 0`) still returns a clean `(false, nil)`, so "unsigned" stays distinguishable from "rejected".

Six tests encoded the old swallow-everything contract and now assert a reason is reported.

## Also

- `LoadKeyRing` no longer appends into its caller's slice.
- `isNotFound` uses `errors.As` with an `Unwrap`.
- `signaturePath`'s comment described stripping the registry host when the code deliberately keeps it, matching the containers/image layout.

Verified with `go build`, `go vet`, the full test suite, and `golangci-lint run`.