### PR TITLE
refactor(config)!: remove the dead force-basic-auth option

### DIFF
--- a/registry/remote/config/properties.go
+++ b/registry/remote/config/properties.go
@@ -75,10 +75,6 @@ func NewRegistryProperties(ref string, regConf *RegistriesConfig) (*properties.R
 			props.Transport.Insecure = true
 		}
 
-		if origReg.ForceBasicAuth {
-			props.Attributes.ForceBasicAuth = true
-		}
-
 		switch origReg.ReferrersAPI {
 		case "supported":
 			props.Attributes.ReferrersAPI = properties.ReferrersAPISupported

--- a/registry/remote/config/properties_test.go
+++ b/registry/remote/config/properties_test.go
@@ -379,31 +379,6 @@ func TestNewRegistryProperties_MirrorByDigestOnlyDefault(t *testing.T) {
 	}
 }
 
-func TestNewRegistryProperties_ForceBasicAuth(t *testing.T) {
-	config := &RegistriesConfig{
-		Registries: []Registry{
-			{Prefix: "basic-auth.example.com", ForceBasicAuth: true},
-			{Prefix: "normal.example.com"},
-		},
-		Aliases: map[string]string{},
-	}
-
-	props, err := NewRegistryProperties("basic-auth.example.com/image:v1", config)
-	if err != nil {
-		t.Fatalf("NewRegistryProperties() unexpected error: %v", err)
-	}
-	if !props.Attributes.ForceBasicAuth {
-		t.Error("Attributes.ForceBasicAuth should be true")
-	}
-
-	props, err = NewRegistryProperties("normal.example.com/image:v1", config)
-	if err != nil {
-		t.Fatalf("NewRegistryProperties() unexpected error: %v", err)
-	}
-	if props.Attributes.ForceBasicAuth {
-		t.Error("Attributes.ForceBasicAuth should be false for normal registry")
-	}
-}
 
 func TestNewRegistryProperties_ReferrersAPI(t *testing.T) {
 	config := &RegistriesConfig{

--- a/registry/remote/config/registries.go
+++ b/registry/remote/config/registries.go
@@ -53,12 +53,6 @@ type Registry struct {
 	Mirrors []Mirror `toml:"mirror"`
 	// MirrorByDigestOnly restricts mirrors to digest-based pulls only.
 	MirrorByDigestOnly bool `toml:"mirror-by-digest-only"`
-	// ForceBasicAuth forces HTTP Basic authentication regardless of what the
-	// registry advertises. When true, if the registry challenges with Bearer
-	// auth the client will use Basic auth instead. Requires the registry to
-	// also accept Basic auth credentials. This is an ORAS-specific field and
-	// may be ignored by other tools that parse registries.conf.
-	ForceBasicAuth bool `toml:"force-basic-auth"`
 	// ReferrersAPI indicates whether the registry supports the OCI Referrers
 	// API. Valid values: "supported", "unsupported". An empty or unrecognized
 	// value defaults to auto-detection on first use. This is an ORAS-specific

--- a/registry/remote/config/registries_test.go
+++ b/registry/remote/config/registries_test.go
@@ -170,10 +170,6 @@ location = "mirror.example.com"
 			name: "config with oras-specific attributes",
 			content: `
 [[registry]]
-prefix = "basic-auth.example.com"
-force-basic-auth = true
-
-[[registry]]
 prefix = "referrers-supported.example.com"
 referrers-api = "supported"
 
@@ -183,10 +179,6 @@ referrers-api = "unsupported"
 `,
 			want: &RegistriesConfig{
 				Registries: []Registry{
-					{
-						Prefix:         "basic-auth.example.com",
-						ForceBasicAuth: true,
-					},
 					{
 						Prefix:       "referrers-supported.example.com",
 						ReferrersAPI: "supported",

--- a/registry/remote/properties/attributes.go
+++ b/registry/remote/properties/attributes.go
@@ -46,11 +46,4 @@ type Attributes struct {
 	// - ReferrersAPIUnsupported: the registry does not support the Referrers API
 	// - ReferrersAPIUnknown: the capability is unknown and will be auto-detected
 	ReferrersAPI ReferrersAPI
-
-	// ForceBasicAuth forces the client to use HTTP Basic authentication
-	// regardless of what authentication scheme the registry advertises.
-	// When true, if the registry challenges with Bearer auth, the client
-	// will use Basic auth instead. This requires the registry to also
-	// accept Basic auth credentials.
-	ForceBasicAuth bool
 }


### PR DESCRIPTION
`force-basic-auth` is parsed from registries.conf into `properties.Attributes.ForceBasicAuth`, and nothing reads it:

```
$ git grep -n ForceBasicAuth -- '*.go' | grep -v _test
registry/remote/config/properties.go:78:  if origReg.ForceBasicAuth {
registry/remote/config/properties.go:79:      props.Attributes.ForceBasicAuth = true
registry/remote/config/registries.go:61:  ForceBasicAuth bool `toml:"force-basic-auth"`
registry/remote/properties/attributes.go:55: ForceBasicAuth bool
```

Parse, store, and no consumer. Setting `force-basic-auth = true` today succeeds and silently does nothing, which is worse than not offering the option: it promises an authentication behaviour the library does not implement, and a user relying on it has no way to notice.

Beyond being unimplemented, it is the wrong thing to configure. The authentication scheme follows the registry's `WWW-Authenticate` challenge; a client overriding a Bearer challenge with Basic is working against the registry rather than with it.

What *is* worth configuring is how a bearer token is acquired for username/password credentials — the distribution-spec `GET` versus the OAuth2 password grant, which is a Docker extension rather than part of the OCI spec, and which not every registry implements. That option arrives together with the `ClientBuilder` that will consume it, rather than landing here as another unread field.

## Breaking change

The `force-basic-auth` registries.conf field and `properties.Attributes.ForceBasicAuth` are removed. Since nothing consumed either, no behaviour changes — configurations setting it were already no-ops.

Verified with `go build`, `go vet`, the full test suite, and `golangci-lint run`.