### PR TITLE
feat(remote): separate registry warning logging from HTTP debug logging

### DIFF
--- a/registry/remote/builder.go
+++ b/registry/remote/builder.go
@@ -69,8 +69,14 @@ type ClientBuilder struct {
 
 	// Logger enables HTTP request/response debug logging when non-nil.
 	// Each retry attempt is logged individually. If nil, no logging transport
-	// is added. Use slog.Default() to log to the default handler.
+	// is added. Logger is also used for registry warnings when WarningLogger is
+	// nil. Use slog.Default() to log to the default handler.
 	Logger *slog.Logger
+
+	// WarningLogger logs registry warnings at slog.LevelWarn, deduplicated per
+	// registry. If nil, Logger is used for backward compatibility. If both are
+	// nil, warnings are not logged.
+	WarningLogger *slog.Logger
 }
 
 // NewClientBuilder creates a new ClientBuilder with default settings.
@@ -213,6 +219,13 @@ func (b *ClientBuilder) buildTransport(tlsConfig *tls.Config) http.RoundTripper 
 	return transport
 }
 
+func (b *ClientBuilder) warningLogger() *slog.Logger {
+	if b.WarningLogger != nil {
+		return b.WarningLogger
+	}
+	return b.Logger
+}
+
 // buildHTTPClient creates an HTTP client with the given transport.
 func (b *ClientBuilder) buildHTTPClient(transport http.RoundTripper) *http.Client {
 	return &http.Client{
@@ -295,8 +308,8 @@ func NewRegistryWithProperties(props *properties.Registry, builder *ClientBuilde
 		Policy:    builder.PolicyEvaluator,
 	}
 
-	if builder.Logger != nil {
-		reg.HandleWarning = NewWarningLogger(props.Reference.Registry, builder.Logger)
+	if logger := builder.warningLogger(); logger != nil {
+		reg.HandleWarning = NewWarningLogger(props.Reference.Registry, logger)
 	}
 
 	return reg, nil
@@ -375,8 +388,8 @@ func buildMirrorRepositories(props *properties.Registry, builder *ClientBuilder)
 			Reference: registry.Reference{Registry: m.Location},
 			PlainHTTP: m.Transport.PlainHTTP,
 		}
-		if builder.Logger != nil {
-			mirrorReg.HandleWarning = NewWarningLogger(m.Location, builder.Logger)
+		if logger := builder.warningLogger(); logger != nil {
+			mirrorReg.HandleWarning = NewWarningLogger(m.Location, logger)
 		}
 
 		pullPolicy := m.PullFromMirror

--- a/registry/remote/builder_test.go
+++ b/registry/remote/builder_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package remote
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -23,11 +24,14 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"io"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -714,6 +718,138 @@ func TestNewRegistryWithProperties_WithPolicyEvaluator(t *testing.T) {
 	if reg.Policy != evaluator {
 		t.Error("Registry.Policy should be set to the builder's PolicyEvaluator")
 	}
+}
+
+func TestClientBuilder_LoggerRouting(t *testing.T) {
+	props := &properties.Registry{
+		Reference: properties.Reference{Registry: "registry.example.com"},
+	}
+	warning := Warning{WarningValue: WarningValue{Code: 299, Agent: "-", Text: "deprecated API"}}
+	baseTransport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"status":"ok"}`)),
+			Request:    req,
+		}, nil
+	})
+	newLogger := func(buf *bytes.Buffer, level slog.Level) *slog.Logger {
+		return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: level}))
+	}
+	clientTransport := func(t *testing.T, reg *Registry) http.RoundTripper {
+		t.Helper()
+		client, ok := reg.Client.(*auth.Client)
+		if !ok {
+			t.Fatalf("registry client is %T, want *auth.Client", reg.Client)
+		}
+		return client.Client.Transport
+	}
+	doRequest := func(t *testing.T, transport http.RoundTripper) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodGet, "https://registry.example.com/v2/", nil)
+		if err != nil {
+			t.Fatalf("NewRequest() error = %v", err)
+		}
+		resp, err := transport.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("RoundTrip() error = %v", err)
+		}
+		resp.Body.Close()
+	}
+
+	t.Run("warning logger only", func(t *testing.T) {
+		var warningLogs bytes.Buffer
+		builder := NewClientBuilder()
+		builder.BaseTransport = baseTransport
+		builder.WarningLogger = newLogger(&warningLogs, slog.LevelWarn)
+
+		reg, err := NewRegistryWithProperties(props, builder)
+		if err != nil {
+			t.Fatalf("NewRegistryWithProperties() error = %v", err)
+		}
+		if _, ok := clientTransport(t, reg).(*LoggingTransport); ok {
+			t.Fatal("WarningLogger should not enable HTTP debug logging")
+		}
+		if reg.HandleWarning == nil {
+			t.Fatal("HandleWarning should be configured")
+		}
+		reg.HandleWarning(warning)
+		if !strings.Contains(warningLogs.String(), warning.Text) {
+			t.Errorf("warning log = %q, want warning %q", warningLogs.String(), warning.Text)
+		}
+	})
+
+	t.Run("logger remains the warning fallback", func(t *testing.T) {
+		var logs bytes.Buffer
+		builder := NewClientBuilder()
+		builder.BaseTransport = baseTransport
+		builder.Logger = newLogger(&logs, slog.LevelDebug)
+
+		reg, err := NewRegistryWithProperties(props, builder)
+		if err != nil {
+			t.Fatalf("NewRegistryWithProperties() error = %v", err)
+		}
+		transport := clientTransport(t, reg)
+		if _, ok := transport.(*LoggingTransport); !ok {
+			t.Fatalf("client transport is %T, want *LoggingTransport", transport)
+		}
+		reg.HandleWarning(warning)
+		doRequest(t, transport)
+		if got := logs.String(); !strings.Contains(got, warning.Text) || !strings.Contains(got, "level=DEBUG") {
+			t.Errorf("combined log = %q, want warning and debug records", got)
+		}
+	})
+
+	t.Run("warning and debug loggers are independent", func(t *testing.T) {
+		var debugLogs bytes.Buffer
+		var warningLogs bytes.Buffer
+		builder := NewClientBuilder()
+		builder.BaseTransport = baseTransport
+		builder.Logger = newLogger(&debugLogs, slog.LevelDebug)
+		builder.WarningLogger = newLogger(&warningLogs, slog.LevelWarn)
+
+		reg, err := NewRegistryWithProperties(props, builder)
+		if err != nil {
+			t.Fatalf("NewRegistryWithProperties() error = %v", err)
+		}
+		reg.HandleWarning(warning)
+		doRequest(t, clientTransport(t, reg))
+		if got := warningLogs.String(); !strings.Contains(got, warning.Text) || strings.Contains(got, "level=DEBUG") {
+			t.Errorf("warning log = %q, want only warning records", got)
+		}
+		if got := debugLogs.String(); !strings.Contains(got, "level=DEBUG") || strings.Contains(got, warning.Text) {
+			t.Errorf("debug log = %q, want only debug records", got)
+		}
+	})
+
+	t.Run("mirror warnings use the mirror location", func(t *testing.T) {
+		var warningLogs bytes.Buffer
+		builder := NewClientBuilder()
+		builder.WarningLogger = newLogger(&warningLogs, slog.LevelWarn)
+		mirrorProps := &properties.Registry{
+			Reference: properties.Reference{Registry: "registry.example.com", Repository: "app"},
+			Mirrors: []properties.Mirror{
+				{Location: "mirror.example.com"},
+			},
+		}
+
+		mirrors, err := buildMirrorRepositories(mirrorProps, builder)
+		if err != nil {
+			t.Fatalf("buildMirrorRepositories() error = %v", err)
+		}
+		if len(mirrors) != 1 {
+			t.Fatalf("buildMirrorRepositories() returned %d mirrors, want 1", len(mirrors))
+		}
+		mirrors[0].Registry.HandleWarning(warning)
+		got := warningLogs.String()
+		if !strings.Contains(got, "mirror.example.com") {
+			t.Errorf("warning log = %q, want mirror location", got)
+		}
+		if strings.Contains(got, "registry.example.com") {
+			t.Errorf("warning log = %q, should not contain primary registry location", got)
+		}
+	})
 }
 
 // mockCredentialStore is a test helper that returns credentials from a map.

--- a/registry/remote/logging_transport.go
+++ b/registry/remote/logging_transport.go
@@ -74,6 +74,10 @@ func NewLoggingTransport(inner http.RoundTripper, logger *slog.Logger) *LoggingT
 
 // RoundTrip implements http.RoundTripper, logging the request and response.
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !t.logger.Enabled(req.Context(), slog.LevelDebug) {
+		return t.inner.RoundTrip(req)
+	}
+
 	id := requestCounter.Add(1) - 1
 	loggedURL := *req.URL
 	loggedURL.RawQuery = ""

--- a/registry/remote/logging_transport_test.go
+++ b/registry/remote/logging_transport_test.go
@@ -91,6 +91,53 @@ func TestLoggingTransport_RoundTrip_Error(t *testing.T) {
 	}
 }
 
+func TestLoggingTransport_RoundTrip_DebugDisabledDoesNotReadBody(t *testing.T) {
+	payload := `{"status":"ok"}`
+	body := &trackingReadCloser{Reader: strings.NewReader(payload)}
+	inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       body,
+			Request:    req,
+		}, nil
+	})
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	lt := NewLoggingTransport(inner, logger)
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+
+	resp, err := lt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	defer resp.Body.Close()
+	if body.reads != 0 {
+		t.Fatalf("response body read %d times with debug logging disabled, want 0", body.reads)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(got) != payload {
+		t.Errorf("body = %q, want %q", got, payload)
+	}
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	reads int
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	r.reads++
+	return r.Reader.Read(p)
+}
+
+func (*trackingReadCloser) Close() error {
+	return nil
+}
+
 func TestFormatHeaders_Scrubbing(t *testing.T) {
 	h := http.Header{
 		"Authorization": {"Bearer secret"},


### PR DESCRIPTION
## What changed

- add `ClientBuilder.WarningLogger` while retaining `Logger` as the backward-compatible fallback
- route warning handlers for both primary and mirror registries through the dedicated warning logger
- bypass `LoggingTransport` formatting and body inspection when debug logging is disabled
- cover independent logger routing, fallback behavior, mirror attribution, and the disabled-debug fast path

## Why

Registry warnings are production-facing signals, while full HTTP request/response debug logs are a troubleshooting feature. Separating the loggers lets callers enable warnings without enabling the logging transport or paying its response-body inspection cost.

## Testing

- `go test -race ./...` (Go 1.25.14, Linux container, non-root)
- `golangci-lint v2.11.4`: `govet` and `ineffassign`, 0 issues
- `gofmt` and `git diff --check`

`docs/SCENARIOS.md` referenced by the issue is not present on `main`, so this PR does not add a scenario-document update.

Fixes #1347