### PR TITLE
avoid redundant policy evaluation in blobStore/manifestStore Exists

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1227,7 +1227,7 @@ func (s *blobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	_, err := s.Resolve(ctx, target.Digest.String())
+	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
 	if err == nil {
 		return true, nil
 	}
@@ -1431,7 +1431,7 @@ func (s *manifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
-	_, err := s.Resolve(ctx, target.Digest.String())
+	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
 	if err == nil {
 		return true, nil
 	}


### PR DESCRIPTION
## What this PR does

`blobStore.Exists` and `manifestStore.Exists` both call `checkPolicy` and then
delegate to their own `Resolve`, which calls `checkPolicy` again. For a
configured `Policy`, that means two `IsImageAllowed` evaluations per `Exists`
call — and for signature-based requirements (`signedBy` / `sigstoreSigned`)
that can mean doing the verification work twice.

This threads `withPolicyChecked(ctx)` into the inner `Resolve` call in both
methods, so the evaluation already performed by `Exists` is not repeated. This
is the same pattern already used by `Repository.Fetch`, `Repository.Push`,
`Repository.Resolve`, and friends when they delegate to a sub-store.

Fixes #1325 