### PR TITLE
fix(ci): resolve dependency go.mod path relative to config directory

### DIFF
--- a/.github/licenserc.yml
+++ b/.github/licenserc.yml
@@ -41,4 +41,4 @@ header:
 
 dependency:
   files:
-    - go.mod
+    - ../go.mod


### PR DESCRIPTION
Fixes #1359

`dependency.files` entries in a skywalking-eyes config are resolved relative to the config file's directory, so `go.mod` in `.github/licenserc.yml` has always meant the nonexistent `.github/go.mod`. skywalking-eyes 0.8.0 passed by accident — its Go resolver just chdir'd into `.github/` and `go mod download` walked up to the root module — but 0.9.0 validates the declared path before the chdir, which is the `open .../.github/go.mod: no such file or directory` failure on #1358.

This changes the entry to `../go.mod`, which joins/cleans to the root `go.mod` — the same module 0.8.0 was scanning accidentally, so the set of checked dependencies is unchanged.

Verified locally with both pinned versions:

```console
$ license-eye -c .github/licenserc.yml dependency check   # v0.9.0, before: fails with ENOENT on .github/go.mod
$ license-eye -c .github/licenserc.yml dependency check   # v0.9.0 and v0.8.0, after: exit 0
```

Since the fix is also correct under the currently pinned 0.8.0, it can land independently; #1358 then needs a `@dependabot rebase` for its `check-license` run to go green.

Note: this PR was prepared with the assistance of an AI coding agent (Claude); the change was verified locally as described above, and the commit is DCO signed.
