### PR TITLE
refactor(registry)!: include Untagger in ManifestStore interface

### DIFF
--- a/registry/interfaces.go
+++ b/registry/interfaces.go
@@ -62,10 +62,11 @@ type BlobStore interface {
 }
 
 // ManifestStore is a CAS with the ability to stat and delete its content.
-// Besides, ManifestStore provides reference tagging.
+// Besides, ManifestStore provides reference tagging and untagging.
 type ManifestStore interface {
 	BlobStore
 	content.Tagger
+	content.Untagger
 	ReferencePusher
 }
 

--- a/registry/remote/middleware.go
+++ b/registry/remote/middleware.go
@@ -301,6 +301,14 @@ func (s *policyEnforcingManifestStore) Tag(ctx context.Context, desc ocispec.Des
 	return s.manifests.Tag(ctx, desc, reference)
 }
 
+// Untag removes a tag reference with policy enforcement.
+func (s *policyEnforcingManifestStore) Untag(ctx context.Context, reference string) error {
+	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	return s.manifests.Untag(ctx, reference)
+}
+
 // Ensure the wrappers satisfy the registry interfaces they enforce policy on.
 var (
 	_ registry.Repository    = (*policyEnforcingRepository)(nil)

--- a/registry/remote/middleware_test.go
+++ b/registry/remote/middleware_test.go
@@ -275,6 +275,12 @@ func TestWithPolicyEnforcement_Manifests(t *testing.T) {
 	if err != nil {
 		t.Errorf("Manifests().Tag() error = %v, want nil", err)
 	}
+
+	// Test Untag
+	err = manifests.Untag(ctx, "latest")
+	if err != nil {
+		t.Errorf("Manifests().Untag() error = %v, want nil", err)
+	}
 }
 
 func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
@@ -355,6 +361,9 @@ func TestWithPolicyEnforcement_PolicyDenied_AllOperations(t *testing.T) {
 	}
 	if err := manifests.Tag(ctx, desc, "latest"); err == nil {
 		t.Error("Manifests().Tag() should return error when policy denies access")
+	}
+	if err := manifests.Untag(ctx, "latest"); err == nil {
+		t.Error("Manifests().Untag() should return error when policy denies access")
 	}
 }
 
@@ -458,6 +467,7 @@ type mockRepository struct {
 	resolveDesc        ocispec.Descriptor
 	resolveErr         error
 	tagErr             error
+	untagErr           error
 	pushReferenceErr   error
 	fetchReferenceRC   io.ReadCloser
 	fetchReferenceErr  error
@@ -603,6 +613,10 @@ func (s *mockManifestStore) FetchReference(ctx context.Context, reference string
 
 func (s *mockManifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
 	return s.repo.Tag(ctx, desc, reference)
+}
+
+func (s *mockManifestStore) Untag(ctx context.Context, reference string) error {
+	return s.repo.untagErr
 }
 
 func (s *mockManifestStore) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -564,13 +564,7 @@ func (r *Repository) Untag(ctx context.Context, reference string) error {
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
-
-	manifests := r.Manifests()
-	untagger, ok := manifests.(content.Untagger)
-	if !ok {
-		return fmt.Errorf("manifest store %T does not implement content.Untagger", manifests)
-	}
-	return untagger.Untag(withPolicyChecked(ctx), reference)
+	return r.Manifests().Untag(withPolicyChecked(ctx), reference)
 }
 
 // PushReference pushes the manifest with a reference tag.

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/oras-project/oras-go/v3/content"
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
 )
@@ -344,7 +343,7 @@ func TestRepository_ManifestStore_PushReference_PolicyCheck(t *testing.T) {
 
 func TestRepository_ManifestStore_Untag_PolicyCheck(t *testing.T) {
 	repo := newRejectPolicyRepo(t)
-	err := repo.Manifests().(content.Untagger).Untag(context.Background(), "latest")
+	err := repo.Manifests().Untag(context.Background(), "latest")
 	assertPolicyDenied(t, err, "Manifests().Untag()")
 }
 

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -6475,7 +6475,7 @@ func Test_ManifestStore_Untag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRepository() error = %v", err)
 	}
-	store := repo.Manifests().(content.Untagger)
+	store := repo.Manifests()
 	repo.Registry.PlainHTTP = true
 	ctx := context.Background()
 


### PR DESCRIPTION
### Description
Resolves #1344 

`Repository.Untag` (added in #1217) previously guarded its delegation to the manifest store behind a runtime type assertion:

```go
manifests := r.Manifests()
untagger, ok := manifests.(content.Untagger)
if !ok {
    return fmt.Errorf("manifest store %T does not implement content.Untagger", manifests)
}
return untagger.Untag(withPolicyChecked(ctx), reference)
```

Because `Manifests()` returns `*manifestStore` which implements `content.Untagger`, `ok` was always `true`. This left the `!ok` error branch completely unreachable and untestable.

`registry.ManifestStore` already embeds `content.Tagger`. This PR adds `content.Untagger` directly to `registry.ManifestStore`, bringing symmetry to reference tag management and allowing `Repository.Untag` to delegate directly to `r.Manifests().Untag(...)` matching its sibling methods (`Tag`, `PushReference`).

### What Changes Were Made?

- Embedded `content.Untagger` into `registry.ManifestStore` and updated its doc comment in `registry/interfaces.go`.
- Simplified `Repository.Untag` in `registry/remote/repository.go` by removing the unreachable type assertion and directly calling `r.Manifests().Untag(withPolicyChecked(ctx), reference)`.
- Added policy-enforced `Untag` to `policyEnforcingManifestStore` in `registry/remote/middleware.go`.
- Updated `mockManifestStore` and added unit test assertions for `Untag` under allowed and denied policies in `registry/remote/middleware_test.go`.
- Removed unnecessary `.(content.Untagger)` casts in `registry/remote/repository_policy_test.go` and `registry/remote/repository_test.go`, and cleaned up unused imports.

### How Was This Verified?

- `go test -v ./registry/remote -run "TestRepository_Untag|TestManifestStoreInterface|Test_ManifestStore_Untag|TestWithPolicyEnforcement"` (all pass).
- Coverage checked with `go test -coverprofile`: `Repository.Untag` statement coverage increased to **100.0%** (from 85.7%).
- `make check-encoding` passed without CRLF or formatting issues.
- `go build ./...` and `go vet ./...` pass cleanly.

### Checklist

- [x] `content.Untagger` added to `registry.ManifestStore` in `registry/interfaces.go`
- [x] `Repository.Untag` simplified to delegate directly without defensive type assertion
- [x] `policyEnforcingManifestStore` updated to implement `Untag` with policy checks
- [x] Unit tests and mock implementations updated in `middleware_test.go`, `repository_policy_test.go`, and `repository_test.go`
- [x] All tests pass and `Repository.Untag` reaches 100% statement coverage
- [x] Code passes `go build ./...`, `go vet ./...`, and `make check-encoding`