### PR TITLE
chore: make main gofmt-clean and enforce formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,5 +19,9 @@ linters:
     - govet
     - ineffassign
 
+formatters:
+  enable:
+    - gofmt
+
 run:
   go: "1.25"

--- a/content/cache/cache_test.go
+++ b/content/cache/cache_test.go
@@ -85,4 +85,3 @@ func TestCache_ReadOnlyTarget(t *testing.T) {
 		t.Error("ReadOnlyTarget() should return wrapped target")
 	}
 }
-

--- a/registry/interfaces.go
+++ b/registry/interfaces.go
@@ -122,4 +122,3 @@ type Mounter interface {
 		getContent func() (io.ReadCloser, error),
 	) error
 }
-

--- a/registry/interfaces_test.go
+++ b/registry/interfaces_test.go
@@ -403,4 +403,3 @@ func equalDescriptorSet(actual []ocispec.Descriptor, expected []ocispec.Descript
 	}
 	return true
 }
-

--- a/registry/remote/config/properties_test.go
+++ b/registry/remote/config/properties_test.go
@@ -355,9 +355,9 @@ func TestNewRegistryProperties_MirrorByDigestOnlyDefault(t *testing.T) {
 				Prefix:             "docker.io",
 				MirrorByDigestOnly: true,
 				Mirrors: []Mirror{
-					{Location: "m1.example.com"},                              // empty → should default to "digest-only"
-					{Location: "m2.example.com", PullFromMirror: "tag-only"},  // explicit → should stay "tag-only"
-					{Location: "m3.example.com", PullFromMirror: "all"},       // explicit → should stay "all"
+					{Location: "m1.example.com"},                             // empty → should default to "digest-only"
+					{Location: "m2.example.com", PullFromMirror: "tag-only"}, // explicit → should stay "tag-only"
+					{Location: "m3.example.com", PullFromMirror: "all"},      // explicit → should stay "all"
 				},
 			},
 		},
@@ -378,7 +378,6 @@ func TestNewRegistryProperties_MirrorByDigestOnlyDefault(t *testing.T) {
 		t.Errorf("Mirrors[2].PullFromMirror = %q, want %q", props.Mirrors[2].PullFromMirror, "all")
 	}
 }
-
 
 func TestNewRegistryProperties_ReferrersAPI(t *testing.T) {
 	config := &RegistriesConfig{

--- a/registry/remote/config/registries_test.go
+++ b/registry/remote/config/registries_test.go
@@ -696,12 +696,12 @@ func TestMergeRegistriesConfig(t *testing.T) {
 		UnqualifiedSearchRegistries: []string{"quay.io", "docker.io"},
 		ShortNameMode:               "enforcing",
 		Registries: []Registry{
-			{Prefix: "quay.io", Insecure: true},               // Override
-			{Prefix: "gcr.io", Location: "mirror.gcr.io"},     // Add new
+			{Prefix: "quay.io", Insecure: true},           // Override
+			{Prefix: "gcr.io", Location: "mirror.gcr.io"}, // Add new
 		},
 		Aliases: map[string]string{
-			"nginx":  "quay.io/nginx/nginx",              // Override
-			"ubuntu": "docker.io/library/ubuntu",         // Add new
+			"nginx":  "quay.io/nginx/nginx",      // Override
+			"ubuntu": "docker.io/library/ubuntu", // Add new
 		},
 	}
 

--- a/registry/remote/credentials/store_test.go
+++ b/registry/remote/credentials/store_test.go
@@ -291,7 +291,7 @@ func Test_DynamicStore_authConfigured_IgnoreDefaultNativeStore(t *testing.T) {
 	}
 
 	opts := StoreOptions{
-		AllowPlaintextPut:       true,
+		AllowPlaintextPut:        true,
 		IgnoreDefaultNativeStore: true,
 	}
 	ds, err := NewStore(configPath, opts)
@@ -365,7 +365,7 @@ func Test_DynamicStore_noAuthConfigured_IgnoreDefaultNativeStore(t *testing.T) {
 	}
 
 	ds, err := NewStore(configPath, StoreOptions{
-		AllowPlaintextPut:       true,
+		AllowPlaintextPut:        true,
 		IgnoreDefaultNativeStore: true,
 	})
 	if err != nil {

--- a/registry/remote/internal/configpaths/current_darwin.go
+++ b/registry/remote/internal/configpaths/current_darwin.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build darwin
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/current_freebsd.go
+++ b/registry/remote/internal/configpaths/current_freebsd.go
@@ -1,3 +1,5 @@
+//go:build freebsd
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build freebsd
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/current_linux.go
+++ b/registry/remote/internal/configpaths/current_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build linux
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/current_windows.go
+++ b/registry/remote/internal/configpaths/current_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build windows
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/uapi_darwin.go
+++ b/registry/remote/internal/configpaths/uapi_darwin.go
@@ -1,3 +1,5 @@
+//go:build darwin
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build darwin
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/uapi_freebsd.go
+++ b/registry/remote/internal/configpaths/uapi_freebsd.go
@@ -1,3 +1,5 @@
+//go:build freebsd
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build freebsd
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/uapi_linux.go
+++ b/registry/remote/internal/configpaths/uapi_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build linux
 
 package configpaths
 

--- a/registry/remote/internal/configpaths/uapi_windows.go
+++ b/registry/remote/internal/configpaths/uapi_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build windows
 
 package configpaths
 

--- a/registry/remote/policy/policy_other.go
+++ b/registry/remote/policy/policy_other.go
@@ -1,3 +1,5 @@
+//go:build !linux
+
 /*
 Copyright The ORAS Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build !linux
 
 package policy
 

--- a/registry/remote/policy/policy_test.go
+++ b/registry/remote/policy/policy_test.go
@@ -832,8 +832,8 @@ func TestPolicyRequirements_JSONRoundTrip(t *testing.T) {
 			name: "sigstoreSigned with fulcio",
 			reqs: PolicyRequirements{
 				&PRSigstoreSigned{
-					KeyPath: "/path/to/key.pub",
-					KeyData: []byte("key data"),
+					KeyPath:  "/path/to/key.pub",
+					KeyData:  []byte("key data"),
 					KeyDatas: []string{"base64key1", "base64key2"},
 					Fulcio: &FulcioConfig{
 						CAPath:       "/path/ca.pem",

--- a/registry/remote/policy/requirement_test.go
+++ b/registry/remote/policy/requirement_test.go
@@ -454,7 +454,6 @@ func TestRequirementType_Constants(t *testing.T) {
 	}
 }
 
-
 // Test edge case: empty string fields
 func TestSignedIdentity_EmptyFields(t *testing.T) {
 	tests := []struct {
@@ -507,4 +506,3 @@ func TestSignedIdentity_EmptyFields(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## What

- run `gofmt` over the 17 files identified in #1327
- enable the `gofmt` formatter in golangci-lint so CI catches future formatting drift

The source changes are mechanical only: build constraints move to the canonical preamble position, stray blank lines are removed, and composite literal fields are aligned.

Fixes #1327

## Testing

- `gofmt -l .` (no output)
- `golangci-lint fmt --diff` (no output)
- `golangci-lint run`
- `go build ./...`
- `license-eye -c .github/licenserc.yml header check`
- verified `go list` selects the same platform files for darwin, freebsd, linux, and windows
- `go test ./...` on Windows still has the same platform-specific symlink, permission, XDG-path, and file-URL failures reproduced on an untouched `main`; no new failures were introduced
