### PR TITLE
fix(credentials)!: stop persisting the detected credentials store

### DIFF
--- a/registry/remote/credentials/store.go
+++ b/registry/remote/credentials/store.go
@@ -25,8 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/oras-project/oras-go/v3/internal/syncutil"
 )
 
 // ConfigFile is the interface for a Docker configuration file that provides
@@ -48,14 +46,10 @@ type ConfigFile interface {
 	GetCredentialHelper(serverAddress string) string
 	// CredentialsStore returns the configured credentials store name.
 	CredentialsStore() string
-	// SetCredentialsStore sets the credentials store name.
-	SetCredentialsStore(credsStore string)
 	// IsAuthConfigured returns true if any authentication is configured.
 	IsAuthConfigured() bool
 	// Path returns the path to the config file.
 	Path() string
-	// Save saves the config file.
-	Save() error
 }
 
 // ConfigFileLoader is a function that loads a ConfigFile from a path.
@@ -83,7 +77,6 @@ type DynamicStore struct {
 	config             ConfigFile
 	options            StoreOptions
 	detectedCredsStore string
-	setCredsStoreOnce  syncutil.OnceOrRetry
 }
 
 // StoreOptions provides options for NewStore.
@@ -200,20 +193,15 @@ func (ds *DynamicStore) Get(ctx context.Context, serverAddress string) (Credenti
 // Put saves credentials into the store for the given server address.
 // Put returns ErrPlaintextPutDisabled if native store is not available and
 // [StoreOptions].AllowPlaintextPut is set to false.
+//
+// A detected native store is used for this store's own operations only; it is
+// deliberately not written back to the config file. Persisting it would edit a
+// file this library does not own — one shared with the Docker CLI and every
+// other tool that reads it — as a side effect of saving one credential, and
+// would change their behaviour too. Callers that want the setting recorded
+// should write it themselves.
 func (ds *DynamicStore) Put(ctx context.Context, serverAddress string, cred Credential) error {
-	if err := ds.getStore(serverAddress).Put(ctx, serverAddress, cred); err != nil {
-		return err
-	}
-	// save the detected creds store back to the config file on first put
-	return ds.setCredsStoreOnce.Do(func() error {
-		if ds.detectedCredsStore != "" {
-			ds.config.SetCredentialsStore(ds.detectedCredsStore)
-			if err := ds.config.Save(); err != nil {
-				return fmt.Errorf("failed to save config with credsStore: %w", err)
-			}
-		}
-		return nil
-	})
+	return ds.getStore(serverAddress).Put(ctx, serverAddress, cred)
 }
 
 // Delete removes credentials from the store for the given server address.

--- a/registry/remote/credentials/store_test.go
+++ b/registry/remote/credentials/store_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package credentials
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -477,9 +478,19 @@ func Test_DynamicStore_noAuthConfigured(t *testing.T) {
 		t.Fatal("DynamicStore.Put() error =", err)
 	}
 
-	// Put() should set the detected store back to config
-	if got := ds.config.CredentialsStore(); got != ds.detectedCredsStore {
-		t.Errorf("ds.config.CredentialsStore() = %v, want %v", got, ds.detectedCredsStore)
+	// Put() must not write the detected store back to the config file. The
+	// detected value governs this store's own behaviour only; persisting it
+	// would edit a file shared with the Docker CLI and change its behaviour
+	// too, as a side effect of saving one credential.
+	if got := ds.config.CredentialsStore(); got != "" {
+		t.Errorf("ds.config.CredentialsStore() = %v, want empty (Put must not persist the detected store)", got)
+	}
+	configAfter, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	if bytes.Contains(configAfter, []byte("credsStore")) {
+		t.Errorf("config file gained a credsStore entry after Put: %s", configAfter)
 	}
 
 	// test get


### PR DESCRIPTION
On the first successful `Put`, `DynamicStore` wrote the detected native helper into the user's `~/.docker/config.json` and saved the file:

```go
return ds.setCredsStoreOnce.Do(func() error {
    if ds.detectedCredsStore != "" {
        ds.config.SetCredentialsStore(ds.detectedCredsStore)
        if err := ds.config.Save(); err != nil { ... }
    }
    return nil
})
```

That edits a file this library does not own — shared with the Docker CLI and every other tool that reads it — as a side effect of saving one credential. And because `credsStore` is a global setting, it changed *their* behaviour too, not just ours.

The write also bought nothing locally: `detectedCredsStore` is consulted directly by `getStore`, so detection works without persisting anything. The write only exported the decision to other tools.

**Detection itself is unchanged and stays on by default.** The `!cfg.IsAuthConfigured()` guard already limits it to config files with no auth at all, so users with existing credentials there are unaffected.

## Breaking change

`SetCredentialsStore` and `Save` are removed from the `credentials.ConfigFile` interface. They were used only by the removed block — `PutAuthConfig` and `DeleteAuthConfig` call `saveFile()` internally, so the plaintext file store never needed them. The interface goes from 10 methods to 8.

`Test_DynamicStore_noAuthConfigured` asserted the old behaviour and now asserts the opposite, reading the config file back from disk to confirm no `credsStore` key appears — the file being the thing that was previously modified.

Verified with `go build`, `go vet`, the full test suite, and `golangci-lint run`.