### PR TITLE
feat(registry): expose predecessor finder

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,9 @@
 # Migration Guide
 
+## Major Changes in `v3`
+
+- `registry.Repository` now embeds `content.PredecessorFinder`. Implementations of `registry.Repository` must provide a `Predecessors` method. Consumers who only call the interface are unaffected.
+
 In version `v2`, ORAS Go library has been completely refreshed with:
 
 - More unified interfaces

--- a/extendedcopy_registry_test.go
+++ b/extendedcopy_registry_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras_test
+
+import (
+	"context"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	oras "github.com/oras-project/oras-go/v3"
+	"github.com/oras-project/oras-go/v3/registry/remote"
+)
+
+func TestRegistryRepositorySupportsExtendedCopyGraph(t *testing.T) {
+	ctx := context.Background()
+
+	reg, err := remote.NewRegistry("example.com")
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	repo, err := reg.Repository(ctx, "test")
+	if err != nil {
+		t.Fatalf("Repository() error = %v", err)
+	}
+
+	err = oras.ExtendedCopyGraph(
+		ctx,
+		repo,
+		nil,
+		ocispec.Descriptor{},
+		oras.DefaultExtendedCopyGraphOptions,
+	)
+	if err == nil {
+		t.Fatal("ExtendedCopyGraph() error = nil, want non-nil for nil destination")
+	}
+}

--- a/registry/interfaces.go
+++ b/registry/interfaces.go
@@ -40,6 +40,7 @@ type Repository interface {
 	content.Storage
 	content.Deleter
 	content.TagResolver
+	content.PredecessorFinder
 	ReferenceFetcher
 	ReferencePusher
 	ReferrerLister

--- a/registry/remote/middleware.go
+++ b/registry/remote/middleware.go
@@ -162,6 +162,11 @@ func (r *policyEnforcingRepository) Referrers(ctx context.Context, desc ocispec.
 	return r.repo.Referrers(ctx, desc, artifactType, fn)
 }
 
+// Predecessors bypasses policy checks so policy verification can discover attestations.
+func (r *policyEnforcingRepository) Predecessors(ctx context.Context, node ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	return r.repo.Predecessors(ctx, node)
+}
+
 // Tags bypasses policy checks because it returns names rather than image content.
 func (r *policyEnforcingRepository) Tags(ctx context.Context, last string, fn func(tags []string) error) error {
 	return r.repo.Tags(ctx, last, fn)

--- a/registry/remote/middleware_test.go
+++ b/registry/remote/middleware_test.go
@@ -381,8 +381,9 @@ func TestWithPolicyEnforcement_PolicyDenied_CarveOuts(t *testing.T) {
 
 	desc := ocispec.Descriptor{Digest: "sha256:test"}
 	baseRepo := &mockRepository{
-		referrersResult: []ocispec.Descriptor{desc},
-		tagsResult:      []string{"latest"},
+		referrersResult:    []ocispec.Descriptor{desc},
+		predecessorsResult: []ocispec.Descriptor{desc},
+		tagsResult:         []string{"latest"},
 	}
 	middleware := WithPolicyEnforcement(evaluator, policy.TransportNameDocker, "test/repo")
 	wrapped := middleware(baseRepo)
@@ -406,6 +407,14 @@ func TestWithPolicyEnforcement_PolicyDenied_CarveOuts(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Errorf("Referrers() error = %v, want nil", err)
+	}
+
+	predecessors, err := wrapped.Predecessors(ctx, desc)
+	if err != nil {
+		t.Errorf("Predecessors() error = %v, want nil", err)
+	}
+	if len(predecessors) != 1 || predecessors[0].Digest != desc.Digest {
+		t.Errorf("Predecessors() = %v, want [%v]", predecessors, desc)
 	}
 }
 


### PR DESCRIPTION
## Summary

- embed `content.PredecessorFinder` in `registry.Repository`
- make the policy-enforcing repository explicitly delegate `Predecessors`, mirroring the existing referrers carve-out
- add coverage that a repository returned by `Registry.Repository()` can be passed directly to `oras.ExtendedCopyGraph` without a type assertion
- document the `registry.Repository` interface change in the migration guide

## Testing

- `go test ./...`
- `make test`
- `git diff --check`

Fixes #1353
