### PR TITLE
fix(remote): correct mirror fallback semantics

### DIFF
--- a/registry/remote/mirror.go
+++ b/registry/remote/mirror.go
@@ -17,6 +17,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
@@ -102,7 +103,10 @@ func isMirrorFallbackError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return err != context.Canceled && err != context.DeadlineExceeded
+	// errors.Is, not ==: the transport wraps context errors, so a comparison
+	// against the sentinels would miss a cancelled context and go on to try
+	// every remaining mirror and then the primary.
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 // withMirrorFallbackResolve tries to resolve the reference against each
@@ -196,7 +200,14 @@ func withMirrorFallbackExists(
 		}
 		ok, err := exists(ctx, mirrors[i].Repository, target)
 		if err == nil {
-			return ok, nil
+			// Only a positive result is authoritative. A mirror that does not
+			// have the content says nothing about the primary, so keep
+			// looking; treating "absent here" as "absent everywhere" would
+			// report content that exists as missing.
+			if ok {
+				return true, nil
+			}
+			continue
 		}
 		if !isMirrorFallbackError(err) {
 			return false, err

--- a/registry/remote/mirror_isolation_test.go
+++ b/registry/remote/mirror_isolation_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Test_withMirrorFallbackExists_mirrorMissing_fallsToPrimary covers a mirror
+// that answers authoritatively "not here". That is not an error, so the
+// fallback loop has to distinguish it from a hit: content present on the
+// primary but absent from the mirror must still be reported as existing.
+func Test_withMirrorFallbackExists_mirrorMissing_fallsToPrimary(t *testing.T) {
+	content := []byte("only on the primary")
+	contentDigest := digest.FromBytes(content)
+
+	// Mirror has nothing: HEAD 404 makes Exists return (false, nil).
+	mirrorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer mirrorServer.Close()
+
+	primaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Docker-Content-Digest", contentDigest.String())
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer primaryServer.Close()
+
+	mirrors := []mirrorRepository{
+		{Repository: repoFromServer(t, mirrorServer), pullFromMirror: PullFromMirrorAll},
+	}
+	primaryRepo := repoFromServer(t, primaryServer)
+
+	target := ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    contentDigest,
+		Size:      int64(len(content)),
+	}
+
+	ok, err := withMirrorFallbackExists(context.Background(), mirrors, primaryRepo, target,
+		func(ctx context.Context, repo *Repository, t ocispec.Descriptor) (bool, error) {
+			return repo.blobStore(t).Exists(ctx, t)
+		})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !ok {
+		t.Error("content exists on the primary but Exists reported false after the mirror missed")
+	}
+}
+
+// Test_withMirrorFallbackExists_allMiss reports false only once every mirror
+// and the primary have been consulted.
+func Test_withMirrorFallbackExists_allMiss(t *testing.T) {
+	notFound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer notFound.Close()
+
+	primaryHits := 0
+	primaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryHits++
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer primaryServer.Close()
+
+	mirrors := []mirrorRepository{
+		{Repository: repoFromServer(t, notFound), pullFromMirror: PullFromMirrorAll},
+	}
+
+	target := ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    digest.FromBytes([]byte("nowhere")),
+		Size:      7,
+	}
+
+	ok, err := withMirrorFallbackExists(context.Background(), mirrors, repoFromServer(t, primaryServer), target,
+		func(ctx context.Context, repo *Repository, t ocispec.Descriptor) (bool, error) {
+			return repo.blobStore(t).Exists(ctx, t)
+		})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if ok {
+		t.Error("expected exists to return false")
+	}
+	if primaryHits == 0 {
+		t.Error("primary was never consulted after the mirror missed")
+	}
+}
+
+func Test_isMirrorFallbackError_wrappedContextErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// The transport wraps context errors before they reach us, so the
+		// bare-sentinel cases are not representative on their own.
+		{"wrapped canceled", fmt.Errorf("Get %q: %w", "http://x/v2/", context.Canceled), false},
+		{"wrapped deadline", fmt.Errorf("Get %q: %w", "http://x/v2/", context.DeadlineExceeded), false},
+		{"doubly wrapped canceled", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", context.Canceled)), false},
+		{"wrapped generic", fmt.Errorf("outer: %w", fmt.Errorf("connection refused")), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMirrorFallbackError(tt.err); got != tt.want {
+				t.Errorf("isMirrorFallbackError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two bugs in the mirror read-fallback path.

## `Exists` reports missing content that exists

`withMirrorFallbackExists` treated a mirror's `(false, nil)` as authoritative:

```go
ok, err := exists(ctx, mirrors[i].Repository, target)
if err == nil {
    return ok, nil   // returns false without consulting the primary
}
```

A mirror answering "I don't have it" is not an error, so this returned `false` and the primary was never asked. Content present on the primary but absent from a mirror was reported as non-existent.

Only a positive result now ends the search; a miss continues to the next mirror and then the primary.

## Cancelled contexts walk every mirror

`isMirrorFallbackError` compared against the sentinels with `==`:

```go
return err != context.Canceled && err != context.DeadlineExceeded
```

The transport wraps context errors, so these comparisons never matched in practice and a cancelled context still tried every remaining mirror before failing. Now uses `errors.Is`.

The existing test only covered bare sentinels, which is why this survived; the new test covers wrapped and doubly-wrapped errors.

Verified with `go build`, `go vet`, the full test suite, and `golangci-lint run`.