### PR TITLE
fix: validate successor descriptors during copy

### DIFF
--- a/copy.go
+++ b/copy.go
@@ -263,8 +263,9 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 		successors = removeForeignLayers(successors)
 		for _, successor := range successors {
 			if err := validateSuccessor(successor); err != nil {
-				return fmt.Errorf("invalid successor descriptor for %s: successor media type: %s; successor size: %d; successor digest: %s: %w",
-					desc.Digest, successor.MediaType, successor.Size, successor.Digest, err)
+				return newCopyError("FindSuccessors", CopyErrorOriginSource, desc,
+					fmt.Errorf("invalid successor descriptor: successor media type: %s; successor size: %d; successor digest: %s: %w",
+						successor.MediaType, successor.Size, successor.Digest, err))
 			}
 		}
 
@@ -334,7 +335,7 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 // the next node in a content graph.
 func validateSuccessor(desc ocispec.Descriptor) error {
 	if err := desc.Digest.Validate(); err != nil {
-		return fmt.Errorf("invalid digest: %w", err)
+		return fmt.Errorf("invalid digest: %v: %w", err, errdef.ErrInvalidDigest)
 	}
 	if desc.Size < 0 {
 		return fmt.Errorf("invalid size %d", desc.Size)

--- a/copy.go
+++ b/copy.go
@@ -261,6 +261,12 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 			return newCopyError("FindSuccessors", CopyErrorOriginSource, desc, err)
 		}
 		successors = removeForeignLayers(successors)
+		for _, successor := range successors {
+			if err := validateSuccessor(successor); err != nil {
+				return fmt.Errorf("invalid successor descriptor for %s: successor media type: %s; successor size: %d; successor digest: %s: %w",
+					desc.Digest, successor.MediaType, successor.Size, successor.Digest, err)
+			}
+		}
 
 		if len(successors) != 0 {
 			// for non-leaf nodes, process successors and wait for them to complete
@@ -322,6 +328,24 @@ func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Sto
 	}
 
 	return syncutil.Go(ctx, limiter, fn, root)
+}
+
+// validateSuccessor checks the descriptor fields needed to safely traverse to
+// the next node in a content graph.
+func validateSuccessor(desc ocispec.Descriptor) error {
+	if err := desc.Digest.Validate(); err != nil {
+		return fmt.Errorf("invalid digest: %w", err)
+	}
+	if desc.Size < 0 {
+		return fmt.Errorf("invalid size %d", desc.Size)
+	}
+	// A zero-byte blob is valid, but content described as a manifest must
+	// contain a document. A zero size here typically means the required size
+	// field was omitted when the manifest descriptor was decoded.
+	if desc.Size == 0 && descriptor.IsManifest(desc) {
+		return errors.New("manifest size must be greater than zero")
+	}
+	return nil
 }
 
 // isMissingReferencedContentError reports whether err indicates that a

--- a/copy_test.go
+++ b/copy_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -1890,6 +1891,105 @@ func TestCopyGraph_WithOptions(t *testing.T) {
 			t.Errorf("count(PostCopy()) = %d, want %d", got, expected)
 		}
 	})
+}
+
+func TestCopyGraph_InvalidSuccessorDescriptor(t *testing.T) {
+	ctx := context.Background()
+	rootContent := []byte("root")
+	root := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, rootContent)
+
+	tests := []struct {
+		name      string
+		successor ocispec.Descriptor
+		reason    string
+	}{
+		{
+			name: "missing manifest size",
+			successor: ocispec.Descriptor{
+				MediaType: ocispec.MediaTypeImageManifest,
+				Digest:    digest.FromString("successor"),
+			},
+			reason: "manifest size must be greater than zero",
+		},
+		{
+			name: "negative size",
+			successor: ocispec.Descriptor{
+				MediaType: ocispec.MediaTypeImageLayer,
+				Digest:    digest.FromString("successor"),
+				Size:      -1,
+			},
+			reason: "invalid size -1",
+		},
+		{
+			name: "invalid digest",
+			successor: ocispec.Descriptor{
+				MediaType: ocispec.MediaTypeImageLayer,
+				Digest:    "not-a-digest",
+				Size:      1,
+			},
+			reason: "invalid digest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := cas.NewMemory()
+			if err := src.Push(ctx, root, bytes.NewReader(rootContent)); err != nil {
+				t.Fatal(err)
+			}
+			opts := oras.CopyGraphOptions{
+				FindSuccessors: func(context.Context, content.Fetcher, ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+					return []ocispec.Descriptor{tt.successor}, nil
+				},
+			}
+
+			err := oras.CopyGraph(ctx, src, cas.NewMemory(), root, opts)
+			if err == nil {
+				t.Fatal("CopyGraph() error = nil, want invalid successor descriptor error")
+			}
+			want := fmt.Sprintf("invalid successor descriptor for %s: successor media type: %s; successor size: %d; successor digest: %s",
+				root.Digest, tt.successor.MediaType, tt.successor.Size, tt.successor.Digest)
+			if got := err.Error(); !strings.Contains(got, want) || !strings.Contains(got, tt.reason) {
+				t.Errorf("CopyGraph() error = %q, want it to contain %q and %q", got, want, tt.reason)
+			}
+		})
+	}
+}
+
+func TestCopyGraph_ZeroSizeBlobSuccessor(t *testing.T) {
+	ctx := context.Background()
+	src := cas.NewMemory()
+	dst := cas.NewMemory()
+	rootContent := []byte("root")
+	root := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, rootContent)
+	emptyBlob := content.NewDescriptorFromBytes(ocispec.MediaTypeImageLayer, nil)
+	contents := []struct {
+		desc ocispec.Descriptor
+		blob []byte
+	}{
+		{root, rootContent},
+		{emptyBlob, nil},
+	}
+	for _, item := range contents {
+		if err := src.Push(ctx, item.desc, bytes.NewReader(item.blob)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	opts := oras.CopyGraphOptions{
+		FindSuccessors: func(_ context.Context, _ content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			if content.Equal(desc, root) {
+				return []ocispec.Descriptor{emptyBlob}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	if err := oras.CopyGraph(ctx, src, dst, root, opts); err != nil {
+		t.Fatalf("CopyGraph() error = %v", err)
+	}
+	if exists, err := dst.Exists(ctx, emptyBlob); err != nil || !exists {
+		t.Errorf("empty blob copied = %v, error = %v; want true, nil", exists, err)
+	}
 }
 
 // countingStorage counts the calls to its content.Storage methods

--- a/copy_test.go
+++ b/copy_test.go
@@ -1947,7 +1947,7 @@ func TestCopyGraph_InvalidSuccessorDescriptor(t *testing.T) {
 			if err == nil {
 				t.Fatal("CopyGraph() error = nil, want invalid successor descriptor error")
 			}
-			want := fmt.Sprintf("invalid successor descriptor for %s: successor media type: %s; successor size: %d; successor digest: %s",
+			want := fmt.Sprintf("failed to perform \"FindSuccessors\" on source for %s: invalid successor descriptor: successor media type: %s; successor size: %d; successor digest: %s",
 				root.Digest, tt.successor.MediaType, tt.successor.Size, tt.successor.Digest)
 			if got := err.Error(); !strings.Contains(got, want) || !strings.Contains(got, tt.reason) {
 				t.Errorf("CopyGraph() error = %q, want it to contain %q and %q", got, want, tt.reason)


### PR DESCRIPTION
## What this PR does

Validate each non-foreign successor descriptor immediately after `FindSuccessors` and before any successor copy is scheduled. The validation checks digest validity, negative sizes, and zero-sized manifest descriptors. Errors identify both the parent digest and all core fields of the invalid successor.

Zero-byte blobs remain valid and are covered by a regression test; only zero-sized descriptors for manifest media types are rejected because a manifest must contain a document. Media type itself is not rejected because custom graph implementations can return traversable descriptors without one.

This turns late, registry-specific failures such as `mismatch Content-Length` into an actionable error at the graph edge that introduced the malformed descriptor.

## Testing

- `go test .`
- focused invalid digest, negative size, and missing manifest size cases
- focused valid zero-byte blob traversal case

Closes #958