### PR TITLE
fix(registry/remote): make signedBy policy satisfiable for tag references and tagless operations

### DIFF
--- a/registry/remote/policy/evaluator.go
+++ b/registry/remote/policy/evaluator.go
@@ -102,6 +102,12 @@ func NewEvaluator(policy *Policy, opts ...EvaluatorOption) (*Evaluator, error) {
 
 // IsImageAllowed determines if an image is allowed by the policy
 func (e *Evaluator) IsImageAllowed(ctx context.Context, image ImageReference) (bool, error) {
+	return e.isImageAllowed(ctx, image, nil)
+}
+
+// isImageAllowed evaluates policy requirements accepted by filter. A nil
+// filter evaluates every requirement.
+func (e *Evaluator) isImageAllowed(ctx context.Context, image ImageReference, filter func(PolicyRequirement) bool) (bool, error) {
 	reqs := e.policy.GetRequirementsForImage(image.Transport, image.Scope)
 
 	if len(reqs) == 0 {
@@ -111,6 +117,9 @@ func (e *Evaluator) IsImageAllowed(ctx context.Context, image ImageReference) (b
 
 	// All requirements must be satisfied
 	for _, req := range reqs {
+		if filter != nil && !filter(req) {
+			continue
+		}
 		allowed, err := e.evaluateRequirement(ctx, req, image)
 		if err != nil {
 			return false, fmt.Errorf("failed to evaluate requirement %s: %w", req.Type(), err)
@@ -128,32 +137,21 @@ func (e *Evaluator) IsImageAllowed(ctx context.Context, image ImageReference) (b
 // insecureAcceptAnything. Signature-based requirements (signedBy,
 // sigstoreSigned) are skipped: they verify signatures against a manifest
 // digest, which a tag reference or a reference-less operation does not
-// carry. Callers should evaluate them with IsImageAllowed once the
+// carry. Callers should evaluate them with IsResolvedImageAllowed once the
 // reference is resolved, setting ImageReference.Digest to the resolved
 // manifest digest.
 func (e *Evaluator) IsReferenceAllowed(ctx context.Context, image ImageReference) (bool, error) {
-	reqs := e.policy.GetRequirementsForImage(image.Transport, image.Scope)
+	return e.isImageAllowed(ctx, image, func(req PolicyRequirement) bool {
+		return !requiresResolvedImage(req)
+	})
+}
 
-	if len(reqs) == 0 {
-		// No requirements: treat as a policy error and reject by default for safety.
-		return false, fmt.Errorf("no policy requirements found for %s:%s", image.Transport, image.Scope)
-	}
-
-	// All reference-level requirements must be satisfied.
-	for _, req := range reqs {
-		if requiresResolvedImage(req) {
-			continue
-		}
-		allowed, err := e.evaluateRequirement(ctx, req, image)
-		if err != nil {
-			return false, fmt.Errorf("failed to evaluate requirement %s: %w", req.Type(), err)
-		}
-		if !allowed {
-			return false, nil
-		}
-	}
-
-	return true, nil
+// IsResolvedImageAllowed determines if an image is allowed by requirements
+// that need its resolved manifest digest, such as signedBy and
+// sigstoreSigned. Reference-level requirements are skipped because callers
+// should evaluate them first with IsReferenceAllowed.
+func (e *Evaluator) IsResolvedImageAllowed(ctx context.Context, image ImageReference) (bool, error) {
+	return e.isImageAllowed(ctx, image, requiresResolvedImage)
 }
 
 // requiresResolvedImage reports whether the requirement needs the resolved

--- a/registry/remote/policy/evaluator.go
+++ b/registry/remote/policy/evaluator.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/oras-project/oras-go/v3/errdef"
 )
 
@@ -30,6 +31,12 @@ type ImageReference struct {
 	Scope string
 	// Reference is the full reference (e.g., "docker.io/library/nginx:latest")
 	Reference string
+	// Digest is the manifest digest the reference resolves to, if known.
+	// Signature-based requirements (signedBy, sigstoreSigned) verify
+	// signatures against the manifest digest, so callers that resolve a tag
+	// reference should set it before evaluating those requirements.
+	// When empty, verifiers fall back to extracting a digest from Reference.
+	Digest digest.Digest
 }
 
 // SignedByVerifier verifies GPG/simple signing signatures.
@@ -114,6 +121,49 @@ func (e *Evaluator) IsImageAllowed(ctx context.Context, image ImageReference) (b
 	}
 
 	return true, nil
+}
+
+// IsReferenceAllowed determines if an image is allowed by the requirements
+// that can be decided from the reference alone, such as reject and
+// insecureAcceptAnything. Signature-based requirements (signedBy,
+// sigstoreSigned) are skipped: they verify signatures against a manifest
+// digest, which a tag reference or a reference-less operation does not
+// carry. Callers should evaluate them with IsImageAllowed once the
+// reference is resolved, setting ImageReference.Digest to the resolved
+// manifest digest.
+func (e *Evaluator) IsReferenceAllowed(ctx context.Context, image ImageReference) (bool, error) {
+	reqs := e.policy.GetRequirementsForImage(image.Transport, image.Scope)
+
+	if len(reqs) == 0 {
+		// No requirements: treat as a policy error and reject by default for safety.
+		return false, fmt.Errorf("no policy requirements found for %s:%s", image.Transport, image.Scope)
+	}
+
+	// All reference-level requirements must be satisfied.
+	for _, req := range reqs {
+		if requiresResolvedImage(req) {
+			continue
+		}
+		allowed, err := e.evaluateRequirement(ctx, req, image)
+		if err != nil {
+			return false, fmt.Errorf("failed to evaluate requirement %s: %w", req.Type(), err)
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// requiresResolvedImage reports whether the requirement needs the resolved
+// manifest digest of the image to be evaluated.
+func requiresResolvedImage(req PolicyRequirement) bool {
+	switch req.(type) {
+	case *PRSignedBy, *PRSigstoreSigned:
+		return true
+	}
+	return false
 }
 
 // evaluateRequirement evaluates a single policy requirement

--- a/registry/remote/policy/evaluator_test.go
+++ b/registry/remote/policy/evaluator_test.go
@@ -347,3 +347,54 @@ func TestEvaluator_IsReferenceAllowed(t *testing.T) {
 		}
 	})
 }
+
+func TestEvaluator_IsResolvedImageAllowed_SkipsReferenceRequirements(t *testing.T) {
+	policy := &Policy{
+		Default: PolicyRequirements{
+			&Reject{},
+			&PRSignedBy{KeyType: "GPGKeys", KeyPath: "/path/to/key.gpg"},
+		},
+	}
+	evaluator, err := NewEvaluator(policy, WithSignedByVerifier(&mockSignedByVerifier{result: true}))
+	if err != nil {
+		t.Fatalf("NewEvaluator() error: %v", err)
+	}
+
+	allowed, err := evaluator.IsResolvedImageAllowed(context.Background(), ImageReference{
+		Transport: TransportNameDocker,
+		Scope:     "docker.io/library/nginx",
+		Reference: "docker.io/library/nginx:latest",
+	})
+	if err != nil {
+		t.Fatalf("IsResolvedImageAllowed() error: %v", err)
+	}
+	if !allowed {
+		t.Error("IsResolvedImageAllowed() = false, want true (reference requirements skipped)")
+	}
+}
+
+func TestEvaluator_IsResolvedImageAllowed_NoRequirementsRejects(t *testing.T) {
+	policy := &Policy{
+		Default: PolicyRequirements{&InsecureAcceptAnything{}},
+		Transports: map[TransportName]TransportScopes{
+			TransportNameDocker: {
+				"docker.io/library/nginx": PolicyRequirements{},
+			},
+		},
+	}
+	evaluator, err := NewEvaluator(policy)
+	if err != nil {
+		t.Fatalf("NewEvaluator() error: %v", err)
+	}
+
+	allowed, err := evaluator.IsResolvedImageAllowed(context.Background(), ImageReference{
+		Transport: TransportNameDocker,
+		Scope:     "docker.io/library/nginx",
+	})
+	if err == nil {
+		t.Error("IsResolvedImageAllowed() error = nil, want error for empty requirements")
+	}
+	if allowed {
+		t.Error("IsResolvedImageAllowed() = true, want false")
+	}
+}

--- a/registry/remote/policy/evaluator_test.go
+++ b/registry/remote/policy/evaluator_test.go
@@ -254,3 +254,96 @@ func TestEvaluator_WithBothVerifiers(t *testing.T) {
 		t.Error("IsImageAllowed() should return true when all verifiers pass")
 	}
 }
+
+func TestEvaluator_IsReferenceAllowed(t *testing.T) {
+	image := ImageReference{
+		Transport: TransportNameDocker,
+		Scope:     "docker.io/library/nginx",
+		Reference: "docker.io/library/nginx:latest",
+	}
+
+	t.Run("signature requirements are deferred", func(t *testing.T) {
+		policy := &Policy{
+			Default: PolicyRequirements{
+				&PRSignedBy{KeyType: "GPGKeys", KeyPath: "/path/to/key.gpg"},
+				&PRSigstoreSigned{KeyPath: "/path/to/key.pub"},
+			},
+		}
+		// No verifiers configured: if signature requirements were evaluated,
+		// this would fail with ErrUnsupported.
+		evaluator, err := NewEvaluator(policy)
+		if err != nil {
+			t.Fatalf("NewEvaluator() error: %v", err)
+		}
+
+		allowed, err := evaluator.IsReferenceAllowed(context.Background(), image)
+		if err != nil {
+			t.Fatalf("IsReferenceAllowed() error: %v", err)
+		}
+		if !allowed {
+			t.Error("IsReferenceAllowed() = false, want true (signature requirements deferred)")
+		}
+	})
+
+	t.Run("reject is evaluated", func(t *testing.T) {
+		policy := &Policy{
+			Default: PolicyRequirements{
+				&PRSignedBy{KeyType: "GPGKeys", KeyPath: "/path/to/key.gpg"},
+				&Reject{},
+			},
+		}
+		evaluator, err := NewEvaluator(policy)
+		if err != nil {
+			t.Fatalf("NewEvaluator() error: %v", err)
+		}
+
+		allowed, err := evaluator.IsReferenceAllowed(context.Background(), image)
+		if err != nil {
+			t.Fatalf("IsReferenceAllowed() error: %v", err)
+		}
+		if allowed {
+			t.Error("IsReferenceAllowed() = true, want false (reject)")
+		}
+	})
+
+	t.Run("insecureAcceptAnything is evaluated", func(t *testing.T) {
+		policy := &Policy{
+			Default: PolicyRequirements{&InsecureAcceptAnything{}},
+		}
+		evaluator, err := NewEvaluator(policy)
+		if err != nil {
+			t.Fatalf("NewEvaluator() error: %v", err)
+		}
+
+		allowed, err := evaluator.IsReferenceAllowed(context.Background(), image)
+		if err != nil {
+			t.Fatalf("IsReferenceAllowed() error: %v", err)
+		}
+		if !allowed {
+			t.Error("IsReferenceAllowed() = false, want true")
+		}
+	})
+
+	t.Run("no requirements rejects", func(t *testing.T) {
+		policy := &Policy{
+			Default: PolicyRequirements{&InsecureAcceptAnything{}},
+			Transports: map[TransportName]TransportScopes{
+				TransportNameDocker: {
+					image.Scope: PolicyRequirements{},
+				},
+			},
+		}
+		evaluator, err := NewEvaluator(policy)
+		if err != nil {
+			t.Fatalf("NewEvaluator() error: %v", err)
+		}
+
+		allowed, err := evaluator.IsReferenceAllowed(context.Background(), image)
+		if err == nil {
+			t.Error("IsReferenceAllowed() error = nil, want error for empty requirements")
+		}
+		if allowed {
+			t.Error("IsReferenceAllowed() = true, want false")
+		}
+	})
+}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -410,25 +410,17 @@ func withPolicyChecked(ctx context.Context) context.Context {
 	return context.WithValue(ctx, policyCheckedKey{}, true)
 }
 
-// checkPolicy validates the repository access against the requirements of
-// the configured policy that can be decided from the reference alone, such
-// as reject and insecureAcceptAnything. If no policy is configured (Policy
-// is nil), this is a no-op.
+// checkPolicy validates repository access before network I/O. It evaluates
+// reference-level requirements for every reference and digest-dependent
+// requirements when the reference already carries a digest. If no policy is
+// configured (Policy is nil), this is a no-op.
 //
-// Policy is enforced on all registry operations including:
-//   - Content operations: Fetch, Push, Resolve, FetchReference, PushReference
-//   - Metadata operations: Exists, Tags, Referrers, Predecessors
-//   - Mutating operations: Delete, Tag, Mount
-//
-// Signature requirements (signedBy/sigstoreSigned) verify signatures
-// against a manifest digest, which a tag reference or a reference-less
-// operation does not carry, so they are evaluated separately by
-// checkPolicyResolved on the operations that resolve or supply a manifest
-// descriptor: Fetch, Push, Exists, Delete, Resolve, FetchReference, Tag and
-// PushReference. Operations that never involve a manifest are subject only
-// to reference-level requirements. Descriptor-based push operations verify
-// the supplied manifest before uploading it, so its signing material must be
-// discoverable by the configured verifier at that point.
+// Signature requirements (signedBy/sigstoreSigned) are otherwise evaluated
+// by checkPolicyResolved when an operation resolves or supplies a manifest
+// descriptor. Blob operations and operations without a manifest remain
+// reference-level only. Descriptor-based push operations verify the supplied
+// manifest before uploading it, so its signing material must be discoverable
+// by the configured verifier at that point.
 func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 	if ctx.Value(policyCheckedKey{}) != nil {
 		return nil
@@ -447,7 +439,8 @@ func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 	if !allowed {
 		return fmt.Errorf("access denied by policy for %s", imageRef.Reference)
 	}
-	if imageRef.Digest = r.policyDigest(reference); imageRef.Digest != "" {
+	imageRef.Digest = r.policyDigest(reference)
+	if imageRef.Digest != "" {
 		allowed, err = pol.IsResolvedImageAllowed(withPolicyChecked(ctx), imageRef)
 		if err != nil {
 			return fmt.Errorf("policy check failed: %w", err)
@@ -462,7 +455,8 @@ func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 // checkPolicyResolved validates the manifest descriptor a reference resolves
 // to against digest-dependent policy requirements. The caller's reference is
 // kept for signed identity matching while the resolved digest is used for
-// signature lookup and payload validation.
+// signature lookup and payload validation. Callers must first call checkPolicy
+// with the same reference because digest references are fully checked there.
 func (r *Repository) checkPolicyResolved(ctx context.Context, reference string, desc ocispec.Descriptor) error {
 	if ctx.Value(policyCheckedKey{}) != nil {
 		return nil
@@ -478,7 +472,11 @@ func (r *Repository) checkPolicyResolved(ctx context.Context, reference string, 
 		return nil
 	}
 
-	imageRef := r.policyImageReference(reference)
+	policyReference := reference
+	if policyReference == "" {
+		policyReference = desc.Digest.String()
+	}
+	imageRef := r.policyImageReference(policyReference)
 	imageRef.Digest = desc.Digest
 
 	// Mark the context as checked so verifiers that call back into this
@@ -516,7 +514,11 @@ func (r *Repository) policyImageReference(reference string) policy.ImageReferenc
 	repoRef := r.Reference()
 	ref := repoRef.String()
 	if reference != "" {
-		ref = reference
+		if parsed, err := r.ParseReference(reference); err == nil {
+			ref = parsed.String()
+		} else {
+			ref = reference
+		}
 	}
 	return policy.ImageReference{
 		Transport: policy.TransportNameDocker,

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -424,9 +424,11 @@ func withPolicyChecked(ctx context.Context) context.Context {
 // against a manifest digest, which a tag reference or a reference-less
 // operation does not carry, so they are evaluated separately by
 // checkPolicyResolved on the operations that resolve or supply a manifest
-// descriptor: Resolve, FetchReference, Tag and PushReference. Operations
-// that never involve a manifest reference are subject only to
-// reference-level requirements.
+// descriptor: Fetch, Push, Exists, Delete, Resolve, FetchReference, Tag and
+// PushReference. Operations that never involve a manifest are subject only
+// to reference-level requirements. Descriptor-based push operations verify
+// the supplied manifest before uploading it, so its signing material must be
+// discoverable by the configured verifier at that point.
 func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 	if ctx.Value(policyCheckedKey{}) != nil {
 		return nil
@@ -445,15 +447,29 @@ func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 	if !allowed {
 		return fmt.Errorf("access denied by policy for %s", imageRef.Reference)
 	}
+	if imageRef.Digest = r.policyDigest(reference); imageRef.Digest != "" {
+		allowed, err = pol.IsResolvedImageAllowed(withPolicyChecked(ctx), imageRef)
+		if err != nil {
+			return fmt.Errorf("policy check failed: %w", err)
+		}
+		if !allowed {
+			return fmt.Errorf("access denied by policy for %s", imageRef.Reference)
+		}
+	}
 	return nil
 }
 
 // checkPolicyResolved validates the manifest descriptor a reference resolves
-// to against the full policy, including signature requirements. The caller's
-// reference is kept for signed identity matching while the resolved digest
-// is used for signature lookup and payload validation.
+// to against digest-dependent policy requirements. The caller's reference is
+// kept for signed identity matching while the resolved digest is used for
+// signature lookup and payload validation.
 func (r *Repository) checkPolicyResolved(ctx context.Context, reference string, desc ocispec.Descriptor) error {
 	if ctx.Value(policyCheckedKey{}) != nil {
+		return nil
+	}
+	// Digest references are fully evaluated by checkPolicy before any
+	// registry request is made.
+	if r.policyDigest(reference) != "" {
 		return nil
 	}
 
@@ -468,7 +484,7 @@ func (r *Repository) checkPolicyResolved(ctx context.Context, reference string, 
 	// Mark the context as checked so verifiers that call back into this
 	// repository (e.g. to fetch signature artifacts) do not recursively
 	// evaluate policy.
-	allowed, err := pol.IsImageAllowed(withPolicyChecked(ctx), imageRef)
+	allowed, err := pol.IsResolvedImageAllowed(withPolicyChecked(ctx), imageRef)
 	if err != nil {
 		return fmt.Errorf("policy check failed: %w", err)
 	}
@@ -476,6 +492,22 @@ func (r *Repository) checkPolicyResolved(ctx context.Context, reference string, 
 		return fmt.Errorf("access denied by policy for %s", imageRef.Reference)
 	}
 	return nil
+}
+
+// checkManifestPolicy evaluates both policy phases for a known manifest.
+func (r *Repository) checkManifestPolicy(ctx context.Context, reference string, desc ocispec.Descriptor) error {
+	if err := r.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	return r.checkPolicyResolved(ctx, reference, desc)
+}
+
+// checkDescriptorPolicy evaluates signature requirements only for manifests.
+func (r *Repository) checkDescriptorPolicy(ctx context.Context, desc ocispec.Descriptor) error {
+	if isManifest(r.manifestMediaTypes(), desc) {
+		return r.checkManifestPolicy(ctx, "", desc)
+	}
+	return r.checkPolicy(ctx, "")
 }
 
 // policyImageReference builds the policy image reference for the given
@@ -493,10 +525,26 @@ func (r *Repository) policyImageReference(reference string) policy.ImageReferenc
 	}
 }
 
+// policyDigest returns the digest carried by reference, if any.
+func (r *Repository) policyDigest(reference string) digest.Digest {
+	if reference == "" {
+		return ""
+	}
+	ref, err := r.ParseReference(reference)
+	if err != nil {
+		return ""
+	}
+	d, err := digest.Parse(ref.Reference)
+	if err != nil {
+		return ""
+	}
+	return d
+}
+
 // Fetch fetches the content identified by the descriptor.
 // If mirrors are configured, they are tried in order before the primary.
 func (r *Repository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
-	if err := r.checkPolicy(ctx, ""); err != nil {
+	if err := r.checkDescriptorPolicy(ctx, target); err != nil {
 		return nil, err
 	}
 	ctx = withPolicyChecked(ctx)
@@ -511,7 +559,7 @@ func (r *Repository) Fetch(ctx context.Context, target ocispec.Descriptor) (io.R
 
 // Push pushes the content, matching the expected descriptor.
 func (r *Repository) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
-	if err := r.checkPolicy(ctx, ""); err != nil {
+	if err := r.checkDescriptorPolicy(ctx, expected); err != nil {
 		return err
 	}
 	return r.blobStore(expected).Push(withPolicyChecked(ctx), expected, content)
@@ -540,7 +588,7 @@ func (r *Repository) Mount(ctx context.Context, desc ocispec.Descriptor, fromRep
 // Exists returns true if the described content exists.
 // If mirrors are configured, they are tried in order before the primary.
 func (r *Repository) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
-	if err := r.checkPolicy(ctx, ""); err != nil {
+	if err := r.checkDescriptorPolicy(ctx, target); err != nil {
 		return false, err
 	}
 	ctx = withPolicyChecked(ctx)
@@ -555,7 +603,7 @@ func (r *Repository) Exists(ctx context.Context, target ocispec.Descriptor) (boo
 
 // Delete removes the content identified by the descriptor.
 func (r *Repository) Delete(ctx context.Context, target ocispec.Descriptor) error {
-	if err := r.checkPolicy(ctx, ""); err != nil {
+	if err := r.checkDescriptorPolicy(ctx, target); err != nil {
 		return err
 	}
 	return r.blobStore(target).Delete(withPolicyChecked(ctx), target)
@@ -601,10 +649,7 @@ func (r *Repository) Resolve(ctx context.Context, reference string) (ocispec.Des
 
 // Tag tags a manifest descriptor with a reference string.
 func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
-	if err := r.checkPolicy(ctx, reference); err != nil {
-		return err
-	}
-	if err := r.checkPolicyResolved(ctx, reference, desc); err != nil {
+	if err := r.checkManifestPolicy(ctx, reference, desc); err != nil {
 		return err
 	}
 	return r.Manifests().Tag(withPolicyChecked(ctx), desc, reference)
@@ -630,10 +675,7 @@ func (r *Repository) Untag(ctx context.Context, reference string) error {
 
 // PushReference pushes the manifest with a reference tag.
 func (r *Repository) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
-	if err := r.checkPolicy(ctx, reference); err != nil {
-		return err
-	}
-	if err := r.checkPolicyResolved(ctx, reference, expected); err != nil {
+	if err := r.checkManifestPolicy(ctx, reference, expected); err != nil {
 		return err
 	}
 	return r.Manifests().PushReference(withPolicyChecked(ctx), expected, content, reference)
@@ -1463,7 +1505,7 @@ type manifestStore struct {
 
 // Fetch fetches the content identified by the descriptor.
 func (s *manifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io.ReadCloser, err error) {
-	if err := s.repo.checkPolicy(ctx, ""); err != nil {
+	if err := s.repo.checkManifestPolicy(ctx, "", target); err != nil {
 		return nil, err
 	}
 	repoRef := s.repo.Reference()
@@ -1514,15 +1556,15 @@ func (s *manifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (r
 
 // Push pushes the content, matching the expected descriptor.
 func (s *manifestStore) Push(ctx context.Context, expected ocispec.Descriptor, content io.Reader) error {
-	if err := s.repo.checkPolicy(ctx, ""); err != nil {
+	if err := s.repo.checkManifestPolicy(ctx, "", expected); err != nil {
 		return err
 	}
-	return s.pushWithIndexing(ctx, expected, content, expected.Digest.String())
+	return s.pushWithIndexing(withPolicyChecked(ctx), expected, content, expected.Digest.String())
 }
 
 // Exists returns true if the described content exists.
 func (s *manifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (bool, error) {
-	if err := s.repo.checkPolicy(ctx, ""); err != nil {
+	if err := s.repo.checkManifestPolicy(ctx, "", target); err != nil {
 		return false, err
 	}
 	_, err := s.Resolve(withPolicyChecked(ctx), target.Digest.String())
@@ -1537,10 +1579,10 @@ func (s *manifestStore) Exists(ctx context.Context, target ocispec.Descriptor) (
 
 // Delete removes the manifest content identified by the descriptor.
 func (s *manifestStore) Delete(ctx context.Context, target ocispec.Descriptor) error {
-	if err := s.repo.checkPolicy(ctx, ""); err != nil {
+	if err := s.repo.checkManifestPolicy(ctx, "", target); err != nil {
 		return err
 	}
-	return s.deleteWithIndexing(ctx, target)
+	return s.deleteWithIndexing(withPolicyChecked(ctx), target)
 }
 
 // deleteWithIndexing removes the manifest content identified by the descriptor,
@@ -1694,12 +1736,10 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 
 // Tag tags a manifest descriptor with a reference string.
 func (s *manifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
-	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+	if err := s.repo.checkManifestPolicy(ctx, reference, desc); err != nil {
 		return err
 	}
-	if err := s.repo.checkPolicyResolved(ctx, reference, desc); err != nil {
-		return err
-	}
+	ctx = withPolicyChecked(ctx)
 	ref, err := s.repo.ParseReference(reference)
 	if err != nil {
 		return err
@@ -1751,12 +1791,10 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 
 // PushReference pushes the manifest with a reference tag.
 func (s *manifestStore) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
-	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+	if err := s.repo.checkManifestPolicy(ctx, reference, expected); err != nil {
 		return err
 	}
-	if err := s.repo.checkPolicyResolved(ctx, reference, expected); err != nil {
-		return err
-	}
+	ctx = withPolicyChecked(ctx)
 	ref, err := s.repo.ParseReference(reference)
 	if err != nil {
 		return err

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -402,17 +402,23 @@ func withPolicyChecked(ctx context.Context) context.Context {
 	return context.WithValue(ctx, policyCheckedKey{}, true)
 }
 
-// checkPolicy validates the repository access against the configured policy.
-// If no policy is configured (Policy is nil), this is a no-op.
+// checkPolicy validates the repository access against the requirements of
+// the configured policy that can be decided from the reference alone, such
+// as reject and insecureAcceptAnything. If no policy is configured (Policy
+// is nil), this is a no-op.
 //
 // Policy is enforced on all registry operations including:
 //   - Content operations: Fetch, Push, Resolve, FetchReference, PushReference
 //   - Metadata operations: Exists, Tags, Referrers, Predecessors
 //   - Mutating operations: Delete, Tag, Mount
 //
-// For signedBy/sigstoreSigned requirements, signature verification is
-// performed regardless of operation type. If this is too restrictive for
-// administrative operations, configure a separate policy scope.
+// Signature requirements (signedBy/sigstoreSigned) verify signatures
+// against a manifest digest, which a tag reference or a reference-less
+// operation does not carry, so they are evaluated separately by
+// checkPolicyResolved on the operations that resolve or supply a manifest
+// descriptor: Resolve, FetchReference, Tag and PushReference. Operations
+// that never involve a manifest reference are subject only to
+// reference-level requirements.
 func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 	if ctx.Value(policyCheckedKey{}) != nil {
 		return nil
@@ -423,26 +429,60 @@ func (r *Repository) checkPolicy(ctx context.Context, reference string) error {
 		return nil
 	}
 
+	imageRef := r.policyImageReference(reference)
+	allowed, err := pol.IsReferenceAllowed(ctx, imageRef)
+	if err != nil {
+		return fmt.Errorf("policy check failed: %w", err)
+	}
+	if !allowed {
+		return fmt.Errorf("access denied by policy for %s", imageRef.Reference)
+	}
+	return nil
+}
+
+// checkPolicyResolved validates the manifest descriptor a reference resolves
+// to against the full policy, including signature requirements. The caller's
+// reference is kept for signed identity matching while the resolved digest
+// is used for signature lookup and payload validation.
+func (r *Repository) checkPolicyResolved(ctx context.Context, reference string, desc ocispec.Descriptor) error {
+	if ctx.Value(policyCheckedKey{}) != nil {
+		return nil
+	}
+
+	pol := r.policy()
+	if pol == nil {
+		return nil
+	}
+
+	imageRef := r.policyImageReference(reference)
+	imageRef.Digest = desc.Digest
+
+	// Mark the context as checked so verifiers that call back into this
+	// repository (e.g. to fetch signature artifacts) do not recursively
+	// evaluate policy.
+	allowed, err := pol.IsImageAllowed(withPolicyChecked(ctx), imageRef)
+	if err != nil {
+		return fmt.Errorf("policy check failed: %w", err)
+	}
+	if !allowed {
+		return fmt.Errorf("access denied by policy for %s", imageRef.Reference)
+	}
+	return nil
+}
+
+// policyImageReference builds the policy image reference for the given
+// caller reference, falling back to the repository reference when empty.
+func (r *Repository) policyImageReference(reference string) policy.ImageReference {
 	repoRef := r.Reference()
 	ref := repoRef.String()
 	if reference != "" {
 		ref = reference
 	}
-
-	imageRef := policy.ImageReference{
+	return policy.ImageReference{
 		Transport: policy.TransportNameDocker,
 		Scope:     repoRef.Registry + "/" + repoRef.Repository,
 		Reference: ref,
 	}
-
-	allowed, err := pol.IsImageAllowed(ctx, imageRef)
-	if err != nil {
-		return fmt.Errorf("policy check failed: %w", err)
-	}
-	if !allowed {
-		return fmt.Errorf("access denied by policy for %s", ref)
-	}
-	return nil
 }
 
 // Fetch fetches the content identified by the descriptor.
@@ -531,19 +571,32 @@ func (r *Repository) Resolve(ctx context.Context, reference string) (ocispec.Des
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	ctx = withPolicyChecked(ctx)
+	resolveCtx := withPolicyChecked(ctx)
+	var desc ocispec.Descriptor
+	var err error
 	if len(r.mirrors) > 0 {
-		return withMirrorFallbackResolve(ctx, r.mirrors, r, reference,
+		desc, err = withMirrorFallbackResolve(resolveCtx, r.mirrors, r, reference,
 			func(ctx context.Context, repo *Repository, ref string) (ocispec.Descriptor, error) {
 				return repo.Manifests().Resolve(ctx, ref)
 			})
+	} else {
+		desc, err = r.Manifests().Resolve(resolveCtx, reference)
 	}
-	return r.Manifests().Resolve(ctx, reference)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	if err := r.checkPolicyResolved(ctx, reference, desc); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return desc, nil
 }
 
 // Tag tags a manifest descriptor with a reference string.
 func (r *Repository) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
 	if err := r.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	if err := r.checkPolicyResolved(ctx, reference, desc); err != nil {
 		return err
 	}
 	return r.Manifests().Tag(withPolicyChecked(ctx), desc, reference)
@@ -572,6 +625,9 @@ func (r *Repository) PushReference(ctx context.Context, expected ocispec.Descrip
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return err
 	}
+	if err := r.checkPolicyResolved(ctx, reference, expected); err != nil {
+		return err
+	}
 	return r.Manifests().PushReference(withPolicyChecked(ctx), expected, content, reference)
 }
 
@@ -582,14 +638,26 @@ func (r *Repository) FetchReference(ctx context.Context, reference string) (ocis
 	if err := r.checkPolicy(ctx, reference); err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	ctx = withPolicyChecked(ctx)
+	fetchCtx := withPolicyChecked(ctx)
+	var desc ocispec.Descriptor
+	var rc io.ReadCloser
+	var err error
 	if len(r.mirrors) > 0 {
-		return withMirrorFallbackFetchReference(ctx, r.mirrors, r, reference,
+		desc, rc, err = withMirrorFallbackFetchReference(fetchCtx, r.mirrors, r, reference,
 			func(ctx context.Context, repo *Repository, ref string) (ocispec.Descriptor, io.ReadCloser, error) {
 				return repo.Manifests().FetchReference(ctx, ref)
 			})
+	} else {
+		desc, rc, err = r.Manifests().FetchReference(fetchCtx, reference)
 	}
-	return r.Manifests().FetchReference(ctx, reference)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	if err := r.checkPolicyResolved(ctx, reference, desc); err != nil {
+		rc.Close()
+		return ocispec.Descriptor{}, nil, err
+	}
+	return desc, rc, nil
 }
 
 // ParseReference resolves a tag or a digest reference to a fully qualified
@@ -1549,7 +1617,14 @@ func (s *manifestStore) Resolve(ctx context.Context, reference string) (ocispec.
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return s.generateDescriptor(resp, ref, req.Method)
+		desc, err := s.generateDescriptor(resp, ref, req.Method)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		if err := s.repo.checkPolicyResolved(ctx, reference, desc); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		return desc, nil
 	case http.StatusNotFound:
 		return ocispec.Descriptor{}, fmt.Errorf("%s: %w", ref, errdef.ErrNotFound)
 	default:
@@ -1589,11 +1664,16 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 	switch resp.StatusCode {
 	case http.StatusOK:
 		if resp.ContentLength == -1 {
-			desc, err = s.Resolve(ctx, reference)
+			// policy is evaluated below against the fetched descriptor, so
+			// skip the redundant evaluation in Resolve.
+			desc, err = s.Resolve(withPolicyChecked(ctx), reference)
 		} else {
 			desc, err = s.generateDescriptor(resp, ref, req.Method)
 		}
 		if err != nil {
+			return ocispec.Descriptor{}, nil, err
+		}
+		if err = s.repo.checkPolicyResolved(ctx, reference, desc); err != nil {
 			return ocispec.Descriptor{}, nil, err
 		}
 		return desc, resp.Body, nil
@@ -1607,6 +1687,9 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 // Tag tags a manifest descriptor with a reference string.
 func (s *manifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, reference string) error {
 	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	if err := s.repo.checkPolicyResolved(ctx, reference, desc); err != nil {
 		return err
 	}
 	ref, err := s.repo.ParseReference(reference)
@@ -1661,6 +1744,9 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 // PushReference pushes the manifest with a reference tag.
 func (s *manifestStore) PushReference(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
 	if err := s.repo.checkPolicy(ctx, reference); err != nil {
+		return err
+	}
+	if err := s.repo.checkPolicyResolved(ctx, reference, expected); err != nil {
 		return err
 	}
 	ref, err := s.repo.ParseReference(reference)

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -400,9 +400,11 @@ func TestRepository_ScopeSpecificPolicy(t *testing.T) {
 // mockReadCloser is a simple mock for testing
 type mockReadCloser struct {
 	io.Reader
+	closed bool
 }
 
 func (m *mockReadCloser) Close() error {
+	m.closed = true
 	return nil
 }
 
@@ -450,13 +452,21 @@ func newSignedByPolicyRepo(t *testing.T, verifier policy.SignedByVerifier) *Repo
 // reference without an explicit digest.
 func newSignedByTestServer(t *testing.T, verifier policy.SignedByVerifier) (*Repository, ocispec.Descriptor) {
 	t.Helper()
+	repo, desc, _ := newSignedByTestServerWithRequests(t, verifier)
+	return repo, desc
+}
+
+func newSignedByTestServerWithRequests(t *testing.T, verifier policy.SignedByVerifier) (*Repository, ocispec.Descriptor, *int) {
+	t.Helper()
 	index := []byte(`{"manifests":[]}`)
 	indexDesc := ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageIndex,
 		Digest:    digest.FromBytes(index),
 		Size:      int64(len(index)),
 	}
+	requests := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
 		switch r.URL.Path {
 		case "/v2/test/manifests/signed",
 			"/v2/test/manifests/" + indexDesc.Digest.String():
@@ -483,7 +493,7 @@ func newSignedByTestServer(t *testing.T, verifier policy.SignedByVerifier) (*Rep
 	}
 	repo.Registry.PlainHTTP = true
 	repo.Registry.Policy = newSignedByEvaluator(t, verifier)
-	return repo, indexDesc
+	return repo, indexDesc, &requests
 }
 
 func TestRepository_SignedByPolicy_TaglessOperation(t *testing.T) {
@@ -497,6 +507,70 @@ func TestRepository_SignedByPolicy_TaglessOperation(t *testing.T) {
 	}
 	if len(verifier.seen) != 0 {
 		t.Errorf("signature verifier should not be called without a manifest reference, got %d calls", len(verifier.seen))
+	}
+}
+
+func TestRepository_ManifestDescriptorOperations_SignedByPolicy_Denied(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(context.Context, *Repository, ocispec.Descriptor) error
+	}{
+		{
+			name: "Fetch",
+			operation: func(ctx context.Context, repo *Repository, desc ocispec.Descriptor) error {
+				_, err := repo.Fetch(ctx, desc)
+				return err
+			},
+		},
+		{
+			name: "Manifests().Fetch",
+			operation: func(ctx context.Context, repo *Repository, desc ocispec.Descriptor) error {
+				_, err := repo.Manifests().Fetch(ctx, desc)
+				return err
+			},
+		},
+		{
+			name: "Push",
+			operation: func(ctx context.Context, repo *Repository, desc ocispec.Descriptor) error {
+				return repo.Push(ctx, desc, strings.NewReader(`{"manifests":[]}`))
+			},
+		},
+		{
+			name: "Manifests().Push",
+			operation: func(ctx context.Context, repo *Repository, desc ocispec.Descriptor) error {
+				return repo.Manifests().Push(ctx, desc, strings.NewReader(`{"manifests":[]}`))
+			},
+		},
+		{
+			name: "Delete",
+			operation: func(ctx context.Context, repo *Repository, desc ocispec.Descriptor) error {
+				repo.SetReferrersCapability(true)
+				return repo.Delete(ctx, desc)
+			},
+		},
+		{
+			name: "Manifests().Delete",
+			operation: func(ctx context.Context, repo *Repository, desc ocispec.Descriptor) error {
+				repo.SetReferrersCapability(true)
+				return repo.Manifests().Delete(ctx, desc)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := &recordingSignedByVerifier{allow: false}
+			repo, desc, requests := newSignedByTestServerWithRequests(t, verifier)
+
+			err := tt.operation(context.Background(), repo, desc)
+			assertPolicyDenied(t, err, tt.name)
+			if *requests != 0 {
+				t.Errorf("registry requests = %d, want 0", *requests)
+			}
+			if len(verifier.seen) != 1 || verifier.seen[0].Digest != desc.Digest {
+				t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, desc.Digest)
+			}
+		})
 	}
 }
 
@@ -531,6 +605,90 @@ func TestRepository_Resolve_SignedByPolicy_Denied(t *testing.T) {
 	assertPolicyDenied(t, err, "Resolve()")
 }
 
+func TestRepository_Resolve_SignedByPolicy_DigestPreflight(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo, desc, requests := newSignedByTestServerWithRequests(t, verifier)
+	reference := "@" + desc.Digest.String()
+
+	_, err := repo.Resolve(context.Background(), reference)
+	assertPolicyDenied(t, err, "Resolve()")
+	if *requests != 0 {
+		t.Errorf("registry requests = %d, want 0", *requests)
+	}
+	if len(verifier.seen) != 1 || verifier.seen[0].Digest != desc.Digest {
+		t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, desc.Digest)
+	} else if verifier.seen[0].Reference != reference {
+		t.Errorf("verifier got reference %q, want %q", verifier.seen[0].Reference, reference)
+	}
+}
+
+func TestRepository_Resolve_SignedByPolicy_DigestChecksOnce(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: true}
+	repo, desc, requests := newSignedByTestServerWithRequests(t, verifier)
+	reference := "@" + desc.Digest.String()
+
+	got, err := repo.Resolve(context.Background(), reference)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Digest != desc.Digest {
+		t.Errorf("Resolve() = %v, want %v", got, desc)
+	}
+	if *requests != 1 {
+		t.Errorf("registry requests = %d, want 1", *requests)
+	}
+	if len(verifier.seen) != 1 || verifier.seen[0].Digest != desc.Digest {
+		t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, desc.Digest)
+	}
+}
+
+func TestRepository_SignedByPolicy_MirrorPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(context.Context, *Repository) (ocispec.Descriptor, io.ReadCloser, error)
+	}{
+		{
+			name: "Resolve",
+			operation: func(ctx context.Context, repo *Repository) (ocispec.Descriptor, io.ReadCloser, error) {
+				desc, err := repo.Resolve(ctx, "signed")
+				return desc, nil, err
+			},
+		},
+		{
+			name: "FetchReference",
+			operation: func(ctx context.Context, repo *Repository) (ocispec.Descriptor, io.ReadCloser, error) {
+				return repo.FetchReference(ctx, "signed")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			verifier := &recordingSignedByVerifier{allow: true}
+			primary, want, primaryRequests := newSignedByTestServerWithRequests(t, verifier)
+			mirror, _, mirrorRequests := newSignedByTestServerWithRequests(t, verifier)
+			primary.mirrors = []mirrorRepository{{Repository: mirror, pullFromMirror: PullFromMirrorAll}}
+
+			got, rc, err := tt.operation(context.Background(), primary)
+			if err != nil {
+				t.Fatalf("%s() error = %v", tt.name, err)
+			}
+			if rc != nil {
+				defer rc.Close()
+			}
+			if got.Digest != want.Digest {
+				t.Errorf("%s() = %v, want %v", tt.name, got, want)
+			}
+			if *primaryRequests != 0 || *mirrorRequests != 1 {
+				t.Errorf("registry requests = primary %d, mirror %d; want primary 0, mirror 1", *primaryRequests, *mirrorRequests)
+			}
+			if len(verifier.seen) != 1 || verifier.seen[0].Digest != want.Digest {
+				t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, want.Digest)
+			}
+		})
+	}
+}
+
 func TestRepository_FetchReference_SignedByPolicy_Tag(t *testing.T) {
 	verifier := &recordingSignedByVerifier{allow: true}
 	repo, indexDesc := newSignedByTestServer(t, verifier)
@@ -554,6 +712,71 @@ func TestRepository_FetchReference_SignedByPolicy_Denied(t *testing.T) {
 
 	_, _, err := repo.FetchReference(context.Background(), "signed")
 	assertPolicyDenied(t, err, "FetchReference()")
+}
+
+func TestRepository_FetchReference_SignedByPolicy_DeniedClosesBody(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo := newSignedByPolicyRepo(t, verifier)
+	manifest := []byte(`{"manifests":[]}`)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+	body := &mockReadCloser{Reader: strings.NewReader(string(manifest))}
+	repo.Registry.Client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": {desc.MediaType}, "Docker-Content-Digest": {desc.Digest.String()}},
+			Body:          body,
+			ContentLength: desc.Size,
+			Request:       req,
+		}, nil
+	})}
+
+	_, _, err := repo.FetchReference(context.Background(), "signed")
+	assertPolicyDenied(t, err, "FetchReference()")
+	if !body.closed {
+		t.Error("response body was not closed after policy denial")
+	}
+}
+
+func TestRepository_ManifestStore_FetchReference_UnknownContentLengthChecksPolicyOnce(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: true}
+	repo := newSignedByPolicyRepo(t, verifier)
+	manifest := []byte(`{"manifests":[]}`)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+	repo.Registry.Client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := io.NopCloser(strings.NewReader(""))
+		contentLength := desc.Size
+		if req.Method == http.MethodGet {
+			body = io.NopCloser(strings.NewReader(string(manifest)))
+			contentLength = -1
+		}
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Type": {desc.MediaType}, "Docker-Content-Digest": {desc.Digest.String()}},
+			Body:          body,
+			ContentLength: contentLength,
+			Request:       req,
+		}, nil
+	})}
+
+	got, rc, err := repo.Manifests().FetchReference(context.Background(), "signed")
+	if err != nil {
+		t.Fatalf("Manifests().FetchReference() error = %v", err)
+	}
+	defer rc.Close()
+	if got.Digest != desc.Digest {
+		t.Errorf("Manifests().FetchReference() = %v, want %v", got, desc)
+	}
+	if len(verifier.seen) != 1 || verifier.seen[0].Digest != desc.Digest {
+		t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, desc.Digest)
+	}
 }
 
 func TestRepository_ManifestStore_Resolve_SignedByPolicy_Denied(t *testing.T) {

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -18,9 +18,14 @@ package remote
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
@@ -399,4 +404,193 @@ type mockReadCloser struct {
 
 func (m *mockReadCloser) Close() error {
 	return nil
+}
+
+// recordingSignedByVerifier implements policy.SignedByVerifier and records
+// the image references it is asked to verify.
+type recordingSignedByVerifier struct {
+	allow bool
+	seen  []policy.ImageReference
+}
+
+func (v *recordingSignedByVerifier) Verify(ctx context.Context, req *policy.PRSignedBy, image policy.ImageReference) (bool, error) {
+	v.seen = append(v.seen, image)
+	return v.allow, nil
+}
+
+func newSignedByEvaluator(t *testing.T, verifier policy.SignedByVerifier) *policy.Evaluator {
+	t.Helper()
+	pol := &policy.Policy{
+		Default: policy.PolicyRequirements{
+			&policy.PRSignedBy{KeyType: "GPGKeys", KeyPath: "/path/to/key.gpg"},
+		},
+	}
+	evaluator, err := policy.NewEvaluator(pol, policy.WithSignedByVerifier(verifier))
+	if err != nil {
+		t.Fatalf("failed to create evaluator: %v", err)
+	}
+	return evaluator
+}
+
+func newSignedByPolicyRepo(t *testing.T, verifier policy.SignedByVerifier) *Repository {
+	t.Helper()
+	reg := &Registry{
+		Reference: registry.Reference{Registry: testReference.Registry},
+		Policy:    newSignedByEvaluator(t, verifier),
+	}
+	return &Repository{
+		Registry:       reg,
+		RepositoryName: testReference.Repository,
+	}
+}
+
+// newSignedByTestServer starts a test registry serving a single index
+// manifest under the tag "signed" and returns a policy-enforcing repository
+// pointing at it. Fixes #1337: a signedBy requirement used to fail for any
+// reference without an explicit digest.
+func newSignedByTestServer(t *testing.T, verifier policy.SignedByVerifier) (*Repository, ocispec.Descriptor) {
+	t.Helper()
+	index := []byte(`{"manifests":[]}`)
+	indexDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(index),
+		Size:      int64(len(index)),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/test/manifests/signed",
+			"/v2/test/manifests/" + indexDesc.Digest.String():
+			w.Header().Set("Content-Type", indexDesc.MediaType)
+			w.Header().Set("Docker-Content-Digest", indexDesc.Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(int(indexDesc.Size)))
+			if r.Method == http.MethodGet {
+				w.Write(index)
+			}
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("invalid test http server: %v", err)
+	}
+
+	repo, err := NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	repo.Registry.PlainHTTP = true
+	repo.Registry.Policy = newSignedByEvaluator(t, verifier)
+	return repo, indexDesc
+}
+
+func TestRepository_SignedByPolicy_TaglessOperation(t *testing.T) {
+	// Operations without a manifest reference must not evaluate signature
+	// requirements, which would otherwise always fail for lack of a digest.
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo := newSignedByPolicyRepo(t, verifier)
+
+	if err := repo.checkPolicy(context.Background(), ""); err != nil {
+		t.Errorf("checkPolicy() with signedBy-only policy should defer signature checks, got: %v", err)
+	}
+	if len(verifier.seen) != 0 {
+		t.Errorf("signature verifier should not be called without a manifest reference, got %d calls", len(verifier.seen))
+	}
+}
+
+func TestRepository_Resolve_SignedByPolicy_Tag(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: true}
+	repo, indexDesc := newSignedByTestServer(t, verifier)
+
+	got, err := repo.Resolve(context.Background(), "signed")
+	if err != nil {
+		t.Fatalf("Repository.Resolve() error = %v", err)
+	}
+	if got.Digest != indexDesc.Digest {
+		t.Errorf("Repository.Resolve() = %v, want %v", got, indexDesc)
+	}
+
+	if len(verifier.seen) != 1 {
+		t.Fatalf("signature verifier called %d times, want 1", len(verifier.seen))
+	}
+	if verifier.seen[0].Digest != indexDesc.Digest {
+		t.Errorf("verifier got digest %q, want %q", verifier.seen[0].Digest, indexDesc.Digest)
+	}
+	if verifier.seen[0].Reference != "signed" {
+		t.Errorf("verifier got reference %q, want %q", verifier.seen[0].Reference, "signed")
+	}
+}
+
+func TestRepository_Resolve_SignedByPolicy_Denied(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo, _ := newSignedByTestServer(t, verifier)
+
+	_, err := repo.Resolve(context.Background(), "signed")
+	assertPolicyDenied(t, err, "Resolve()")
+}
+
+func TestRepository_FetchReference_SignedByPolicy_Tag(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: true}
+	repo, indexDesc := newSignedByTestServer(t, verifier)
+
+	got, rc, err := repo.FetchReference(context.Background(), "signed")
+	if err != nil {
+		t.Fatalf("Repository.FetchReference() error = %v", err)
+	}
+	defer rc.Close()
+	if got.Digest != indexDesc.Digest {
+		t.Errorf("Repository.FetchReference() = %v, want %v", got, indexDesc)
+	}
+	if len(verifier.seen) != 1 || verifier.seen[0].Digest != indexDesc.Digest {
+		t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, indexDesc.Digest)
+	}
+}
+
+func TestRepository_FetchReference_SignedByPolicy_Denied(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo, _ := newSignedByTestServer(t, verifier)
+
+	_, _, err := repo.FetchReference(context.Background(), "signed")
+	assertPolicyDenied(t, err, "FetchReference()")
+}
+
+func TestRepository_ManifestStore_Resolve_SignedByPolicy_Denied(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo, _ := newSignedByTestServer(t, verifier)
+
+	_, err := repo.Manifests().Resolve(context.Background(), "signed")
+	assertPolicyDenied(t, err, "Manifests().Resolve()")
+}
+
+func TestRepository_Tag_SignedByPolicy_Denied(t *testing.T) {
+	// The descriptor carries the digest, so signature requirements are
+	// evaluated before any network access.
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo := newSignedByPolicyRepo(t, verifier)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.Tag(context.Background(), desc, "v1.0")
+	assertPolicyDenied(t, err, "Tag()")
+	if len(verifier.seen) != 1 || verifier.seen[0].Digest != desc.Digest {
+		t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, desc.Digest)
+	}
+}
+
+func TestRepository_PushReference_SignedByPolicy_Denied(t *testing.T) {
+	verifier := &recordingSignedByVerifier{allow: false}
+	repo := newSignedByPolicyRepo(t, verifier)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+		Size:      1234,
+	}
+
+	err := repo.PushReference(context.Background(), desc, strings.NewReader("test content"), "v1.0")
+	assertPolicyDenied(t, err, "PushReference()")
 }

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 package remote
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,10 +27,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+	"github.com/oras-project/oras-go/v3/registry/remote/signature"
 )
 
 var testReference = registry.Reference{
@@ -592,8 +596,63 @@ func TestRepository_Resolve_SignedByPolicy_Tag(t *testing.T) {
 	if verifier.seen[0].Digest != indexDesc.Digest {
 		t.Errorf("verifier got digest %q, want %q", verifier.seen[0].Digest, indexDesc.Digest)
 	}
-	if verifier.seen[0].Reference != "signed" {
-		t.Errorf("verifier got reference %q, want %q", verifier.seen[0].Reference, "signed")
+	wantReference := repo.Reference().String() + ":signed"
+	if verifier.seen[0].Reference != wantReference {
+		t.Errorf("verifier got reference %q, want %q", verifier.seen[0].Reference, wantReference)
+	}
+}
+
+func TestRepository_DefaultSignedByVerifier_EndToEnd(t *testing.T) {
+	repo, desc := newSignedByTestServer(t, &recordingSignedByVerifier{allow: true})
+	imageReference := repo.Reference().String() + ":signed"
+
+	signer, err := openpgp.NewEntity("Test", "", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("openpgp.NewEntity() error = %v", err)
+	}
+	payload := signature.NewSimpleSigningPayload(desc.Digest, imageReference)
+	payloadBytes, err := payload.Marshal()
+	if err != nil {
+		t.Fatalf("payload.Marshal() error = %v", err)
+	}
+	signedData, err := signature.CreateOpenPGPSignature(payloadBytes, signer)
+	if err != nil {
+		t.Fatalf("CreateOpenPGPSignature() error = %v", err)
+	}
+
+	var publicKey bytes.Buffer
+	if err := signer.Serialize(&publicKey); err != nil {
+		t.Fatalf("signer.Serialize() error = %v", err)
+	}
+	storeURL := "file://" + t.TempDir()
+	store := signature.NewLookasideStore(storeURL, storeURL)
+	if err := store.PutSignature(context.Background(), repo.Reference().String(), desc.Digest, signedData); err != nil {
+		t.Fatalf("PutSignature() error = %v", err)
+	}
+	pol, err := policy.NewEvaluator(&policy.Policy{
+		Default: policy.PolicyRequirements{&policy.PRSignedBy{
+			KeyType: "GPGKeys",
+			KeyData: base64.StdEncoding.EncodeToString(publicKey.Bytes()),
+		}},
+	}, policy.WithSignedByVerifier(signature.NewSignedByVerifier(store)))
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+	repo.Registry.Policy = pol
+
+	got, err := repo.Resolve(context.Background(), "signed")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.Digest != desc.Digest {
+		t.Errorf("Resolve() = %v, want %v", got, desc)
+	}
+	rc, err := repo.Fetch(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Errorf("Fetch().Close() error = %v", err)
 	}
 }
 
@@ -615,10 +674,11 @@ func TestRepository_Resolve_SignedByPolicy_DigestPreflight(t *testing.T) {
 	if *requests != 0 {
 		t.Errorf("registry requests = %d, want 0", *requests)
 	}
+	wantReference := repo.Reference().String() + reference
 	if len(verifier.seen) != 1 || verifier.seen[0].Digest != desc.Digest {
 		t.Errorf("verifier calls = %v, want one call with digest %q", verifier.seen, desc.Digest)
-	} else if verifier.seen[0].Reference != reference {
-		t.Errorf("verifier got reference %q, want %q", verifier.seen[0].Reference, reference)
+	} else if verifier.seen[0].Reference != wantReference {
+		t.Errorf("verifier got reference %q, want %q", verifier.seen[0].Reference, wantReference)
 	}
 }
 

--- a/registry/remote/signature/verifier.go
+++ b/registry/remote/signature/verifier.go
@@ -64,10 +64,17 @@ func (v *DefaultSignedByVerifier) Verify(ctx context.Context, req *policy.PRSign
 		return false, fmt.Errorf("failed to load keyring: %w", err)
 	}
 
-	// Parse the image reference to get the digest.
-	imgDigest, err := parseImageDigest(image.Reference)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse image digest from reference %s: %w", image.Reference, err)
+	// Determine the manifest digest to verify against: prefer the resolved
+	// digest supplied by the caller, falling back to one embedded in the
+	// reference.
+	imgDigest := image.Digest
+	if imgDigest == "" {
+		imgDigest, err = parseImageDigest(image.Reference)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse image digest from reference %s: %w", image.Reference, err)
+		}
+	} else if err := imgDigest.Validate(); err != nil {
+		return false, fmt.Errorf("invalid image digest %q: %w", imgDigest, err)
 	}
 
 	// Fetch signatures.

--- a/registry/remote/signature/verifier_test.go
+++ b/registry/remote/signature/verifier_test.go
@@ -608,3 +608,77 @@ func createKeyFile(t *testing.T, entity *openpgp.Entity, path string) (string, e
 	}
 	return path, nil
 }
+
+func TestDefaultSignedByVerifier_Verify_ResolvedDigest(t *testing.T) {
+	// A tag reference paired with a resolved digest in ImageReference.Digest
+	// must verify without a digest embedded in the reference itself.
+	entity, err := openpgp.NewEntity("Test", "", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("NewEntity() error: %v", err)
+	}
+
+	imgDigest := digest.FromString("test image content")
+	imgRef := "registry.example.com/repo:latest" // No digest in the reference.
+	scope := "registry.example.com/repo"
+
+	payload := NewSimpleSigningPayload(imgDigest, "registry.example.com/repo:latest")
+	payloadBytes, err := payload.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error: %v", err)
+	}
+	signedData, err := CreateOpenPGPSignature(payloadBytes, entity)
+	if err != nil {
+		t.Fatalf("CreateOpenPGPSignature() error: %v", err)
+	}
+
+	store := newMockStore()
+	store.addSignature(scope, imgDigest, signedData)
+
+	keyFile := t.TempDir() + "/test.gpg"
+	if _, err := createKeyFile(t, entity, keyFile); err != nil {
+		t.Fatalf("createKeyFile() error: %v", err)
+	}
+
+	verifier := NewSignedByVerifier(store)
+	req := &policy.PRSignedBy{
+		KeyType: "GPGKeys",
+		KeyPath: keyFile,
+	}
+	image := policy.ImageReference{
+		Transport: "docker",
+		Scope:     scope,
+		Reference: imgRef,
+		Digest:    imgDigest,
+	}
+
+	result, err := verifier.Verify(context.Background(), req, image)
+	if err != nil {
+		t.Fatalf("Verify() error: %v", err)
+	}
+	if !result {
+		t.Error("Verify() = false, want true")
+	}
+}
+
+func TestDefaultSignedByVerifier_Verify_InvalidResolvedDigest(t *testing.T) {
+	entity, _ := openpgp.NewEntity("Test", "", "test@example.com", nil)
+	keyFile := t.TempDir() + "/test.gpg"
+	createKeyFile(t, entity, keyFile)
+
+	verifier := NewSignedByVerifier(newMockStore())
+	req := &policy.PRSignedBy{
+		KeyType: "GPGKeys",
+		KeyPath: keyFile,
+	}
+	image := policy.ImageReference{
+		Transport: "docker",
+		Scope:     "registry.example.com/repo",
+		Reference: "registry.example.com/repo:latest",
+		Digest:    "not-a-digest",
+	}
+
+	_, err := verifier.Verify(context.Background(), req, image)
+	if err == nil {
+		t.Fatal("Verify() should return error for invalid resolved digest")
+	}
+}


### PR DESCRIPTION
Fixes #1337

### Problem

A `signedBy` requirement could only be satisfied by an explicit `@digest` reference. `checkPolicy` evaluated the full policy before resolution, so:

- tag references (`Resolve`, `FetchReference`, `Tag`, `PushReference`) reached `DefaultSignedByVerifier` without a digest and failed at `parseImageDigest`;
- every tagless operation called `checkPolicy(ctx, "")`, fell back to the bare repository reference, and failed the same way.

### Approach (option 1 from the issue: two-phase evaluation)

**Pre-resolve** — `checkPolicy` now evaluates only requirements decidable from the reference alone (`reject`, `insecureAcceptAnything`) via the new `Evaluator.IsReferenceAllowed`, so it can still deny before any registry round-trip.

**Post-resolve** — the new `checkPolicyResolved` evaluates the full policy, signature requirements included, once the manifest descriptor is known:

- `Resolve` / `FetchReference` check the resolved descriptor (at both `Repository` and `Manifests()` levels, guarded by `policyCheckedKey` so the wrapped path evaluates once);
- `Tag` / `PushReference` check the supplied descriptor before any network access;
- on a post-resolve denial, `FetchReference` closes the fetched body and returns the policy error.

The resolved digest travels in a new additive `policy.ImageReference.Digest` field, so the caller's original reference stays intact for signed identity matching (`matchExact` etc. keep working for tag pulls, mirroring how containers/image feeds identity and digest separately). `DefaultSignedByVerifier` prefers that field and falls back to parsing the reference, validating the supplied digest before using it for signature lookup.

Operations that never involve a manifest reference (blob operations, `Tags`, `Referrers`, `Predecessors`, `Delete`, `Mount`, `Exists`, `Untag`) are now subject only to reference-level requirements instead of failing unconditionally — per the issue, `signedBy` is not applicable there rather than denying. The stale `checkPolicy` doc claim ("performed regardless of operation type") is corrected accordingly.

Behavior summary under a `signedBy` policy:

| Operation | Before | After |
|---|---|---|
| `Resolve`/`FetchReference` with `@digest` | verified | verified (unchanged) |
| `Resolve`/`FetchReference` with tag | always denied | verified against resolved digest |
| `Tag`/`PushReference` | always denied | verified against descriptor digest |
| tagless/blob/metadata ops | always denied | reference-level requirements only |

Not covered here: the opt-in `WithPolicyEnforcement` middleware has the same limitation (it passes raw references/digest strings to `IsImageAllowed`). It can now be fixed the same way using `IsReferenceAllowed` + `ImageReference.Digest`; happy to do that as a follow-up if wanted.

Tested with `go test -race ./...`; new coverage for the evaluator phase split, the verifier digest-field path, and repository/manifest-store two-phase enforcement (allow + deny, verifier call recording).
