### PR TITLE
fix(registry/remote): reject tag or digest in NewRepository reference

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -72,6 +72,15 @@ repo.Registry.PlainHTTP = true
 ref := repo.Reference()
 ```
 
+`repo.Reference` → `repo.Reference()` is not a pure rename. In v2 the field
+held the full parsed reference, including any tag or digest passed to
+`remote.NewRepository`; in v3 a `remote.Repository` identifies a repository
+only, so `Reference()` returns just the registry and repository name, and
+`remote.NewRepository` rejects a reference carrying a tag or digest with an
+error wrapping `errdef.ErrInvalidReference`. Parse such input with
+`properties.NewReference` and keep the tag or digest for the operation that
+needs it.
+
 `remote.NewRegistryWithProperties` and
 `remote.NewRepositoryWithProperties` are the preferred constructors when
 configuration comes from `registries.conf`, Docker configuration, certificates,
@@ -238,6 +247,10 @@ changes:
 
 ## Observable behavior changes
 
+- `remote.NewRepository` returns an error wrapping `errdef.ErrInvalidReference`
+  when the reference contains a tag or digest (e.g.
+  `localhost:5000/example:v1`). In v2 such a reference was accepted and the
+  tag or digest was kept on `repo.Reference`.
 - `oras.CopyError` includes a `Descriptor` when a copy operation had already
   selected content. Its error string includes the digest in those cases. Use
   `errors.As` and the structured fields rather than comparing error strings.

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -177,10 +177,18 @@ type Repository struct {
 // NewRepository creates a client to the remote repository identified by a
 // reference. A default Registry is created internally.
 // Example: localhost:5000/hello-world
+//
+// The reference must not contain a tag or a digest, since a Repository
+// identifies a repository rather than a specific artifact. A reference
+// carrying one is rejected with an error wrapping
+// [errdef.ErrInvalidReference].
 func NewRepository(reference string) (*Repository, error) {
 	ref, err := registry.ParseReference(reference)
 	if err != nil {
 		return nil, err
+	}
+	if ref.Tag != "" || ref.Digest != "" {
+		return nil, fmt.Errorf("%w: %q: expected a repository without a tag or digest", errdef.ErrInvalidReference, reference)
 	}
 
 	// Create a default Registry

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -149,6 +149,16 @@ func TestNewRepository(t *testing.T) {
 			wantErr:   errdef.ErrInvalidReference,
 		},
 		{
+			name:      "reference with tag",
+			reference: "localhost:5000/hello-world:v1",
+			wantErr:   errdef.ErrInvalidReference,
+		},
+		{
+			name:      "reference with digest",
+			reference: "localhost:5000/hello-world@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+			wantErr:   errdef.ErrInvalidReference,
+		},
+		{
 			name:      "empty reference",
 			reference: "",
 			wantErr:   errdef.ErrInvalidReference,


### PR DESCRIPTION
Fixes #1365

`remote.NewRepository` parsed its reference argument and silently dropped any tag or digest it carried, so

```go
repo, _ := remote.NewRepository("localhost:5000/hello:v1")
repo.Reference() // localhost:5000/hello — the ":v1" is unrecoverable
```

succeeded with the `:v1` gone and no way to read it back. This implements option 1 from the issue: `NewRepository` now returns an error wrapping `errdef.ErrInvalidReference` when the reference contains a tag or digest, turning the silent data loss into a loud one at the call site. A `Repository` models a repository rather than a specific artifact, so rejecting the input also keeps `Reference()` accurate for every value the constructor accepts.

Changes:

- `registry/remote/repository.go`: reject tag/digest-bearing references in `NewRepository`, and state the contract in its doc comment.
- `registry/remote/repository_test.go`: table cases for a tagged and a digested reference.
- `MIGRATION_GUIDE.md`: note that `repo.Reference` → `repo.Reference()` is not a pure rename, and record the new constructor error under **Observable behavior changes**.

No in-repo caller passes a tagged or digested reference to `NewRepository`, so nothing else changes. `NewRepositoryWithProperties` is untouched: its input is a structured `properties.Registry` built field by field, not a parsed string.

`go build ./...`, `go vet ./registry/...`, and `go test ./...` pass.
