### PR TITLE
docs(remote): explain the policy-checked marker and the referrers capability rule

### DIFF
--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -336,9 +336,11 @@ func (r *Repository) skipReferrersGC() bool {
 // SetReferrersCapability indicates the Referrers API capability of the remote
 // repository. true: capable; false: not capable.
 //
-// The capability is fixed once set; the first value set wins and conflicting
-// later calls are ignored. Callers can use ReferrersCapability to read back
-// the effective capability.
+// The first value set wins; any later call is a no-op, whether it agrees or
+// conflicts. This is deliberate rather than an oversight: the same setter
+// records the result of auto-detection, where concurrent operations may each
+// observe the registry's behavior and race to record it. Callers that need to
+// know the effective value should read it back with ReferrersCapability.
 //   - When the capability is set to true, the Referrers() function will always
 //     request the Referrers API. Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
 //   - When the capability is set to false, the Referrers() function will always

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -1227,6 +1227,8 @@ func (s *blobStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
+	// Policy has been evaluated for this operation; mark the context so the
+	// Resolve below does not evaluate it a second time.
 	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
 	if err == nil {
 		return true, nil
@@ -1431,6 +1433,8 @@ func (s *manifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return false, err
 	}
+	// Policy has been evaluated for this operation; mark the context so the
+	// Resolve below does not evaluate it a second time.
 	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
 	if err == nil {
 		return true, nil


### PR DESCRIPTION
Two comment-only clarifications in `registry/remote/repository.go`, split out of the v3 working branch (#1130). No behavior change — `go build`, `go vet` and `go test ./registry/remote/` pass, and the file is gofmt-clean.

### 1. The `withPolicyChecked` marker

`blobStore.Exists` and `manifestStore.Exists` evaluate the policy themselves and then call `Resolve`, which would evaluate it a second time. They pass `withPolicyChecked` to suppress that, but nothing at the call site said so — the marker reads as redundant and is easy to drop by accident, which silently doubles policy evaluation on every existence check.

### 2. Why `SetReferrersCapability` ignores later calls

The doc records that the first value wins, but not why, which reads like a limitation someone should fix. It is not. The same setter is also the recorder for auto-detection, called from six internal sites that race by design:

- `repository.go:741`, `:747` — `pingReferrers`
- `:932`, `:939` — referrers-API probe
- `:1690`, `:1786` — manifest push / delete fallbacks

First-value-wins is the correct rule there, so the doc now says that rather than leaving it to be inferred.

Follows #1333, which shortened this doc while removing `ErrReferrersCapabilityAlreadySet`.