### PR TITLE
refactor(remote): remove unreachable ErrReferrersCapabilityAlreadySet

### DIFF
--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -46,11 +46,6 @@ type referrerChange struct {
 }
 
 var (
-	// ErrReferrersCapabilityAlreadySet is reserved to signal that the referrers
-	// capability of a repository has already been set to a conflicting value.
-	// The capability is fixed once set; the first value wins.
-	ErrReferrersCapabilityAlreadySet = errors.New("referrers capability cannot be changed once set")
-
 	// errNoReferrerUpdate is returned by applyReferrerChanges() when there
 	// is no any referrer update.
 	errNoReferrerUpdate = errors.New("no referrer update")

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -336,9 +336,11 @@ func (r *Repository) skipReferrersGC() bool {
 // SetReferrersCapability indicates the Referrers API capability of the remote
 // repository. true: capable; false: not capable.
 //
-// SetReferrersCapability has no effect if the capability has already been set
-// to the same value. If the capability has been set to a conflicting value it
-// is silently ignored; the first value set wins.
+// The first value set wins; any later call is a no-op, whether it agrees or
+// conflicts. This is deliberate rather than an oversight: the same setter
+// records the result of auto-detection, where concurrent operations may each
+// observe the registry's behaviour and race to record it. Callers that need to
+// know the effective value should read it back with ReferrersCapability.
 //   - When the capability is set to true, the Referrers() function will always
 //     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - When the capability is set to false, the Referrers() function will always


### PR DESCRIPTION
`ErrReferrersCapabilityAlreadySet` is exported but never returned. `SetReferrersCapability` swallows a conflicting set rather than reporting one, and nothing else in the tree references the value:

```
$ git grep -n ErrReferrersCapabilityAlreadySet -- '*.go'
registry/remote/referrers.go:52: ErrReferrersCapabilityAlreadySet = errors.New(...)
```

Its own doc comment describes it as "reserved to signal", which is dead public surface — and in a major release, the moment to drop it rather than carry it for the life of v3.

## Why the signature stays as it is

The obvious companion change would be restoring an `error` return on `SetReferrersCapability` so the value becomes reachable again. That would be wrong here: the same setter is also the recorder for auto-detection, called from six internal sites:

```
repository.go:751, 757   Referrers fallback
repository.go:942, 949   pingReferrers
repository.go:1700, 1796 push/delete with indexing
```

Those race by design — concurrent operations each observe what the registry did and try to record it. "First value wins" is correct there, and an error return would be meaningless noise at every one of those call sites.

So the no-error signature is kept, and the doc comment now explains that the behaviour is deliberate and points callers at `ReferrersCapability` to read back the effective value, instead of describing it in a way that reads like an oversight.

Verified with `go build`, `go vet`, the full test suite, and `golangci-lint run`.