### PR TITLE
refactor(remote)!: remove unused ErrReferrersCapabilityAlreadySet

### DIFF
--- a/registry/remote/referrers.go
+++ b/registry/remote/referrers.go
@@ -46,11 +46,6 @@ type referrerChange struct {
 }
 
 var (
-	// ErrReferrersCapabilityAlreadySet is reserved to signal that the referrers
-	// capability of a repository has already been set to a conflicting value.
-	// The capability is fixed once set; the first value wins.
-	ErrReferrersCapabilityAlreadySet = errors.New("referrers capability cannot be changed once set")
-
 	// errNoReferrerUpdate is returned by applyReferrerChanges() when there
 	// is no any referrer update.
 	errNoReferrerUpdate = errors.New("no referrer update")

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -336,9 +336,9 @@ func (r *Repository) skipReferrersGC() bool {
 // SetReferrersCapability indicates the Referrers API capability of the remote
 // repository. true: capable; false: not capable.
 //
-// SetReferrersCapability has no effect if the capability has already been set
-// to the same value. If the capability has been set to a conflicting value it
-// is silently ignored; the first value set wins.
+// The capability is fixed once set; the first value set wins and conflicting
+// later calls are ignored. Callers can use ReferrersCapability to read back
+// the effective capability.
 //   - When the capability is set to true, the Referrers() function will always
 //     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - When the capability is set to false, the Referrers() function will always


### PR DESCRIPTION
## Description
Resolves #1324 

`ErrReferrersCapabilityAlreadySet` in `registry/remote/referrers.go` is exported but never returned anywhere in the codebase. `SetReferrersCapability` uses `atomic.CompareAndSwapInt32` where the first value set wins and subsequent conflicting calls are deliberately ignored to accommodate concurrent discovery across call sites. 

This PR removes the dead exported variable for the v3 release and clarifies the deliberate "first value set wins" behavior in `SetReferrersCapability`'s doc comment.

## What Changes Were Made?
- Deleted the unused exported variable `ErrReferrersCapabilityAlreadySet` from `registry/remote/referrers.go`.
- Reworded `SetReferrersCapability` doc comment in `registry/remote/repository.go` to explicitly document that:
  - The capability is fixed once set; the first value wins and conflicting later calls are ignored.
  - Callers can invoke `ReferrersCapability` to read back the effective capability.

## How Was This Verified?
- `go build ./...`
- `go vet ./...`
- `go test -v ./registry/remote -run TestRepository_SetReferrersCapability` (passes and verifies first-value-wins / conflicting sets ignored behavior).
- Code formatted with `gofmt`.

## Checklist
- [x] Unused exported variable `ErrReferrersCapabilityAlreadySet` removed from `registry/remote/referrers.go`
- [x] Doc comment for `SetReferrersCapability` updated to clarify deliberate behavior and mention `ReferrersCapability`
- [x] Existing tests pass (`go test -v ./registry/remote -run TestRepository_SetReferrersCapability`)
- [x] Code passes `go build ./...` and `go vet ./...`