### PR TITLE
fix(ci): resolve dependency license file from config directory

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -41,4 +41,4 @@ header:
 
 dependency:
   files:
-    - go.mod
+    - ../go.mod


### PR DESCRIPTION
## Summary

Fixes #1359 by resolving the dependency license file relative to `.github/licenserc.yml`.

## Reproduction

On `main`, the config contains `dependency.files: [go.mod]`. The dependency checker resolves this path from the config directory, so it looks for `.github/go.mod`, which does not exist. The repository's actual module file is `../go.mod` from that directory. With skywalking-eyes 0.9.0, validation fails immediately with `open .../.github/go.mod: no such file or directory`.

## Cause

The path was written as though it were relative to the repository root, while `dependency.files` is interpreted relative to the configuration file directory.

## Fix and impact

Change the entry to `../go.mod`. This is correct for both the current and previous skywalking-eyes versions and restores the dependency license check without changing application code or runtime behavior.

## Verification

- Confirmed the failing path (`.github/go.mod`) is absent on `main`.
- Confirmed `../go.mod` resolves from `.github/`.
- `go test ./...`
- `go vet ./...`
- `make check-encoding`
- `git diff --check`

All passed. The skywalking-eyes GitHub Action itself was not run locally because it executes in GitHub Actions.

AI disclosure: the repository guidance and contribution-related files were inspected; no AI-use disclosure requirement was found.
