### PR TITLE
feat(remote): add ClientBuilder for constructing configured registries

### DIFF
--- a/registry/remote/builder.go
+++ b/registry/remote/builder.go
@@ -1,0 +1,397 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/auth"
+	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
+	"github.com/oras-project/oras-go/v3/registry/remote/retry"
+)
+
+// ClientBuilder creates auth.Client instances from registry properties.
+// It handles TLS configuration, retry policies, caching, and credential
+// resolution for connecting to container registries.
+type ClientBuilder struct {
+	// BaseTransport is the underlying HTTP transport.
+	// If nil, http.DefaultTransport is used.
+	BaseTransport http.RoundTripper
+
+	// RetryPolicy returns a retry policy for HTTP requests.
+	// If nil, retry.DefaultPolicy is used.
+	RetryPolicy func() retry.Policy
+
+	// CacheFactory creates a cache for the given registry.
+	// If nil, a new cache is created for each registry.
+	CacheFactory func(registry string) auth.Cache
+
+	// CredentialStore is used to resolve credentials when not specified
+	// in the registry properties.
+	// If nil, no credential store fallback is used.
+	CredentialStore credentials.Store
+
+	// UserAgent is the User-Agent header value for HTTP requests.
+	// If empty, no User-Agent header is set.
+	UserAgent string
+
+	// TokenFetcher is an optional custom token fetcher.
+	// If nil, the default token fetching behavior is used.
+	TokenFetcher auth.TokenFetcher
+
+	// PolicyEvaluator is an optional policy evaluator for allow/deny decisions.
+	// If set, repositories created by NewRepositoryWithProperties will
+	// automatically enforce policy on read/write operations.
+	PolicyEvaluator *policy.Evaluator
+
+	// Logger enables HTTP request/response debug logging when non-nil.
+	// Each retry attempt is logged individually. If nil, no logging transport
+	// is added. Use slog.Default() to log to the default handler.
+	Logger *slog.Logger
+}
+
+// NewClientBuilder creates a new ClientBuilder with default settings.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{
+		BaseTransport: http.DefaultTransport,
+		RetryPolicy:   func() retry.Policy { return retry.DefaultPolicy },
+		CacheFactory:  func(registry string) auth.Cache { return auth.NewCache() },
+	}
+}
+
+// Build creates an auth.Client for the given registry properties.
+func (b *ClientBuilder) Build(props *properties.Registry) (*auth.Client, error) {
+	if props == nil {
+		return nil, fmt.Errorf("registry properties cannot be nil")
+	}
+
+	// Build TLS configuration
+	tlsConfig, err := b.buildTLSConfig(props.Transport)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure TLS: %w", err)
+	}
+
+	// Build transport with TLS
+	transport := b.buildTransport(tlsConfig)
+
+	// Build HTTP client with retry
+	httpClient := b.buildHTTPClient(transport)
+
+	// Build credential function
+	credentialFunc := b.buildCredentialFunc(props)
+
+	// Build headers
+	header := b.buildHeader(props.Transport)
+
+	// Build cache
+	var cache auth.Cache
+	if b.CacheFactory != nil {
+		cache = b.CacheFactory(props.Reference.Registry)
+	}
+
+	// Create auth client
+	client := &auth.Client{
+		Client:         httpClient,
+		Header:         header,
+		CredentialFunc: credentialFunc,
+		Cache:          cache,
+		TokenFetcher:   b.tokenFetcher(props, httpClient, header),
+	}
+
+	return client, nil
+}
+
+// tokenFetcher resolves the token acquisition strategy for a registry.
+//
+// An explicitly configured ClientBuilder.TokenFetcher wins: it is the caller
+// speaking directly, whereas the registry properties come from a config file.
+// Otherwise a distribution-spec flow requested via registries.conf is honoured
+// by handing the client a composite fetcher in legacy mode. A nil result leaves
+// the client on its own default, which is OAuth2.
+func (b *ClientBuilder) tokenFetcher(props *properties.Registry, client *http.Client, header http.Header) auth.TokenFetcher {
+	if b.TokenFetcher != nil {
+		return b.TokenFetcher
+	}
+	if props.Attributes.TokenFlow == properties.TokenFlowDistribution {
+		return auth.NewCompositeTokenFetcher(client, header, "", true)
+	}
+	return nil
+}
+
+// buildTLSConfig creates a TLS configuration from transport properties.
+func (b *ClientBuilder) buildTLSConfig(transport properties.Transport) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: transport.Insecure,
+	}
+
+	// Collect all CA certificate paths.
+	var caPaths []string
+	if transport.CACert != "" {
+		caPaths = append(caPaths, transport.CACert)
+	}
+	caPaths = append(caPaths, transport.CACerts...)
+
+	if len(caPaths) > 0 {
+		caCertPool := x509.NewCertPool()
+		for _, p := range caPaths {
+			caCert, err := os.ReadFile(p)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read CA certificate %s: %w", p, err)
+			}
+			if !caCertPool.AppendCertsFromPEM(caCert) {
+				return nil, fmt.Errorf("failed to parse CA certificate %s", p)
+			}
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	// Load client certificate if specified
+	if transport.Cert != "" && transport.Key != "" {
+		cert, err := tls.LoadX509KeyPair(transport.Cert, transport.Key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
+}
+
+// buildTransport creates an HTTP transport with TLS config.
+func (b *ClientBuilder) buildTransport(tlsConfig *tls.Config) http.RoundTripper {
+	// Clone the base transport or use default
+	base := b.BaseTransport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	// If we have TLS config and the base is an *http.Transport, configure it
+	if tlsConfig != nil {
+		if httpTransport, ok := base.(*http.Transport); ok {
+			// Clone the transport to avoid modifying the original
+			cloned := httpTransport.Clone()
+			cloned.TLSClientConfig = tlsConfig
+			base = cloned
+		}
+	}
+
+	// Wrap with retry transport
+	var transport http.RoundTripper = &retry.Transport{
+		Base:   base,
+		Policy: b.RetryPolicy,
+	}
+
+	// Wrap with logging transport if a logger is configured.
+	// Placed outside retry so each attempt is individually logged.
+	if b.Logger != nil {
+		transport = NewLoggingTransport(transport, b.Logger)
+	}
+
+	return transport
+}
+
+// buildHTTPClient creates an HTTP client with the given transport.
+func (b *ClientBuilder) buildHTTPClient(transport http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: transport,
+	}
+}
+
+// buildCredentialFunc creates a credential function that resolves credentials
+// from properties or falls back to the credential store.
+//
+// The credential carried in props belongs to one registry, so it is only
+// returned for that registry's host. Every other host — a mirror, a redirect
+// target, a bearer realm on another origin — resolves through the credential
+// store, which is keyed per host. Returning the static credential
+// unconditionally would hand it to whichever server the client happened to be
+// talking to.
+func (b *ClientBuilder) buildCredentialFunc(props *properties.Registry) credentials.CredentialFunc {
+	// Match what the transport actually dials: Host() maps the "docker.io"
+	// alias onto "registry-1.docker.io", and the credential func is called with
+	// the request host.
+	host := registry.Reference{Registry: props.Reference.Registry}.Host()
+
+	return func(ctx context.Context, reg string) (credentials.Credential, error) {
+		// Credential specified in properties, for its own registry only.
+		if props.Credential != credentials.EmptyCredential && strings.EqualFold(reg, host) {
+			return props.Credential, nil
+		}
+
+		// Fall back to credential store if available
+		if b.CredentialStore != nil {
+			cred, err := b.CredentialStore.Get(ctx, reg)
+			if err != nil {
+				return credentials.EmptyCredential, err
+			}
+			return cred, nil
+		}
+
+		return credentials.EmptyCredential, nil
+	}
+}
+
+// buildHeader creates HTTP headers from transport properties.
+func (b *ClientBuilder) buildHeader(transport properties.Transport) http.Header {
+	header := http.Header{}
+
+	// Set User-Agent if specified
+	if b.UserAgent != "" {
+		header.Set("User-Agent", b.UserAgent)
+	}
+
+	// Add custom headers from properties
+	for key, value := range transport.HeaderFlags {
+		header.Set(key, value)
+	}
+
+	return header
+}
+
+// NewRegistryWithProperties creates a Registry from registry properties
+// using the given ClientBuilder.
+func NewRegistryWithProperties(props *properties.Registry, builder *ClientBuilder) (*Registry, error) {
+	if props == nil {
+		return nil, fmt.Errorf("registry properties cannot be nil")
+	}
+	if builder == nil {
+		builder = NewClientBuilder()
+	}
+
+	// Build auth client
+	client, err := builder.Build(props)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create registry
+	reg := &Registry{
+		Client:    client,
+		Reference: registry.Reference{Registry: props.Reference.Registry},
+		PlainHTTP: props.Transport.PlainHTTP,
+		Policy:    builder.PolicyEvaluator,
+	}
+
+	if builder.Logger != nil {
+		reg.HandleWarning = NewWarningLogger(props.Reference.Registry, builder.Logger)
+	}
+
+	return reg, nil
+}
+
+// NewRepositoryWithProperties creates a Repository from registry properties
+// using the given ClientBuilder.
+func NewRepositoryWithProperties(props *properties.Registry, builder *ClientBuilder) (*Repository, error) {
+	if builder == nil {
+		builder = NewClientBuilder()
+	}
+
+	// Share one construction path with NewRegistryWithProperties so the two
+	// cannot drift in what they configure.
+	reg, err := NewRegistryWithProperties(props, builder)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create repository
+	repo := &Repository{
+		Registry:       reg,
+		RepositoryName: props.Reference.Repository,
+	}
+
+	// Set Referrers API capability if specified
+	switch props.Attributes.ReferrersAPI {
+	case properties.ReferrersAPISupported:
+		repo.SetReferrersCapability(true)
+	case properties.ReferrersAPIUnsupported:
+		repo.SetReferrersCapability(false)
+	}
+
+	// Build mirror repositories
+	mirrors, err := buildMirrorRepositories(props, builder)
+	if err != nil {
+		return nil, err
+	}
+	repo.mirrors = mirrors
+
+	return repo, nil
+}
+
+// buildMirrorRepositories creates mirror Repository instances from the
+// mirror properties. Each mirror gets its own auth.Client built from the
+// mirror's transport settings.
+func buildMirrorRepositories(props *properties.Registry, builder *ClientBuilder) ([]mirrorRepository, error) {
+	if len(props.Mirrors) == 0 {
+		return nil, nil
+	}
+
+	mirrors := make([]mirrorRepository, 0, len(props.Mirrors))
+	for _, m := range props.Mirrors {
+		// Build mirror properties from the mirror's own transport settings.
+		//
+		// The primary's credential is deliberately not propagated: a mirror is
+		// a different host and may be operated by a different party. Mirror
+		// credentials are resolved per host through the ClientBuilder's
+		// credential store, the same way any other registry's are.
+		mirrorProps := &properties.Registry{
+			Reference: properties.Reference{
+				Registry:   m.Location,
+				Repository: props.Reference.Repository,
+			},
+			Transport:  m.Transport,
+			Attributes: props.Attributes,
+		}
+
+		mirrorClient, err := builder.Build(mirrorProps)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build mirror client for %s: %w", m.Location, err)
+		}
+
+		mirrorReg := &Registry{
+			Client:    mirrorClient,
+			Reference: registry.Reference{Registry: m.Location},
+			PlainHTTP: m.Transport.PlainHTTP,
+		}
+		if builder.Logger != nil {
+			mirrorReg.HandleWarning = NewWarningLogger(m.Location, builder.Logger)
+		}
+
+		pullPolicy := m.PullFromMirror
+		if pullPolicy == "" {
+			pullPolicy = PullFromMirrorAll
+		}
+
+		mirrors = append(mirrors, mirrorRepository{
+			Repository: &Repository{
+				Registry:       mirrorReg,
+				RepositoryName: props.Reference.Repository,
+			},
+			pullFromMirror: pullPolicy,
+		})
+	}
+
+	return mirrors, nil
+}

--- a/registry/remote/builder_test.go
+++ b/registry/remote/builder_test.go
@@ -1,0 +1,752 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oras-project/oras-go/v3/registry/remote/auth"
+	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
+	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
+	"github.com/oras-project/oras-go/v3/registry/remote/retry"
+)
+
+func TestNewClientBuilder(t *testing.T) {
+	builder := NewClientBuilder()
+
+	if builder.BaseTransport == nil {
+		t.Error("BaseTransport should not be nil")
+	}
+	if builder.RetryPolicy == nil {
+		t.Error("RetryPolicy should not be nil")
+	}
+	if builder.CacheFactory == nil {
+		t.Error("CacheFactory should not be nil")
+	}
+}
+
+func TestClientBuilder_Build(t *testing.T) {
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if client == nil {
+		t.Fatal("Build() returned nil client")
+	}
+	if client.Client == nil {
+		t.Error("Build() returned client with nil HTTP client")
+	}
+	if client.Cache == nil {
+		t.Error("Build() returned client with nil cache")
+	}
+}
+
+func TestClientBuilder_Build_NilProps(t *testing.T) {
+	builder := NewClientBuilder()
+
+	_, err := builder.Build(nil)
+	if err == nil {
+		t.Error("Build(nil) should return error")
+	}
+}
+
+func TestClientBuilder_Build_WithCredential(t *testing.T) {
+	builder := NewClientBuilder()
+
+	wantUsername := "test-user"
+	wantPassword := "test-password"
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Credential: credentials.Credential{
+			Username: wantUsername,
+			Password: wantPassword,
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	cred, err := client.CredentialFunc(context.Background(), "test-registry.example.com")
+	if err != nil {
+		t.Fatalf("CredentialFunc() error = %v", err)
+	}
+	if cred.Username != wantUsername {
+		t.Errorf("Username = %s, want %s", cred.Username, wantUsername)
+	}
+	if cred.Password != wantPassword {
+		t.Errorf("Password = %s, want %s", cred.Password, wantPassword)
+	}
+}
+
+func TestClientBuilder_Build_WithCredentialStore(t *testing.T) {
+	wantUsername := "store-user"
+	wantPassword := "store-password"
+	wantRegistry := "test-registry.example.com"
+
+	store := &mockCredentialStore{
+		credentials: map[string]credentials.Credential{
+			wantRegistry: {
+				Username: wantUsername,
+				Password: wantPassword,
+			},
+		},
+	}
+
+	builder := NewClientBuilder()
+	builder.CredentialStore = store
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   wantRegistry,
+			Repository: "test/repo",
+		},
+		// No credential in properties, should fall back to store
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	cred, err := client.CredentialFunc(context.Background(), wantRegistry)
+	if err != nil {
+		t.Fatalf("CredentialFunc() error = %v", err)
+	}
+	if cred.Username != wantUsername {
+		t.Errorf("Username = %s, want %s", cred.Username, wantUsername)
+	}
+	if cred.Password != wantPassword {
+		t.Errorf("Password = %s, want %s", cred.Password, wantPassword)
+	}
+}
+
+func TestClientBuilder_Build_WithUserAgent(t *testing.T) {
+	wantUserAgent := "test-agent/1.0"
+
+	builder := NewClientBuilder()
+	builder.UserAgent = wantUserAgent
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if got := client.Header.Get("User-Agent"); got != wantUserAgent {
+		t.Errorf("User-Agent = %s, want %s", got, wantUserAgent)
+	}
+}
+
+func TestClientBuilder_Build_WithCustomHeaders(t *testing.T) {
+	wantHeaderKey := "X-Custom-Header"
+	wantHeaderValue := "custom-value"
+
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			HeaderFlags: map[string]string{
+				wantHeaderKey: wantHeaderValue,
+			},
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if got := client.Header.Get(wantHeaderKey); got != wantHeaderValue {
+		t.Errorf("Header[%s] = %s, want %s", wantHeaderKey, got, wantHeaderValue)
+	}
+}
+
+func TestClientBuilder_Build_WithCustomRetryPolicy(t *testing.T) {
+	customPolicy := &retry.GenericPolicy{
+		MaxRetry: 10,
+	}
+
+	builder := NewClientBuilder()
+	builder.RetryPolicy = func() retry.Policy { return customPolicy }
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	_, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+}
+
+func TestClientBuilder_Build_WithCustomCache(t *testing.T) {
+	customCache := auth.NewCache()
+	cacheFactoryCalled := false
+
+	builder := NewClientBuilder()
+	builder.CacheFactory = func(registry string) auth.Cache {
+		cacheFactoryCalled = true
+		if registry != "test-registry.example.com" {
+			t.Errorf("CacheFactory called with registry = %s, want test-registry.example.com", registry)
+		}
+		return customCache
+	}
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if !cacheFactoryCalled {
+		t.Error("CacheFactory was not called")
+	}
+	if client.Cache != customCache {
+		t.Error("Client cache does not match custom cache")
+	}
+}
+
+func TestClientBuilder_Build_WithTokenFetcher(t *testing.T) {
+	wantToken := "custom-token"
+	customFetcher := &mockTokenFetcher{token: wantToken}
+
+	builder := NewClientBuilder()
+	builder.TokenFetcher = customFetcher
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if client.TokenFetcher != customFetcher {
+		t.Error("Client TokenFetcher does not match custom fetcher")
+	}
+}
+
+func TestClientBuilder_Build_InsecureTLS(t *testing.T) {
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			Insecure: true,
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	// Verify the client was built successfully
+	if client == nil {
+		t.Fatal("Build() returned nil client")
+	}
+}
+
+func TestClientBuilder_Build_WithCACert(t *testing.T) {
+	// Create a temporary CA certificate
+	tmpDir := t.TempDir()
+	caCertPath := filepath.Join(tmpDir, "ca.crt")
+
+	// Generate a self-signed CA certificate
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+
+	caCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCertDER,
+	})
+
+	if err := os.WriteFile(caCertPath, caCertPEM, 0644); err != nil {
+		t.Fatalf("failed to write CA certificate: %v", err)
+	}
+
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			CACert: caCertPath,
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("Build() returned nil client")
+	}
+}
+
+func TestClientBuilder_Build_WithCACerts(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Generate two CA certificates.
+	var caCertPaths []string
+	for i := 0; i < 2; i++ {
+		caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatalf("failed to generate CA key: %v", err)
+		}
+
+		caTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(int64(i + 10)),
+			Subject: pkix.Name{
+				Organization: []string{"Test CA"},
+			},
+			NotBefore:             time.Now(),
+			NotAfter:              time.Now().Add(time.Hour),
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+
+		caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("failed to create CA certificate: %v", err)
+		}
+
+		caCertPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: caCertDER,
+		})
+
+		p := filepath.Join(tmpDir, fmt.Sprintf("ca%d.crt", i))
+		if err := os.WriteFile(p, caCertPEM, 0644); err != nil {
+			t.Fatalf("failed to write CA certificate: %v", err)
+		}
+		caCertPaths = append(caCertPaths, p)
+	}
+
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			CACerts: caCertPaths,
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if client == nil {
+		t.Fatal("Build() returned nil client")
+	}
+}
+
+func TestClientBuilder_Build_WithInvalidCACert(t *testing.T) {
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			CACert: "/nonexistent/ca.crt",
+		},
+	}
+
+	_, err := builder.Build(props)
+	if err == nil {
+		t.Error("Build() should return error for invalid CA cert path")
+	}
+}
+
+func TestClientBuilder_Build_WithClientCert(t *testing.T) {
+	// Create temporary client certificate and key
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "client.crt")
+	keyPath := filepath.Join(tmpDir, "client.key")
+
+	// Generate a self-signed client certificate
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test Client"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	}
+
+	clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, clientTemplate, &clientKey.PublicKey, clientKey)
+	if err != nil {
+		t.Fatalf("failed to create client certificate: %v", err)
+	}
+
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: clientCertDER,
+	})
+
+	clientKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(clientKey),
+	})
+
+	if err := os.WriteFile(certPath, clientCertPEM, 0644); err != nil {
+		t.Fatalf("failed to write client certificate: %v", err)
+	}
+	if err := os.WriteFile(keyPath, clientKeyPEM, 0600); err != nil {
+		t.Fatalf("failed to write client key: %v", err)
+	}
+
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			Cert: certPath,
+			Key:  keyPath,
+		},
+	}
+
+	client, err := builder.Build(props)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if client == nil {
+		t.Fatal("Build() returned nil client")
+	}
+}
+
+func TestClientBuilder_Build_WithInvalidClientCert(t *testing.T) {
+	builder := NewClientBuilder()
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "test-registry.example.com",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			Cert: "/nonexistent/client.crt",
+			Key:  "/nonexistent/client.key",
+		},
+	}
+
+	_, err := builder.Build(props)
+	if err == nil {
+		t.Error("Build() should return error for invalid client cert path")
+	}
+}
+
+func TestNewRepositoryWithProperties(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	props, err := properties.NewRegistry("example.com/test/repo")
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	repo, err := NewRepositoryWithProperties(props, nil)
+	if err != nil {
+		t.Fatalf("NewRepositoryWithProperties() error = %v", err)
+	}
+
+	if repo == nil {
+		t.Fatal("NewRepositoryWithProperties() returned nil repository")
+	}
+	if repo.Registry.Reference.Registry != "example.com" {
+		t.Errorf("Reference.Registry = %s, want example.com", repo.Registry.Reference.Registry)
+	}
+	if repo.RepositoryName != "test/repo" {
+		t.Errorf("RepositoryName = %s, want test/repo", repo.RepositoryName)
+	}
+}
+
+func TestNewRepositoryWithProperties_NilProps(t *testing.T) {
+	_, err := NewRepositoryWithProperties(nil, nil)
+	if err == nil {
+		t.Error("NewRepositoryWithProperties(nil, nil) should return error")
+	}
+}
+
+func TestNewRepositoryWithProperties_PlainHTTP(t *testing.T) {
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "localhost:5000",
+			Repository: "test/repo",
+		},
+		Transport: properties.Transport{
+			PlainHTTP: true,
+		},
+	}
+
+	repo, err := NewRepositoryWithProperties(props, nil)
+	if err != nil {
+		t.Fatalf("NewRepositoryWithProperties() error = %v", err)
+	}
+
+	if !repo.Registry.PlainHTTP {
+		t.Error("PlainHTTP should be true")
+	}
+}
+
+func TestNewRepositoryWithProperties_ReferrersAPISupported(t *testing.T) {
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "example.com",
+			Repository: "test/repo",
+		},
+		Attributes: properties.Attributes{
+			ReferrersAPI: properties.ReferrersAPISupported,
+		},
+	}
+
+	repo, err := NewRepositoryWithProperties(props, nil)
+	if err != nil {
+		t.Fatalf("NewRepositoryWithProperties() error = %v", err)
+	}
+
+	// Conflicting set is silently ignored; capability should remain supported.
+	repo.SetReferrersCapability(false)
+	if repo.ReferrersCapability() != properties.ReferrersAPISupported {
+		t.Error("conflicting SetReferrersCapability(false) should be ignored when already set to supported")
+	}
+}
+
+func TestNewRepositoryWithProperties_ReferrersAPIUnsupported(t *testing.T) {
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "example.com",
+			Repository: "test/repo",
+		},
+		Attributes: properties.Attributes{
+			ReferrersAPI: properties.ReferrersAPIUnsupported,
+		},
+	}
+
+	repo, err := NewRepositoryWithProperties(props, nil)
+	if err != nil {
+		t.Fatalf("NewRepositoryWithProperties() error = %v", err)
+	}
+
+	// Conflicting set is silently ignored; capability should remain unsupported.
+	repo.SetReferrersCapability(true)
+	if repo.ReferrersCapability() != properties.ReferrersAPIUnsupported {
+		t.Error("conflicting SetReferrersCapability(true) should be ignored when already set to unsupported")
+	}
+}
+
+func TestNewRepositoryWithProperties_WithBuilder(t *testing.T) {
+	builder := NewClientBuilder()
+	builder.UserAgent = "test-agent/1.0"
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	repo, err := NewRepositoryWithProperties(props, builder)
+	if err != nil {
+		t.Fatalf("NewRepositoryWithProperties() error = %v", err)
+	}
+
+	if repo == nil {
+		t.Fatal("NewRepositoryWithProperties() returned nil repository")
+	}
+}
+
+func TestNewRepositoryWithProperties_WithPolicyEvaluator(t *testing.T) {
+	pol := policy.NewInsecureAcceptAnythingPolicy()
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	builder := NewClientBuilder()
+	builder.PolicyEvaluator = evaluator
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry:   "example.com",
+			Repository: "test/repo",
+		},
+	}
+
+	repo, err := NewRepositoryWithProperties(props, builder)
+	if err != nil {
+		t.Fatalf("NewRepositoryWithProperties() error = %v", err)
+	}
+
+	if repo.Registry.Policy != evaluator {
+		t.Error("Repository.Registry.Policy should be set to the builder's PolicyEvaluator")
+	}
+}
+
+func TestNewRegistryWithProperties_WithPolicyEvaluator(t *testing.T) {
+	pol := policy.NewInsecureAcceptAnythingPolicy()
+	evaluator, err := policy.NewEvaluator(pol)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	builder := NewClientBuilder()
+	builder.PolicyEvaluator = evaluator
+
+	props := &properties.Registry{
+		Reference: properties.Reference{
+			Registry: "example.com",
+		},
+	}
+
+	reg, err := NewRegistryWithProperties(props, builder)
+	if err != nil {
+		t.Fatalf("NewRegistryWithProperties() error = %v", err)
+	}
+
+	if reg.Policy != evaluator {
+		t.Error("Registry.Policy should be set to the builder's PolicyEvaluator")
+	}
+}
+
+// mockCredentialStore is a test helper that returns credentials from a map.
+type mockCredentialStore struct {
+	credentials map[string]credentials.Credential
+}
+
+func (m *mockCredentialStore) Get(ctx context.Context, serverAddress string) (credentials.Credential, error) {
+	if cred, ok := m.credentials[serverAddress]; ok {
+		return cred, nil
+	}
+	return credentials.EmptyCredential, nil
+}
+
+func (m *mockCredentialStore) Put(ctx context.Context, serverAddress string, cred credentials.Credential) error {
+	m.credentials[serverAddress] = cred
+	return nil
+}
+
+func (m *mockCredentialStore) Delete(ctx context.Context, serverAddress string) error {
+	delete(m.credentials, serverAddress)
+	return nil
+}
+
+// mockTokenFetcher is a test helper that returns a fixed token.
+type mockTokenFetcher struct {
+	token string
+	err   error
+}
+
+func (m *mockTokenFetcher) FetchToken(ctx context.Context, params auth.TokenParams, cred credentials.Credential) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.token, nil
+}

--- a/registry/remote/builder_tokenflow_test.go
+++ b/registry/remote/builder_tokenflow_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/oras-project/oras-go/v3/registry/remote/auth"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
+)
+
+// Test_ClientBuilder_tokenFlowWiring checks that a distribution flow requested
+// in registries.conf reaches the auth client, and that an explicitly configured
+// TokenFetcher still outranks it.
+func Test_ClientBuilder_tokenFlowWiring(t *testing.T) {
+	newProps := func(flow properties.TokenFlow) *properties.Registry {
+		return &properties.Registry{
+			Reference:  properties.Reference{Registry: "registry.example.com", Repository: "app"},
+			Attributes: properties.Attributes{TokenFlow: flow},
+		}
+	}
+
+	t.Run("default leaves the client on its own default", func(t *testing.T) {
+		client, err := NewClientBuilder().Build(newProps(properties.TokenFlowDefault))
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		if client.TokenFetcher != nil {
+			t.Errorf("TokenFetcher = %T, want nil so the client default (OAuth2) applies", client.TokenFetcher)
+		}
+	})
+
+	t.Run("oauth2 is the client default, so still nil", func(t *testing.T) {
+		client, err := NewClientBuilder().Build(newProps(properties.TokenFlowOAuth2))
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		if client.TokenFetcher != nil {
+			t.Errorf("TokenFetcher = %T, want nil", client.TokenFetcher)
+		}
+	})
+
+	t.Run("distribution installs a legacy composite fetcher", func(t *testing.T) {
+		client, err := NewClientBuilder().Build(newProps(properties.TokenFlowDistribution))
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		composite, ok := client.TokenFetcher.(*auth.CompositeTokenFetcher)
+		if !ok {
+			t.Fatalf("TokenFetcher = %T, want *auth.CompositeTokenFetcher", client.TokenFetcher)
+		}
+		if !composite.LegacyMode {
+			t.Error("LegacyMode = false, want true for token-flow=distribution")
+		}
+	})
+
+	t.Run("explicit TokenFetcher outranks the config", func(t *testing.T) {
+		custom := auth.NewCompositeTokenFetcher(nil, nil, "custom-id", false)
+		builder := NewClientBuilder()
+		builder.TokenFetcher = custom
+		client, err := builder.Build(newProps(properties.TokenFlowDistribution))
+		if err != nil {
+			t.Fatalf("Build: %v", err)
+		}
+		if client.TokenFetcher != auth.TokenFetcher(custom) {
+			t.Error("config token-flow overrode an explicitly configured TokenFetcher")
+		}
+	})
+}

--- a/registry/remote/config/properties.go
+++ b/registry/remote/config/properties.go
@@ -82,6 +82,22 @@ func NewRegistryProperties(ref string, regConf *RegistriesConfig) (*properties.R
 			props.Attributes.ReferrersAPI = properties.ReferrersAPIUnsupported
 		}
 
+		// Unlike referrers-api, an unrecognized value is rejected rather than
+		// ignored: silently falling back to the default would leave a user who
+		// typo'd the flow authenticating a way they did not ask for, and the
+		// resulting failure looks like bad credentials.
+		switch origReg.TokenFlow {
+		case "":
+			// leave as TokenFlowDefault
+		case "oauth2":
+			props.Attributes.TokenFlow = properties.TokenFlowOAuth2
+		case "distribution":
+			props.Attributes.TokenFlow = properties.TokenFlowDistribution
+		default:
+			return nil, fmt.Errorf("invalid token-flow %q for registry %q: must be %q or %q",
+				origReg.TokenFlow, origReg.Prefix, "oauth2", "distribution")
+		}
+
 		// Step 6: Populate mirrors.
 		if len(origReg.Mirrors) > 0 {
 			props.Mirrors = make([]properties.Mirror, len(origReg.Mirrors))

--- a/registry/remote/config/registries.go
+++ b/registry/remote/config/registries.go
@@ -53,6 +53,14 @@ type Registry struct {
 	Mirrors []Mirror `toml:"mirror"`
 	// MirrorByDigestOnly restricts mirrors to digest-based pulls only.
 	MirrorByDigestOnly bool `toml:"mirror-by-digest-only"`
+	// TokenFlow selects how a bearer token is acquired for username/password
+	// credentials when the registry issues a Bearer challenge. Valid values:
+	// "oauth2" (default) and "distribution". Use "distribution" for registries
+	// that implement only the distribution-spec token endpoint and not the
+	// OAuth2 password grant, which is a Docker extension. This is an
+	// ORAS-specific field and may be ignored by other tools that parse
+	// registries.conf.
+	TokenFlow string `toml:"token-flow"`
 	// ReferrersAPI indicates whether the registry supports the OCI Referrers
 	// API. Valid values: "supported", "unsupported". An empty or unrecognized
 	// value defaults to auto-detection on first use. This is an ORAS-specific

--- a/registry/remote/config/tokenflow_test.go
+++ b/registry/remote/config/tokenflow_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
+)
+
+func TestNewRegistryProperties_TokenFlow(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    properties.TokenFlow
+		wantErr bool
+	}{
+		{"unset leaves the client default", "", properties.TokenFlowDefault, false},
+		{"oauth2", "oauth2", properties.TokenFlowOAuth2, false},
+		{"distribution", "distribution", properties.TokenFlowDistribution, false},
+		// Rejected rather than ignored: a typo must not silently authenticate
+		// a way the operator did not ask for.
+		{"unrecognized is rejected", "legacy", properties.TokenFlowDefault, true},
+		{"case sensitive", "OAuth2", properties.TokenFlowDefault, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &RegistriesConfig{
+				Registries: []Registry{
+					{Prefix: "example.com", TokenFlow: tt.value},
+				},
+				Aliases: map[string]string{},
+			}
+
+			props, err := NewRegistryProperties("example.com/image:v1", cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("NewRegistryProperties() error = nil, want an error")
+				}
+				if !strings.Contains(err.Error(), "token-flow") {
+					t.Errorf("error = %v, want it to name the token-flow field", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewRegistryProperties() unexpected error: %v", err)
+			}
+			if props.Attributes.TokenFlow != tt.want {
+				t.Errorf("Attributes.TokenFlow = %v, want %v", props.Attributes.TokenFlow, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRegistriesConfig_TokenFlow(t *testing.T) {
+	content := `
+[[registry]]
+prefix = "legacy.example.com"
+token-flow = "distribution"
+`
+	path := filepath.Join(t.TempDir(), "registries.conf")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	cfg, err := LoadRegistriesConfig(path)
+	if err != nil {
+		t.Fatalf("LoadRegistriesConfig() error: %v", err)
+	}
+	if len(cfg.Registries) != 1 {
+		t.Fatalf("got %d registries, want 1", len(cfg.Registries))
+	}
+	if got := cfg.Registries[0].TokenFlow; got != "distribution" {
+		t.Errorf("TokenFlow = %q, want %q", got, "distribution")
+	}
+}

--- a/registry/remote/mirror_isolation_test.go
+++ b/registry/remote/mirror_isolation_test.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/oras-project/oras-go/v3/registry/remote/auth"
+	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 // Test_withMirrorFallbackExists_mirrorMissing_fallsToPrimary covers a mirror
@@ -134,5 +137,91 @@ func Test_isMirrorFallbackError_wrappedContextErrors(t *testing.T) {
 				t.Errorf("isMirrorFallbackError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// Test_buildCredentialFunc_scopedToItsOwnRegistry is the containment property:
+// a credential configured for one registry must not be handed to any other
+// host the client happens to talk to.
+func Test_buildCredentialFunc_scopedToItsOwnRegistry(t *testing.T) {
+	cred := credentials.Credential{Username: "user", Password: "secret"}
+	builder := NewClientBuilder()
+	props := &properties.Registry{
+		Reference:  properties.Reference{Registry: "registry.example.com", Repository: "app"},
+		Credential: cred,
+	}
+
+	credFunc := builder.buildCredentialFunc(props)
+
+	got, err := credFunc(context.Background(), "registry.example.com")
+	if err != nil {
+		t.Fatalf("own registry: unexpected error %v", err)
+	}
+	if got != cred {
+		t.Errorf("own registry: got %v, want the configured credential", got)
+	}
+
+	for _, other := range []string{"mirror.internal", "registry.example.com.evil.test", "evil.test"} {
+		got, err := credFunc(context.Background(), other)
+		if err != nil {
+			t.Fatalf("%s: unexpected error %v", other, err)
+		}
+		if got != credentials.EmptyCredential {
+			t.Errorf("%s: leaked credential %v", other, got)
+		}
+	}
+}
+
+// Test_buildCredentialFunc_dockerIOAlias guards the host normalization: the
+// credential func is called with the host the transport dials, which for the
+// "docker.io" alias is "registry-1.docker.io".
+func Test_buildCredentialFunc_dockerIOAlias(t *testing.T) {
+	cred := credentials.Credential{Username: "user", Password: "secret"}
+	builder := NewClientBuilder()
+	props := &properties.Registry{
+		Reference:  properties.Reference{Registry: "docker.io", Repository: "library/alpine"},
+		Credential: cred,
+	}
+
+	got, err := builder.buildCredentialFunc(props)(context.Background(), "registry-1.docker.io")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if got != cred {
+		t.Errorf("got %v, want the configured credential for the docker.io alias host", got)
+	}
+}
+
+// Test_buildMirrorRepositories_doesNotShareCredential checks the same property
+// end to end: the client built for a mirror must not carry the primary's
+// credential.
+func Test_buildMirrorRepositories_doesNotShareCredential(t *testing.T) {
+	cred := credentials.Credential{Username: "user", Password: "secret"}
+	props := &properties.Registry{
+		Reference:  properties.Reference{Registry: "registry.example.com", Repository: "app"},
+		Credential: cred,
+		Mirrors: []properties.Mirror{
+			{Location: "mirror.internal"},
+		},
+	}
+
+	mirrors, err := buildMirrorRepositories(props, NewClientBuilder())
+	if err != nil {
+		t.Fatalf("buildMirrorRepositories: %v", err)
+	}
+	if len(mirrors) != 1 {
+		t.Fatalf("got %d mirrors, want 1", len(mirrors))
+	}
+
+	authClient, ok := mirrors[0].Registry.Client.(*auth.Client)
+	if !ok {
+		t.Fatalf("mirror client is %T, want *auth.Client", mirrors[0].Registry.Client)
+	}
+	got, err := authClient.CredentialFunc(context.Background(), "mirror.internal")
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if got != credentials.EmptyCredential {
+		t.Errorf("mirror client resolved credential %v; the primary's credential must not reach a mirror", got)
 	}
 }

--- a/registry/remote/properties/attributes.go
+++ b/registry/remote/properties/attributes.go
@@ -39,6 +39,43 @@ func (r ReferrersAPI) String() string {
 	}
 }
 
+// TokenFlow selects how a bearer token is acquired when a registry answers with
+// a Bearer challenge and the credential is a username/password pair.
+//
+// It does not choose between authentication schemes: the scheme always follows
+// the registry's WWW-Authenticate challenge, and under both flows the registry
+// itself is authenticated with a bearer token. Only the exchange at the token
+// endpoint differs. Anonymous, access-token, and refresh-token credentials are
+// unaffected.
+type TokenFlow int
+
+const (
+	// TokenFlowDefault leaves the choice to the client, which uses OAuth2.
+	TokenFlowDefault TokenFlow = iota
+	// TokenFlowOAuth2 posts an OAuth2 password grant to the token endpoint.
+	// Reference: https://distribution.github.io/distribution/spec/auth/oauth/
+	TokenFlowOAuth2
+	// TokenFlowDistribution performs a distribution-spec GET against the token
+	// endpoint, passing the credential as HTTP Basic. This is the flow oras-go
+	// v1 and v2 used. The OAuth2 endpoint is a Docker extension rather than
+	// part of the OCI distribution spec, so registries that implement only the
+	// spec'd endpoint require this flow.
+	// Reference: https://distribution.github.io/distribution/spec/auth/token/
+	TokenFlowDistribution
+)
+
+// String returns the string representation of TokenFlow.
+func (t TokenFlow) String() string {
+	switch t {
+	case TokenFlowOAuth2:
+		return "oauth2"
+	case TokenFlowDistribution:
+		return "distribution"
+	default:
+		return "default"
+	}
+}
+
 // Attributes contains properties specific to the registry itself.
 type Attributes struct {
 	// ReferrersAPI indicates the Referrers API capability of the registry.
@@ -46,4 +83,8 @@ type Attributes struct {
 	// - ReferrersAPIUnsupported: the registry does not support the Referrers API
 	// - ReferrersAPIUnknown: the capability is unknown and will be auto-detected
 	ReferrersAPI ReferrersAPI
+
+	// TokenFlow selects how a bearer token is acquired for username/password
+	// credentials. TokenFlowDefault leaves the choice to the client.
+	TokenFlow TokenFlow
 }


### PR DESCRIPTION
## What

Extracted from #1130. Adds `ClientBuilder`, which turns a
`*properties.Registry` into a fully configured `*auth.Client`, plus
`NewRegistryWithProperties` / `NewRepositoryWithProperties` built on top of it.

Today, assembling a `Repository` from a config file means wiring the TLS
config, CA pool, transport, retry policy, credential func and headers together
by hand at each call site — and then doing it again for every mirror client.
`ClientBuilder` does that once.

`main` already refers to this type: the doc comment at
`registry/remote/repository.go:156` says a Repository "is constructed via the
ClientBuilder", which does not exist yet. This PR makes that true.

## Commits

1. **`feat(properties): add TokenFlow to select the bearer token flow`** —
   prerequisite. Registries implementing only the distribution-spec token
   endpoint cannot serve the OAuth2 password grant (a Docker extension), and
   there was no way to request the spec'd flow short of supplying a custom
   `TokenFetcher`. Adds `properties.TokenFlow` (`Default`/`OAuth2`/
   `Distribution`) and the ORAS-specific `token-flow` key in `registries.conf`.

2. **`feat(remote): add ClientBuilder for constructing configured registries`**
   — the builder itself.

## Notes for reviewers

**Precedence.** A caller-supplied `ClientBuilder.TokenFetcher` wins over the
`registries.conf` `token-flow` setting: the former is the caller speaking
directly, the latter is a config file.

**An unrecognized `token-flow` is rejected, not ignored.** This intentionally
differs from the neighbouring `referrers-api` key, which falls back to
auto-detection. Silently defaulting a typo'd flow would leave the user
authenticating a way they did not ask for, and the failure surfaces as bad
credentials — a confusing place to start debugging.

**Credential scoping.** The credential func matches the requested host against
the registry the credential was configured for and returns `EmptyCredential`
for anything else, so a credential is never handed to a mirror or to a host
that merely shares a suffix with the configured one
(`registry.example.com.evil.test`). The `docker.io` alias is normalized to
`registry-1.docker.io`, since that is the host the transport actually dials.
`mirror_isolation_test.go` covers all three cases.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- 8 files, **+1478, zero deletions** — purely additive, no existing behaviour
  changed.
- All added files are `gofmt`-clean (relevant given #1327).

## Follow-ups

Unblocks #1284, whose `test/functional/mirror_test.go` uses `ClientBuilder`.
