### PR TITLE
feat: identify the failing content in CopyError

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -138,10 +138,10 @@ type CopyGraphOptions struct {
 // Returns the descriptor of the root node on successful copy.
 func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, dstRef string, opts CopyOptions) (ocispec.Descriptor, error) {
 	if src == nil {
-		return ocispec.Descriptor{}, newCopyError("Copy", CopyErrorOriginSource, errors.New("nil source target"))
+		return ocispec.Descriptor{}, newCopyError("Copy", CopyErrorOriginSource, ocispec.Descriptor{}, errors.New("nil source target"))
 	}
 	if dst == nil {
-		return ocispec.Descriptor{}, newCopyError("Copy", CopyErrorOriginDestination, errors.New("nil destination target"))
+		return ocispec.Descriptor{}, newCopyError("Copy", CopyErrorOriginDestination, ocispec.Descriptor{}, errors.New("nil destination target"))
 	}
 
 	// Run policy check before copy if configured.
@@ -169,7 +169,7 @@ func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, ds
 		proxy.StopCaching = true
 		root, err = opts.MapRoot(ctx, proxy, root)
 		if err != nil {
-			return ocispec.Descriptor{}, newCopyError("MapRoot", CopyErrorOriginSource, err)
+			return ocispec.Descriptor{}, newCopyError("MapRoot", CopyErrorOriginSource, root, err)
 		}
 		proxy.StopCaching = false
 	}
@@ -190,10 +190,10 @@ func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, ds
 // The root node (e.g. a manifest of the artifact) is identified by a descriptor.
 func CopyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, root ocispec.Descriptor, opts CopyGraphOptions) error {
 	if src == nil {
-		return newCopyError("CopyGraph", CopyErrorOriginSource, errors.New("nil source target"))
+		return newCopyError("CopyGraph", CopyErrorOriginSource, ocispec.Descriptor{}, errors.New("nil source target"))
 	}
 	if dst == nil {
-		return newCopyError("CopyGraph", CopyErrorOriginDestination, errors.New("nil destination target"))
+		return newCopyError("CopyGraph", CopyErrorOriginDestination, ocispec.Descriptor{}, errors.New("nil destination target"))
 	}
 	return copyGraph(ctx, src, dst, root, nil, nil, nil, opts)
 }
@@ -243,7 +243,7 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 		// skip if a rooted sub-DAG exists
 		exists, err := dst.Exists(ctx, desc)
 		if err != nil {
-			return newCopyError("Exists", CopyErrorOriginDestination, err)
+			return newCopyError("Exists", CopyErrorOriginDestination, desc, err)
 		}
 		if exists {
 			if opts.OnCopySkipped != nil {
@@ -257,7 +257,7 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 		// find successors while non-leaf nodes will be fetched and cached
 		successors, err := opts.FindSuccessors(ctx, proxy, desc)
 		if err != nil {
-			return newCopyError("FindSuccessors", CopyErrorOriginSource, err)
+			return newCopyError("FindSuccessors", CopyErrorOriginSource, desc, err)
 		}
 		successors = removeForeignLayers(successors)
 
@@ -415,7 +415,7 @@ func mountOrCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst conte
 
 		// Mount or copy
 		if err := mounter.Mount(ctx, desc, sourceRepository, getContent); err != nil && !errors.Is(err, skipSource) {
-			return newCopyError("Mount", CopyErrorOriginDestination, err)
+			return newCopyError("Mount", CopyErrorOriginDestination, desc, err)
 		}
 
 		if !mountFailed {
@@ -443,12 +443,12 @@ func mountOrCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst conte
 func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor) error {
 	rc, err := src.Fetch(ctx, desc)
 	if err != nil {
-		return newCopyError("Fetch", CopyErrorOriginSource, err)
+		return newCopyError("Fetch", CopyErrorOriginSource, desc, err)
 	}
 	defer rc.Close()
 	err = dst.Push(ctx, desc, rc)
 	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
-		return newCopyError("Push", CopyErrorOriginDestination, err)
+		return newCopyError("Push", CopyErrorOriginDestination, desc, err)
 	}
 	return nil
 }
@@ -480,13 +480,13 @@ func copyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Stor
 func copyCachedNodeWithReference(ctx context.Context, src *cas.Proxy, dst registry.ReferencePusher, desc ocispec.Descriptor, dstRef string) error {
 	rc, err := src.FetchCached(ctx, desc)
 	if err != nil {
-		return newCopyError("Fetch", CopyErrorOriginSource, err)
+		return newCopyError("Fetch", CopyErrorOriginSource, desc, err)
 	}
 	defer rc.Close()
 
 	err = dst.PushReference(ctx, desc, rc, dstRef)
 	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
-		return newCopyError("PushReference", CopyErrorOriginDestination, err)
+		return newCopyError("PushReference", CopyErrorOriginDestination, desc, err)
 	}
 	return nil
 }
@@ -497,7 +497,7 @@ func resolveRoot(ctx context.Context, src ReadOnlyTarget, srcRef string, proxy *
 	if !ok {
 		desc, err := src.Resolve(ctx, srcRef)
 		if err != nil {
-			return ocispec.Descriptor{}, newCopyError("Resolve", CopyErrorOriginSource, err)
+			return ocispec.Descriptor{}, newCopyError("Resolve", CopyErrorOriginSource, ocispec.Descriptor{}, err)
 		}
 		return desc, nil
 	}
@@ -509,7 +509,7 @@ func resolveRoot(ctx context.Context, src ReadOnlyTarget, srcRef string, proxy *
 	}
 	root, rc, err := refProxy.FetchReference(ctx, srcRef)
 	if err != nil {
-		return ocispec.Descriptor{}, newCopyError("FetchReference", CopyErrorOriginSource, err)
+		return ocispec.Descriptor{}, newCopyError("FetchReference", CopyErrorOriginSource, ocispec.Descriptor{}, err)
 	}
 	defer rc.Close()
 	// cache root if it is a non-leaf node
@@ -520,7 +520,7 @@ func resolveRoot(ctx context.Context, src ReadOnlyTarget, srcRef string, proxy *
 		return nil, errors.New("fetching only root node expected")
 	})
 	if _, err = content.Successors(ctx, fetcher, root); err != nil {
-		return ocispec.Descriptor{}, newCopyError("Successors", CopyErrorOriginSource, err)
+		return ocispec.Descriptor{}, newCopyError("Successors", CopyErrorOriginSource, root, err)
 	}
 
 	// TODO: optimize special case where root is a leaf node (i.e. a blob)
@@ -562,7 +562,7 @@ func prepareCopy(_ context.Context, dst Target, dstRef string, proxy *cas.Proxy,
 			if content.Equal(desc, root) {
 				// for root node, tag it after copying it
 				if err := dst.Tag(ctx, root, dstRef); err != nil {
-					return newCopyError("Tag", CopyErrorOriginDestination, err)
+					return newCopyError("Tag", CopyErrorOriginDestination, root, err)
 				}
 			}
 			if postCopy != nil {
@@ -595,7 +595,7 @@ func prepareCopy(_ context.Context, dst Target, dstRef string, proxy *cas.Proxy,
 			}
 		}
 		if err := dst.Tag(ctx, root, dstRef); err != nil {
-			return newCopyError("Tag", CopyErrorOriginDestination, err)
+			return newCopyError("Tag", CopyErrorOriginDestination, root, err)
 		}
 		return nil
 	}

--- a/copy.go
+++ b/copy.go
@@ -167,10 +167,11 @@ func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, ds
 
 	if opts.MapRoot != nil {
 		proxy.StopCaching = true
-		root, err = opts.MapRoot(ctx, proxy, root)
+		mappedRoot, err := opts.MapRoot(ctx, proxy, root)
 		if err != nil {
 			return ocispec.Descriptor{}, newCopyError("MapRoot", CopyErrorOriginSource, root, err)
 		}
+		root = mappedRoot
 		proxy.StopCaching = false
 	}
 

--- a/copy_selfheal_internal_test.go
+++ b/copy_selfheal_internal_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"testing"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/oras-project/oras-go/v3/registry/remote/errcode"
 )
 
@@ -76,7 +78,7 @@ func TestIsMissingReferencedContentError(t *testing.T) {
 		},
 		{
 			name: "wrapped in CopyError",
-			err: newCopyError("Push", CopyErrorOriginDestination, errcode.Errors{
+			err: newCopyError("Push", CopyErrorOriginDestination, ocispec.Descriptor{}, errcode.Errors{
 				{Code: errcode.ErrorCodeManifestBlobUnknown},
 			}),
 			want: true,

--- a/copy_test.go
+++ b/copy_test.go
@@ -2404,6 +2404,84 @@ func TestCopy_CopyError(t *testing.T) {
 
 }
 
+// TestCopy_CopyError_Descriptor verifies that a CopyError identifies the
+// content that the failing operation was acting on.
+func TestCopy_CopyError_Descriptor(t *testing.T) {
+	t.Run("exists error", func(t *testing.T) {
+		ctx := context.Background()
+		src := memory.New()
+		manifestDesc, err := oras.PackManifest(ctx, src, oras.PackManifestVersion1_1, "application/test", oras.PackManifestOptions{})
+		if err != nil {
+			t.Fatalf("failed to pack test content: %v", err)
+		}
+		dst := &badExister{
+			memory.New(),
+		}
+
+		err = oras.CopyGraph(ctx, src, dst, manifestDesc, oras.DefaultCopyGraphOptions)
+		var copyErr *oras.CopyError
+		if !errors.As(err, &copyErr) {
+			t.Fatalf("CopyGraph() error is not a CopyError: %v", err)
+		}
+		if !reflect.DeepEqual(copyErr.Descriptor, manifestDesc) {
+			t.Errorf("CopyError descriptor = %v, want %v", copyErr.Descriptor, manifestDesc)
+		}
+		want := `failed to perform "Exists" on destination for ` + manifestDesc.Digest.String() + `: ` + errExists.Error()
+		if got := copyErr.Error(); got != want {
+			t.Errorf("CopyError message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("tag error", func(t *testing.T) {
+		ctx := context.Background()
+		src := memory.New()
+		dst := &badTagger{
+			Target: memory.New(),
+		}
+		srcRef := "test"
+
+		manifestDesc, err := oras.PackManifest(ctx, src, oras.PackManifestVersion1_1, "application/test", oras.PackManifestOptions{})
+		if err != nil {
+			t.Fatalf("failed to pack test content: %v", err)
+		}
+		if err := src.Tag(ctx, manifestDesc, srcRef); err != nil {
+			t.Fatalf("failed to tag test content on src: %v", err)
+		}
+
+		_, err = oras.Copy(ctx, src, srcRef, dst, "", oras.DefaultCopyOptions)
+		var copyErr *oras.CopyError
+		if !errors.As(err, &copyErr) {
+			t.Fatalf("Copy() error is not a CopyError: %v", err)
+		}
+		if !reflect.DeepEqual(copyErr.Descriptor, manifestDesc) {
+			t.Errorf("CopyError descriptor = %v, want %v", copyErr.Descriptor, manifestDesc)
+		}
+		want := `failed to perform "Tag" on destination for ` + manifestDesc.Digest.String() + `: ` + errTag.Error()
+		if got := copyErr.Error(); got != want {
+			t.Errorf("CopyError message = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nil source target has no descriptor", func(t *testing.T) {
+		ctx := context.Background()
+		dst := memory.New()
+
+		_, err := oras.Copy(ctx, nil, "", dst, "", oras.DefaultCopyOptions)
+		var copyErr *oras.CopyError
+		if !errors.As(err, &copyErr) {
+			t.Fatalf("Copy() error is not a CopyError: %v", err)
+		}
+		if !reflect.DeepEqual(copyErr.Descriptor, ocispec.Descriptor{}) {
+			t.Errorf("CopyError descriptor = %v, want zero value", copyErr.Descriptor)
+		}
+		// the message must be unchanged when no descriptor is available
+		want := `failed to perform "Copy" on source: nil source target`
+		if got := copyErr.Error(); got != want {
+			t.Errorf("CopyError message = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestCopyGraph_CopyError(t *testing.T) {
 	t.Run("src target is nil", func(t *testing.T) {
 		ctx := context.Background()

--- a/copy_test.go
+++ b/copy_test.go
@@ -2480,6 +2480,42 @@ func TestCopy_CopyError_Descriptor(t *testing.T) {
 			t.Errorf("CopyError message = %q, want %q", got, want)
 		}
 	})
+
+	t.Run("map root error retains the pre-map descriptor", func(t *testing.T) {
+		ctx := context.Background()
+		src := memory.New()
+		dst := memory.New()
+		srcRef := "test"
+
+		manifestDesc, err := oras.PackManifest(ctx, src, oras.PackManifestVersion1_1, "application/test", oras.PackManifestOptions{})
+		if err != nil {
+			t.Fatalf("failed to pack test content: %v", err)
+		}
+		if err := src.Tag(ctx, manifestDesc, srcRef); err != nil {
+			t.Fatalf("failed to tag test content on src: %v", err)
+		}
+
+		opts := oras.DefaultCopyOptions
+		opts.MapRoot = func(ctx context.Context, src content.ReadOnlyStorage, root ocispec.Descriptor) (ocispec.Descriptor, error) {
+			// MapRoot fails and returns a zero-value descriptor, as real
+			// implementations (e.g. platform selection) commonly do.
+			return ocispec.Descriptor{}, errdef.ErrNotFound
+		}
+
+		_, err = oras.Copy(ctx, src, srcRef, dst, "", opts)
+		var copyErr *oras.CopyError
+		if !errors.As(err, &copyErr) {
+			t.Fatalf("Copy() error is not a CopyError: %v", err)
+		}
+		// the CopyError must identify the original (pre-map) root, not the
+		// zero-value descriptor MapRoot returned on failure.
+		if !reflect.DeepEqual(copyErr.Descriptor, manifestDesc) {
+			t.Errorf("CopyError descriptor = %v, want %v", copyErr.Descriptor, manifestDesc)
+		}
+		if reflect.DeepEqual(copyErr.Descriptor, ocispec.Descriptor{}) {
+			t.Errorf("CopyError descriptor is zero value, want the pre-map root descriptor")
+		}
+	})
 }
 
 func TestCopyGraph_CopyError(t *testing.T) {

--- a/copyerror.go
+++ b/copyerror.go
@@ -15,7 +15,11 @@ limitations under the License.
 
 package oras
 
-import "fmt"
+import (
+	"fmt"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
 
 // CopyErrorOrigin defines the source of a copy error.
 type CopyErrorOrigin int
@@ -46,28 +50,44 @@ type CopyError struct {
 	Op string
 	// Origin indicates the source of the error.
 	Origin CopyErrorOrigin
+	// Descriptor is the content that the operation was acting on. It is the
+	// zero value for errors raised before a specific node was selected.
+	Descriptor ocispec.Descriptor
 	// Err is the underlying error.
 	Err error
 }
 
 // newCopyError creates a new CopyError.
-func newCopyError(op string, origin CopyErrorOrigin, err error) error {
+//
+// desc is the content that the operation was acting on. Pass the zero value
+// when the error is raised before a specific node is selected.
+func newCopyError(op string, origin CopyErrorOrigin, desc ocispec.Descriptor, err error) error {
 	if err == nil {
 		return nil
 	}
 	return &CopyError{
-		Op:     op,
-		Origin: origin,
-		Err:    err,
+		Op:         op,
+		Origin:     origin,
+		Descriptor: desc,
+		Err:        err,
 	}
 }
 
 // Error implements the error interface for CopyError.
 func (e *CopyError) Error() string {
+	// the descriptor is optional: it is the zero value for errors raised
+	// before a specific node was selected.
+	hasDescriptor := e.Descriptor.Digest != ""
 	switch e.Origin {
 	case CopyErrorOriginSource, CopyErrorOriginDestination:
+		if hasDescriptor {
+			return fmt.Sprintf("failed to perform %q on %s for %s: %v", e.Op, e.Origin, e.Descriptor.Digest, e.Err)
+		}
 		return fmt.Sprintf("failed to perform %q on %s: %v", e.Op, e.Origin, e.Err)
 	default:
+		if hasDescriptor {
+			return fmt.Sprintf("failed to perform %q for %s: %v", e.Op, e.Descriptor.Digest, e.Err)
+		}
 		return fmt.Sprintf("failed to perform %q: %v", e.Op, e.Err)
 	}
 }

--- a/copyerror_test.go
+++ b/copyerror_test.go
@@ -17,16 +17,31 @@ package oras
 
 import (
 	"errors"
+	"reflect"
 	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var errTest error = errors.New("test error")
+
+// testDigest is the digest carried by descTest.
+const testDigest = "sha256:6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
+
+// descTest is a non-zero descriptor used to verify that a CopyError
+// identifies the content it failed on.
+var descTest = ocispec.Descriptor{
+	MediaType: ocispec.MediaTypeImageLayer,
+	Digest:    testDigest,
+	Size:      12,
+}
 
 func TestNewCopyError(t *testing.T) {
 	tests := []struct {
 		name   string
 		op     string
 		origin CopyErrorOrigin
+		desc   ocispec.Descriptor
 		err    error
 		want   *CopyError
 	}{
@@ -39,6 +54,19 @@ func TestNewCopyError(t *testing.T) {
 				Op:     "pull",
 				Origin: CopyErrorOriginSource,
 				Err:    errTest,
+			},
+		},
+		{
+			name:   "source error with descriptor",
+			op:     "Fetch",
+			origin: CopyErrorOriginSource,
+			desc:   descTest,
+			err:    errTest,
+			want: &CopyError{
+				Op:         "Fetch",
+				Origin:     CopyErrorOriginSource,
+				Descriptor: descTest,
+				Err:        errTest,
 			},
 		},
 		{
@@ -74,7 +102,7 @@ func TestNewCopyError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := newCopyError(tt.op, tt.origin, tt.err)
+			err := newCopyError(tt.op, tt.origin, tt.desc, tt.err)
 			if tt.want == nil {
 				return
 			}
@@ -89,6 +117,10 @@ func TestNewCopyError(t *testing.T) {
 
 			if copyErr.Origin != tt.want.Origin {
 				t.Errorf("expected Origin %q, got %q", tt.want.Origin, copyErr.Origin)
+			}
+
+			if !reflect.DeepEqual(copyErr.Descriptor, tt.want.Descriptor) {
+				t.Errorf("expected Descriptor %v, got %v", tt.want.Descriptor, copyErr.Descriptor)
 			}
 
 			if !errors.Is(copyErr.Err, errTest) {
@@ -130,6 +162,36 @@ func TestCopyError_Error(t *testing.T) {
 				Err:    errTest,
 			},
 			want: `failed to perform "test": test error`,
+		},
+		{
+			name: "source error with descriptor",
+			copyErr: &CopyError{
+				Op:         "Fetch",
+				Origin:     CopyErrorOriginSource,
+				Descriptor: descTest,
+				Err:        errTest,
+			},
+			want: `failed to perform "Fetch" on source for ` + testDigest + `: test error`,
+		},
+		{
+			name: "destination error with descriptor",
+			copyErr: &CopyError{
+				Op:         "Push",
+				Origin:     CopyErrorOriginDestination,
+				Descriptor: descTest,
+				Err:        errTest,
+			},
+			want: `failed to perform "Push" on destination for ` + testDigest + `: test error`,
+		},
+		{
+			name: "undefined origin with descriptor",
+			copyErr: &CopyError{
+				Op:         "test",
+				Origin:     -1,
+				Descriptor: descTest,
+				Err:        errTest,
+			},
+			want: `failed to perform "test" for ` + testDigest + `: test error`,
 		},
 		{
 			name: "nil error",
@@ -238,4 +300,24 @@ func (e *customErr) Error() string {
 
 func (e *customErr) Unwrap() error {
 	return nil
+}
+
+// TestCopyError_Descriptor verifies that a CopyError recovered via errors.As
+// exposes the descriptor of the content that the operation failed on, and
+// that the zero value leaves the message unchanged.
+func TestCopyError_Descriptor(t *testing.T) {
+	err := newCopyError("Fetch", CopyErrorOriginSource, descTest, errTest)
+
+	var copyErr *CopyError
+	if !errors.As(err, &copyErr) {
+		t.Fatalf("expected %T, got %T", copyErr, err)
+	}
+	if !reflect.DeepEqual(copyErr.Descriptor, descTest) {
+		t.Errorf("expected Descriptor %v, got %v", descTest, copyErr.Descriptor)
+	}
+
+	zeroErr := newCopyError("Fetch", CopyErrorOriginSource, ocispec.Descriptor{}, errTest)
+	if want := `failed to perform "Fetch" on source: test error`; zeroErr.Error() != want {
+		t.Errorf("want %q, got %q", want, zeroErr.Error())
+	}
 }

--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -76,10 +76,10 @@ type ExtendedCopyGraphOptions struct {
 // Returns the descriptor of the tagged node on successful copy.
 func ExtendedCopy(ctx context.Context, src ReadOnlyGraphTarget, srcRef string, dst Target, dstRef string, opts ExtendedCopyOptions) (ocispec.Descriptor, error) {
 	if src == nil {
-		return ocispec.Descriptor{}, newCopyError("ExtendedCopy", CopyErrorOriginSource, errors.New("nil source target"))
+		return ocispec.Descriptor{}, newCopyError("ExtendedCopy", CopyErrorOriginSource, ocispec.Descriptor{}, errors.New("nil source target"))
 	}
 	if dst == nil {
-		return ocispec.Descriptor{}, newCopyError("ExtendedCopy", CopyErrorOriginDestination, errors.New("nil destination target"))
+		return ocispec.Descriptor{}, newCopyError("ExtendedCopy", CopyErrorOriginDestination, ocispec.Descriptor{}, errors.New("nil destination target"))
 	}
 	if dstRef == "" {
 		dstRef = srcRef
@@ -87,7 +87,7 @@ func ExtendedCopy(ctx context.Context, src ReadOnlyGraphTarget, srcRef string, d
 
 	node, err := src.Resolve(ctx, srcRef)
 	if err != nil {
-		return ocispec.Descriptor{}, newCopyError("Resolve", CopyErrorOriginSource, err)
+		return ocispec.Descriptor{}, newCopyError("Resolve", CopyErrorOriginSource, ocispec.Descriptor{}, err)
 	}
 
 	if err := ExtendedCopyGraph(ctx, src, dst, node, opts.ExtendedCopyGraphOptions); err != nil {
@@ -95,7 +95,7 @@ func ExtendedCopy(ctx context.Context, src ReadOnlyGraphTarget, srcRef string, d
 	}
 
 	if err := dst.Tag(ctx, node, dstRef); err != nil {
-		return ocispec.Descriptor{}, newCopyError("Tag", CopyErrorOriginDestination, err)
+		return ocispec.Descriptor{}, newCopyError("Tag", CopyErrorOriginDestination, node, err)
 	}
 
 	return node, nil
@@ -108,10 +108,10 @@ func ExtendedCopy(ctx context.Context, src ReadOnlyGraphTarget, srcRef string, d
 // The node (e.g. a manifest of the artifact) is identified by a descriptor.
 func ExtendedCopyGraph(ctx context.Context, src content.ReadOnlyGraphStorage, dst content.Storage, node ocispec.Descriptor, opts ExtendedCopyGraphOptions) error {
 	if src == nil {
-		return newCopyError("ExtendedCopyGraph", CopyErrorOriginSource, errors.New("nil source target"))
+		return newCopyError("ExtendedCopyGraph", CopyErrorOriginSource, ocispec.Descriptor{}, errors.New("nil source target"))
 	}
 	if dst == nil {
-		return newCopyError("ExtendedCopyGraph", CopyErrorOriginDestination, errors.New("nil destination target"))
+		return newCopyError("ExtendedCopyGraph", CopyErrorOriginDestination, ocispec.Descriptor{}, errors.New("nil destination target"))
 	}
 
 	roots, err := findRoots(ctx, src, node, opts)
@@ -189,7 +189,7 @@ func findRoots(ctx context.Context, storage content.ReadOnlyGraphStorage, node o
 
 		predecessors, err := opts.FindPredecessors(ctx, storage, currentNode)
 		if err != nil {
-			return nil, newCopyError("FindPredecessors", CopyErrorOriginSource, err)
+			return nil, newCopyError("FindPredecessors", CopyErrorOriginSource, currentNode, err)
 		}
 
 		// The current node has no predecessor node,

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -1980,3 +1980,35 @@ var errGraphTag = errors.New("graph tag error")
 func (bgt *badGraphTagger) Tag(_ context.Context, _ ocispec.Descriptor, _ string) error {
 	return errGraphTag
 }
+
+// TestExtendedCopy_CopyError_Descriptor verifies that a CopyError raised by
+// ExtendedCopy identifies the node that the failing operation was acting on.
+func TestExtendedCopy_CopyError_Descriptor(t *testing.T) {
+	ctx := context.Background()
+	src := memory.New()
+	dst := &badTagger{
+		Target: memory.New(),
+	}
+	srcRef := "test"
+
+	manifestDesc, err := oras.PackManifest(ctx, src, oras.PackManifestVersion1_1, "application/test", oras.PackManifestOptions{})
+	if err != nil {
+		t.Fatalf("failed to pack test content: %v", err)
+	}
+	if err := src.Tag(ctx, manifestDesc, srcRef); err != nil {
+		t.Fatalf("failed to tag test content on src: %v", err)
+	}
+
+	_, err = oras.ExtendedCopy(ctx, src, srcRef, dst, "", oras.DefaultExtendedCopyOptions)
+	var copyErr *oras.CopyError
+	if !errors.As(err, &copyErr) {
+		t.Fatalf("ExtendedCopy() error is not a CopyError: %v", err)
+	}
+	if !reflect.DeepEqual(copyErr.Descriptor, manifestDesc) {
+		t.Errorf("CopyError descriptor = %v, want %v", copyErr.Descriptor, manifestDesc)
+	}
+	want := `failed to perform "Tag" on destination for ` + manifestDesc.Digest.String() + `: ` + errTag.Error()
+	if got := copyErr.Error(); got != want {
+		t.Errorf("CopyError message = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What this PR does

Closes #1346.

`CopyError` records the operation that failed, the side it failed on and the
underlying error, but not *which* content the operation was acting on. For a
graph copy of a multi-layer image, `failed to perform "Fetch" on source:
unexpected EOF` does not tell the caller which blob is the problem.

This adds an optional `Descriptor` field to `CopyError` and threads it through
the `newCopyError` call sites that already have a descriptor, root or node in
scope, exactly as proposed in the issue:

```go
type CopyError struct {
	Op     string
	Origin CopyErrorOrigin
	// Descriptor is the content that the operation was acting on. It is the
	// zero value for errors raised before a specific node was selected.
	Descriptor ocispec.Descriptor
	Err        error
}
```

Call sites, matching the audit in the issue:

- `copy.go` — 11 of 17 sites get a real descriptor (`Exists`, `FindSuccessors`,
  `Mount`, `Fetch` x2, `Push`, `PushReference` take `desc`; `MapRoot`,
  `Successors` and both `Tag` sites take `root`). The remaining 6 — the nil
  target guards, the `CopyGraph` guards, `Resolve` and `FetchReference` — pass
  the zero value because they fail before a node is selected.
- `extendedcopy.go` — 2 of 7 sites (`Tag` takes `node`, `FindPredecessors`
  takes `currentNode`); the other 5 pass the zero value.

`Error()` includes the digest when the descriptor is set:

```
failed to perform "Fetch" on source for sha256:6ae8a755...: unexpected EOF
```

and renders **exactly** as before when it is not, so existing messages and the
`ExampleCopyError` output block are unchanged.

As the issue notes, the `Resolve` / `FetchReference` case — where a reference
string rather than a descriptor is the useful context — is deliberately left
out of scope; no reference field is added here.

## Compatibility

Additive and non-breaking. No existing field is renamed, retyped or removed.
Every `CopyError{...}` composite literal in the repo is keyed, so inserting
`Descriptor` between `Origin` and `Err` breaks nothing. `newCopyError` is
unexported, so the added parameter is internal.

## Tests

- `copyerror_test.go` — descriptor case added to `TestNewCopyError`; three new
  `TestCopyError_Error` cases (source / destination / undefined origin, all with
  a descriptor); new `TestCopyError_Descriptor` covering `errors.As` exposure
  and the zero-value message being unchanged.
- `copy_test.go` — `TestCopy_CopyError_Descriptor`: end-to-end through
  `oras.CopyGraph` (`Exists` site) and `oras.Copy` (`Tag` site, proving `root`
  threading), plus a nil-source-target case asserting the descriptor is the zero
  value and the message is byte-identical to before.
- `extendedcopy_test.go` — `TestExtendedCopy_CopyError_Descriptor`, proving the
  `node` threading at the `ExtendedCopy` `Tag` site.

Root-package coverage 89.1% -> 89.2%; `go test -race ./...`, `go vet ./...` and
`gofmt -l .` are clean.

## Note for reviewers

The `for <digest>` wording in `Error()` is my choice — the issue only asked that
the digest be included. Happy to change it to a plain `: <digest>` separator (as
in `copy.go`'s `failed to check cache existence: %s: %w`) if you prefer; it is
one `fmt.Sprintf` per branch.