### PR TITLE
perf(remote): skip redundant policy evaluation in Exists

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1227,7 +1227,9 @@ func (s *blobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	_, err := s.Resolve(ctx, target.Digest.String())
+	// Policy has been evaluated for this operation; mark the context so the
+	// Resolve below does not evaluate it a second time.
+	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
 	if err == nil {
 		return true, nil
 	}
@@ -1431,7 +1433,9 @@ func (s *manifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	_, err := s.Resolve(ctx, target.Digest.String())
+	// Policy has been evaluated for this operation; mark the context so the
+	// Resolve below does not evaluate it a second time.
+	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
 	if err == nil {
 		return true, nil
 	}


### PR DESCRIPTION
`blobStore.Exists` and `manifestStore.Exists` evaluate the policy, then call `Resolve`, which evaluates it again for the same operation:

```go
func (s *blobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
    if err := s.repo.checkPolicy(ctx, ""); err != nil {   // first evaluation
        return false, err
    }
    _, err := s.Resolve(ctx, target.Digest.String())      // Resolve checks again
```

`Resolve` opens with its own `checkPolicy`, and the context carries no marker, so every existence check runs the policy twice.

That is exactly the redundancy `policyCheckedKey` exists to prevent — the other operations (`Fetch`, `Push`, `Delete`, `Tag`, `PushReference`, `FetchReference`) all pass `withPolicyChecked` down. These two were missed.

No behavioural change: a denial is still returned by the first check, before any request is made. With a `signedBy` requirement the second evaluation can mean a duplicated signature fetch and verification per `Exists` call.

Verified with `go build`, `go vet`, the full test suite, and `golangci-lint run`.