### PR TITLE
test: cover default certs.d discovery

### DIFF
--- a/registry/remote/config/certsd_test.go
+++ b/registry/remote/config/certsd_test.go
@@ -24,6 +24,52 @@ import (
 	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
+func TestDefaultCertsDirPaths(t *testing.T) {
+	got := defaultCertsDirPaths()
+	want := defaultCertsDirPathsWithStrategy(StrategyContainersImage)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("defaultCertsDirPaths() = %v, want %v", got, want)
+	}
+}
+
+func TestLoadCertsDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	host := filepath.Base(home) + ".invalid"
+	hostDir := filepath.Join(home, ".config", "containers", "certs.d", host)
+	if err := os.MkdirAll(hostDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	caCertPath := filepath.Join(hostDir, "ca.crt")
+	clientCertPath := filepath.Join(hostDir, "client.cert")
+	clientKeyPath := filepath.Join(hostDir, "client.key")
+	for _, path := range []string{caCertPath, clientCertPath, clientKeyPath} {
+		if err := os.WriteFile(path, []byte("test data"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := LoadCertsDir(host)
+	if err != nil {
+		t.Fatalf("LoadCertsDir() error: %v", err)
+	}
+	want := &CertsDir{CACertPaths: []string{caCertPath}, ClientCert: clientCertPath, ClientKey: clientKeyPath}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LoadCertsDir() = %v, want %v", got, want)
+	}
+
+	got, err = LoadCertsDir("unknown.invalid")
+	if err != nil {
+		t.Fatalf("LoadCertsDir() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("LoadCertsDir() = %v, want nil", got)
+	}
+}
+
 func TestLoadCertsDirFromPaths_CACerts(t *testing.T) {
 	tmpDir := t.TempDir()
 	hostDir := filepath.Join(tmpDir, "example.com")


### PR DESCRIPTION
## What

Adds test coverage for the default `certs.d` search-path wiring:

- verifies `defaultCertsDirPaths` uses `StrategyContainersImage`
- verifies `LoadCertsDir` discovers CA, client certificate, and key files from the user-level default directory
- verifies an unknown host returns `(nil, nil)`

The test overrides both Unix and Windows home-directory environment variables so the user path remains platform-independent.

## Why

The existing discovery tests pass explicit base directories to `LoadCertsDirFromPaths`. They did not exercise the exported `LoadCertsDir` entry point or pin its default strategy, so a regression in that wiring could silently skip the documented user certificate directory.

## Testing

- `go test ./registry/remote/config/ -coverprofile=/tmp/oras-go-1342-cover.out`
- `go test -race ./registry/remote/config/...`
- `go vet ./registry/remote/config/...`
- `GOFLAGS=-mod=mod golangci-lint run`

Both previously uncovered wrappers now report 100% coverage. No production code was changed.

Fixes #1342
