### PR TITLE
refactor(auth)!: route bearer token fetching through TokenFetcher

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -128,13 +128,24 @@ func (c *Client) send(req *http.Request) (*http.Response, error) {
 	for key, values := range c.Header {
 		req.Header[key] = append(req.Header[key], values...)
 	}
-	// Drop the Authorization header when a redirect crosses an HTTP origin
-	// (scheme, host, or port). The standard library only strips sensitive
-	// headers when the hostname changes, so a redirect to a different port on
-	// the same host would otherwise forward credentials to an unintended
-	// endpoint. Any caller-provided CheckRedirect is preserved.
-	// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
-	client := c.client()
+	return redirectSafeClient(c.client()).Do(req)
+}
+
+// redirectSafeClient returns a shallow copy of client whose CheckRedirect drops
+// the Authorization header when a redirect crosses an HTTP origin (scheme,
+// host, or port). The standard library only strips sensitive headers when the
+// hostname changes, so a redirect to a different port on the same host would
+// otherwise forward credentials to an unintended endpoint. Any caller-provided
+// CheckRedirect is preserved.
+//
+// This applies to token endpoint requests as well as registry requests: the
+// distribution spec flow sends the credential to the realm as HTTP Basic.
+//
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+func redirectSafeClient(client *http.Client) *http.Client {
+	if client == nil {
+		client = http.DefaultClient
+	}
 	clientCopy := *client
 	checkRedirect := client.CheckRedirect
 	clientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -146,7 +157,7 @@ func (c *Client) send(req *http.Request) (*http.Response, error) {
 		}
 		return nil
 	}
-	return clientCopy.Do(req)
+	return &clientCopy
 }
 
 // sameHTTPOrigin reports whether a and b share the same HTTP origin, i.e. the

--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -19,17 +19,14 @@ package auth
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
-	"github.com/oras-project/oras-go/v3/registry/remote/internal/errutil"
 	"github.com/oras-project/oras-go/v3/registry/remote/retry"
 )
 
@@ -100,18 +97,26 @@ type Client struct {
 	// Reference: https://distribution.github.io/distribution/spec/auth/oauth/#getting-a-token
 	ClientID string
 
-	// TokenFetcher is an optional custom token fetcher for bearer
-	// authentication. If nil, the built-in token-fetching logic is used
-	// (see ForceAttemptOAuth2).
-	TokenFetcher TokenFetcher
-
-	// ForceAttemptOAuth2 controls whether to follow OAuth2 with password grant
-	// instead the distribution spec when authenticating using username and
-	// password.
+	// TokenFetcher determines how a bearer token is acquired when the registry
+	// issues a Bearer challenge.
+	//
+	// If nil, the client fetches an anonymous token via the distribution spec
+	// when there is no credential, and otherwise uses OAuth2 with password
+	// grant. To follow the legacy distribution spec instead — the approach used
+	// in oras-go v1 and v2 — set a composite fetcher in legacy mode:
+	//
+	//	client.TokenFetcher = auth.NewCompositeTokenFetcher(
+	//		client.Client, client.Header, client.ClientID, true)
+	//
+	// Note that in either case the registry itself is authenticated with a
+	// bearer token; the two differ only in how that token is obtained. The
+	// authentication scheme itself is not configurable — it is whatever the
+	// registry advertises in its WWW-Authenticate challenge.
+	//
 	// References:
 	// - https://distribution.github.io/distribution/spec/auth/jwt/
 	// - https://distribution.github.io/distribution/spec/auth/oauth/
-	ForceAttemptOAuth2 bool
+	TokenFetcher TokenFetcher
 }
 
 // client returns an HTTP client used to access the remote registry.
@@ -396,136 +401,27 @@ func (c *Client) fetchBasicAuth(ctx context.Context, registry string) (string, e
 }
 
 // fetchBearerToken fetches an access token for the bearer challenge.
+//
+// The acquisition strategy is delegated to TokenFetcher. When none is
+// configured, a CompositeTokenFetcher is used: anonymous access goes through
+// the distribution spec token endpoint and credentialed access uses OAuth2.
 func (c *Client) fetchBearerToken(ctx context.Context, registry, realm, service string, scopes []string) (string, error) {
 	cred, err := c.credential(ctx, registry)
 	if err != nil {
 		return "", err
 	}
 
-	// Use custom TokenFetcher if provided
-	if c.TokenFetcher != nil {
-		params := TokenParams{
-			Registry: registry,
-			Realm:    realm,
-			Service:  service,
-			Scopes:   scopes,
-		}
-		return c.TokenFetcher.FetchToken(ctx, params, cred)
+	fetcher := c.TokenFetcher
+	if fetcher == nil {
+		fetcher = NewCompositeTokenFetcher(c.Client, c.Header, c.ClientID, false)
 	}
-
-	// Fall back to original implementation
-	if cred.AccessToken != "" {
-		return cred.AccessToken, nil
+	params := TokenParams{
+		Registry: registry,
+		Realm:    realm,
+		Service:  service,
+		Scopes:   scopes,
 	}
-	if cred == credentials.EmptyCredential || (cred.RefreshToken == "" && !c.ForceAttemptOAuth2) {
-		return c.fetchDistributionToken(ctx, realm, service, scopes, cred.Username, cred.Password)
-	}
-	return c.fetchOAuth2Token(ctx, realm, service, scopes, cred)
-}
-
-// fetchDistributionToken fetches an access token as defined by the distribution
-// specification.
-// It fetches anonymous tokens if no credential is provided.
-// References:
-// - https://distribution.github.io/distribution/spec/auth/jwt/
-// - https://distribution.github.io/distribution/spec/auth/token/
-func (c *Client) fetchDistributionToken(ctx context.Context, realm, service string, scopes []string, username, password string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, realm, nil)
-	if err != nil {
-		return "", err
-	}
-	if username != "" || password != "" {
-		req.SetBasicAuth(username, password)
-	}
-	q := req.URL.Query()
-	if service != "" {
-		q.Set("service", service)
-	}
-	for _, scope := range scopes {
-		q.Add("scope", scope)
-	}
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := c.send(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", errutil.ParseErrorResponse(resp)
-	}
-
-	// As specified in https://distribution.github.io/distribution/spec/auth/token/ section
-	// "Token Response Fields", the token is either in `token` or
-	// `access_token`. If both present, they are identical.
-	var result struct {
-		Token       string `json:"token"`
-		AccessToken string `json:"access_token"`
-	}
-	lr := io.LimitReader(resp.Body, maxResponseBytes)
-	if err := json.NewDecoder(lr).Decode(&result); err != nil {
-		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
-	}
-	if result.AccessToken != "" {
-		return result.AccessToken, nil
-	}
-	if result.Token != "" {
-		return result.Token, nil
-	}
-	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
-}
-
-// fetchOAuth2Token fetches an OAuth2 access token.
-// Reference: https://distribution.github.io/distribution/spec/auth/oauth/
-func (c *Client) fetchOAuth2Token(ctx context.Context, realm, service string, scopes []string, cred credentials.Credential) (string, error) {
-	form := url.Values{}
-	if cred.RefreshToken != "" {
-		form.Set("grant_type", "refresh_token")
-		form.Set("refresh_token", cred.RefreshToken)
-	} else if cred.Username != "" && cred.Password != "" {
-		form.Set("grant_type", "password")
-		form.Set("username", cred.Username)
-		form.Set("password", cred.Password)
-	} else {
-		return "", errors.New("missing username or password for bearer auth")
-	}
-	form.Set("service", service)
-	clientID := c.ClientID
-	if clientID == "" {
-		clientID = defaultClientID
-	}
-	form.Set("client_id", clientID)
-	if len(scopes) != 0 {
-		form.Set("scope", strings.Join(scopes, " "))
-	}
-	body := strings.NewReader(form.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, realm, body)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set(headerContentType, "application/x-www-form-urlencoded")
-
-	resp, err := c.send(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", errutil.ParseErrorResponse(resp)
-	}
-
-	var result struct {
-		AccessToken string `json:"access_token"`
-	}
-	lr := io.LimitReader(resp.Body, maxResponseBytes)
-	if err := json.NewDecoder(lr).Decode(&result); err != nil {
-		return "", fmt.Errorf("%s %q: failed to decode response: %w", resp.Request.Method, resp.Request.URL, err)
-	}
-	if result.AccessToken != "" {
-		return result.AccessToken, nil
-	}
-	return "", fmt.Errorf("%s %q: empty token returned", resp.Request.Method, resp.Request.URL)
+	return fetcher.FetchToken(ctx, params, cred)
 }
 
 // rewindRequestBody tries to rewind the request body if exists.

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -18,6 +18,7 @@ package auth
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -726,6 +727,7 @@ func TestClient_Do_Bearer_Auth(t *testing.T) {
 			}, nil
 		},
 	}
+	client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
 
 	// first request
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -853,6 +855,7 @@ func TestClient_Do_Bearer_Auth_Cached(t *testing.T) {
 		},
 		Cache: NewCache(),
 	}
+	client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
 
 	// first request
 	ctx := WithScopes(context.Background(), scopes...)
@@ -995,6 +998,7 @@ func TestClient_Do_Bearer_Auth_Cached_PerHost(t *testing.T) {
 		}),
 		Cache: NewCache(),
 	}
+	client1.TokenFetcher = NewCompositeTokenFetcher(client1.Client, client1.Header, client1.ClientID, true)
 
 	// set up server 2
 	username2 := "test_user2"
@@ -1065,6 +1069,7 @@ func TestClient_Do_Bearer_Auth_Cached_PerHost(t *testing.T) {
 		}),
 		Cache: NewCache(),
 	}
+	client2.TokenFetcher = NewCompositeTokenFetcher(client2.Client, client2.Header, client2.ClientID, true)
 
 	ctx := context.Background()
 	ctx = WithScopesForHost(ctx, uri1.Host, scopes1...)
@@ -1312,7 +1317,6 @@ func TestClient_Do_Bearer_OAuth2_Password(t *testing.T) {
 				Password: password,
 			}, nil
 		},
-		ForceAttemptOAuth2: true,
 	}
 
 	// first request
@@ -1459,8 +1463,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached(t *testing.T) {
 				Password: password,
 			}, nil
 		},
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	// first request
@@ -1622,8 +1625,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached_PerHost(t *testing.T) {
 			Username: username1,
 			Password: password1,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 	// set up server 2
 	username2 := "test_user2"
@@ -1712,8 +1714,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached_PerHost(t *testing.T) {
 			Username: username2,
 			Password: password2,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	ctx := context.Background()
@@ -2970,8 +2971,7 @@ func TestClient_Do_Scope_Hint_Mismatch(t *testing.T) {
 				Password: password,
 			}, nil
 		},
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	// first request
@@ -3114,8 +3114,7 @@ func TestClient_Do_Scope_Hint_Mismatch_PerHost(t *testing.T) {
 			Username: username1,
 			Password: password1,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	// set up server 1
@@ -3208,8 +3207,7 @@ func TestClient_Do_Scope_Hint_Mismatch_PerHost(t *testing.T) {
 			Username: username2,
 			Password: password2,
 		}),
-		ForceAttemptOAuth2: true,
-		Cache:              NewCache(),
+		Cache: NewCache(),
 	}
 
 	ctx := context.Background()
@@ -3350,6 +3348,7 @@ func TestClient_Do_Invalid_Credential_Basic(t *testing.T) {
 			}, nil
 		},
 	}
+	client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
 
 	// request should fail
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -3435,6 +3434,7 @@ func TestClient_Do_Invalid_Credential_Bearer(t *testing.T) {
 			}, nil
 		},
 	}
+	client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
 
 	// request should fail
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -3620,6 +3620,7 @@ func TestClient_Do_Scheme_Change(t *testing.T) {
 		},
 		Cache: NewCache(),
 	}
+	client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
 
 	// request with bearer auth
 	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
@@ -4379,6 +4380,185 @@ func Test_validateRealm(t *testing.T) {
 			err := validateRealm(tt.realm, tt.registry)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateRealm(%q, %v) error = %v, wantErr %v", tt.realm, tt.registry, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestClient_Do_Bearer_TokenFlowSelection pins down which token endpoint flow
+// is used for a Bearer challenge, and asserts that both flows still
+// authenticate to the registry itself with a bearer token. That is the only
+// axis TokenFetcher controls: the scheme itself always follows the registry's
+// WWW-Authenticate challenge and is not configurable.
+func TestClient_Do_Bearer_TokenFlowSelection(t *testing.T) {
+	tests := []struct {
+		name            string
+		legacyFetcher   bool
+		wantTokenMethod string
+	}{
+		{"default uses OAuth2 password grant", false, http.MethodPost},
+		{"legacy composite fetcher uses distribution spec", true, http.MethodGet},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const wantToken = "test/access/token"
+			var gotTokenMethod, gotRegistryAuth string
+
+			as := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotTokenMethod = r.Method
+				if err := json.NewEncoder(w).Encode(map[string]string{
+					"token":        wantToken,
+					"access_token": wantToken,
+				}); err != nil {
+					t.Errorf("failed to write token response: %v", err)
+				}
+			}))
+			defer as.Close()
+
+			var service string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if auth := r.Header.Get("Authorization"); auth != "" {
+					gotRegistryAuth = auth
+					return
+				}
+				challenge := fmt.Sprintf("Bearer realm=%q,service=%q,scope=%q", as.URL, service, "repository:test:pull")
+				w.Header().Set("Www-Authenticate", challenge)
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer ts.Close()
+			uri, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatalf("invalid test http server: %v", err)
+			}
+			service = uri.Host
+
+			client := &Client{
+				CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+					return credentials.Credential{
+						Username: "test_user",
+						Password: "test_password",
+					}, nil
+				},
+			}
+			if tt.legacyFetcher {
+				client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create test request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Client.Do() error = %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+			}
+			if gotTokenMethod != tt.wantTokenMethod {
+				t.Errorf("token endpoint method = %v, want %v", gotTokenMethod, tt.wantTokenMethod)
+			}
+			if want := "Bearer " + wantToken; gotRegistryAuth != want {
+				t.Errorf("registry received %q, want %q", gotRegistryAuth, want)
+			}
+		})
+	}
+}
+
+// TestClient_fetchBearerToken_RealmRedirect verifies that a token endpoint
+// redirect crossing an HTTP origin does not carry the credential along. The
+// distribution spec flow sends the credential to the realm as HTTP Basic, so
+// this path needs the same protection as a registry request.
+// Reference: https://github.com/oras-project/oras-go/security/advisories/GHSA-vh4v-2xq2-g5cg
+func TestClient_fetchBearerToken_RealmRedirect(t *testing.T) {
+	const (
+		username  = "test_user"
+		password  = "test_password"
+		wantToken = "test/access/token"
+	)
+	wantRealmAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+
+	writeToken := func(w http.ResponseWriter) {
+		if err := json.NewEncoder(w).Encode(map[string]string{"token": wantToken}); err != nil {
+			t.Errorf("failed to write token response: %v", err)
+		}
+	}
+
+	tests := []struct {
+		name string
+		// crossOrigin redirects the realm to a second server on a different
+		// port, rather than to another path on the same server.
+		crossOrigin  bool
+		wantSinkAuth string
+	}{
+		{"cross-origin redirect drops credential", true, ""},
+		{"same-origin redirect keeps credential", false, wantRealmAuth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sinkAuth atomic.Value
+			sinkAuth.Store("")
+
+			// sink is the redirect target when crossing origins.
+			sink := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				sinkAuth.Store(r.Header.Get("Authorization"))
+				writeToken(w)
+			}))
+			defer sink.Close()
+
+			var as *httptest.Server
+			as = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.URL.Path == "/redirected":
+					sinkAuth.Store(r.Header.Get("Authorization"))
+					writeToken(w)
+				case tt.crossOrigin:
+					http.Redirect(w, r, sink.URL, http.StatusTemporaryRedirect)
+				default:
+					http.Redirect(w, r, as.URL+"/redirected", http.StatusTemporaryRedirect)
+				}
+			}))
+			defer as.Close()
+
+			var service string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") == "Bearer "+wantToken {
+					return
+				}
+				challenge := fmt.Sprintf("Bearer realm=%q,service=%q,scope=%q", as.URL, service, "repository:test:pull")
+				w.Header().Set("Www-Authenticate", challenge)
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			defer ts.Close()
+			uri, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatalf("invalid test http server: %v", err)
+			}
+			service = uri.Host
+
+			client := &Client{
+				CredentialFunc: func(ctx context.Context, reg string) (credentials.Credential, error) {
+					return credentials.Credential{Username: username, Password: password}, nil
+				},
+			}
+			// Legacy mode sends the credential to the realm as HTTP Basic.
+			client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create test request: %v", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("Client.Do() error = %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Client.Do() = %v, want %v", resp.StatusCode, http.StatusOK)
+			}
+			if got := sinkAuth.Load().(string); got != tt.wantSinkAuth {
+				t.Errorf("redirect target received Authorization %q, want %q", got, tt.wantSinkAuth)
 			}
 		})
 	}

--- a/registry/remote/auth/example_test.go
+++ b/registry/remote/auth/example_test.go
@@ -189,8 +189,6 @@ func ExampleClient_Do_clientConfigurations() {
 			Username: username,
 			Password: password,
 		}),
-		// ForceAttemptOAuth2 controls whether to follow OAuth2 with password grant.
-		ForceAttemptOAuth2: true,
 		// Cache caches credentials for accessing the remote registry.
 		Cache: NewCache(),
 	}

--- a/registry/remote/auth/scope_test.go
+++ b/registry/remote/auth/scope_test.go
@@ -105,7 +105,7 @@ func TestScopeRepository(t *testing.T) {
 	}
 }
 
-func TestWithScopeHints(t *testing.T) {
+func TestAppendRepositoryScope(t *testing.T) {
 	ctx := context.Background()
 	ref1, err := registry.ParseReference("registry.example.com/foo")
 	if err != nil {
@@ -126,10 +126,10 @@ func TestWithScopeHints(t *testing.T) {
 	ctx = AppendRepositoryScope(ctx, ref1, ActionPull)
 	ctx = AppendRepositoryScope(ctx, ref2, ActionPush)
 	if got := GetScopesForHost(ctx, ref1.Host()); !reflect.DeepEqual(got, want1) {
-		t.Errorf("GetScopesPerRegistry(WithScopeHints()) = %v, want %v", got, want1)
+		t.Errorf("GetScopesForHost(AppendRepositoryScope()) = %v, want %v", got, want1)
 	}
 	if got := GetScopesForHost(ctx, ref2.Host()); !reflect.DeepEqual(got, want2) {
-		t.Errorf("GetScopesPerRegistry(WithScopeHints()) = %v, want %v", got, want2)
+		t.Errorf("GetScopesForHost(AppendRepositoryScope()) = %v, want %v", got, want2)
 	}
 
 	// with duplicated scopes
@@ -152,20 +152,20 @@ func TestWithScopeHints(t *testing.T) {
 	ctx = AppendRepositoryScope(ctx, ref1, scopes1...)
 	ctx = AppendRepositoryScope(ctx, ref2, scopes2...)
 	if got := GetScopesForHost(ctx, ref1.Host()); !reflect.DeepEqual(got, want1) {
-		t.Errorf("GetScopesPerRegistry(WithScopeHints()) = %v, want %v", got, want1)
+		t.Errorf("GetScopesForHost(AppendRepositoryScope()) = %v, want %v", got, want1)
 	}
 	if got := GetScopesForHost(ctx, ref2.Host()); !reflect.DeepEqual(got, want2) {
-		t.Errorf("GetScopesPerRegistry(WithScopeHints()) = %v, want %v", got, want2)
+		t.Errorf("GetScopesForHost(AppendRepositoryScope()) = %v, want %v", got, want2)
 	}
 
 	// append empty scopes
 	ctx = AppendRepositoryScope(ctx, ref1)
 	ctx = AppendRepositoryScope(ctx, ref2)
 	if got := GetScopesForHost(ctx, ref1.Host()); !reflect.DeepEqual(got, want1) {
-		t.Errorf("GetScopesPerRegistry(WithScopeHints()) = %v, want %v", got, want1)
+		t.Errorf("GetScopesForHost(AppendRepositoryScope()) = %v, want %v", got, want1)
 	}
 	if got := GetScopesForHost(ctx, ref2.Host()); !reflect.DeepEqual(got, want2) {
-		t.Errorf("GetScopesPerRegistry(WithScopeHints()) = %v, want %v", got, want2)
+		t.Errorf("GetScopesForHost(AppendRepositoryScope()) = %v, want %v", got, want2)
 	}
 }
 

--- a/registry/remote/auth/token.go
+++ b/registry/remote/auth/token.go
@@ -49,14 +49,14 @@ type TokenFetcher interface {
 
 // sendRequest adds the custom headers to the request and sends it using the
 // given client. If client is nil, http.DefaultClient is used.
+//
+// The client is wrapped by redirectSafeClient so that a token endpoint
+// redirect crossing an HTTP origin does not carry the credential along.
 func sendRequest(client *http.Client, header http.Header, req *http.Request) (*http.Response, error) {
 	for key, values := range header {
 		req.Header[key] = append(req.Header[key], values...)
 	}
-	if client == nil {
-		client = http.DefaultClient
-	}
-	return client.Do(req)
+	return redirectSafeClient(client).Do(req)
 }
 
 // decodeTokenResponse decodes a token endpoint response body and returns the


### PR DESCRIPTION
## What

Extracted from #1130. Finishes the `TokenFetcher` work started in #1181 by
making it the single path for bearer token acquisition, and closes a gap where
the new path missed the redirect protection the old one had.

Independent of #1328 — that PR touches `builder.go`/`properties`, this one only
`registry/remote/auth/`. `NewCompositeTokenFetcher`'s signature is unchanged,
so the two do not interact.

## Commits

### 1. `fix(auth): strip credentials on token endpoint redirects`

`Client.send` drops the `Authorization` header when a redirect crosses an HTTP
origin, but token endpoint requests issued through `TokenFetcher` did not —
`sendRequest` called `client.Do` directly. The distribution spec flow sends the
credential to the realm as HTTP Basic, so a redirect away from the realm could
carry it to an unintended endpoint. Same class of leak as
GHSA-vh4v-2xq2-g5cg, which is already fixed for registry requests.

Extracts the wrapper as `redirectSafeClient` and routes both `Client.send` and
`sendRequest` through it.

**No released version is affected.** The `TokenFetcher` path arrived in #1181
on 2026-08-14 and is in no tagged release (the only v3 tags are `v3.0.x-dev`,
all of which predate it), so this never reached users and needs no advisory.
Flagging the reasoning explicitly so it can be double-checked rather than
taken on trust.

### 2. `refactor(auth)!: route bearer token fetching through TokenFetcher`

`Client` carried its own copies of the distribution and OAuth2 flows alongside
the `TokenFetcher` abstraction, so the same two flows existed twice:
`ForceAttemptOAuth2` selected between the built-in pair, while a configured
`TokenFetcher` bypassed both. This deletes `Client.fetchDistributionToken` and
`Client.fetchOAuth2Token` and routes `fetchBearerToken` through
`TokenFetcher`, defaulting to a `CompositeTokenFetcher`.

**Behaviour is unchanged**: anonymous access uses the distribution spec token
endpoint, credentialed access uses OAuth2 with password grant.

## Breaking change

`Client.ForceAttemptOAuth2` is removed. To follow the legacy distribution spec
flow used in v1 and v2:

```go
client.TokenFetcher = auth.NewCompositeTokenFetcher(
	client.Client, client.Header, client.ClientID, true)
```

The removal is contained to the `auth` package — I grepped the tree and no
other package referenced the field.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass (33 packages).
- Net **−168 lines** of duplicated token-fetching logic, with `client_test.go`
  gaining coverage for the routed paths.
- `gofmt`-clean (relevant given #1327).
