### PR TITLE
fix(auth): prevent scope hints from crossing registry hosts

### DIFF
--- a/registry/remote/auth/client.go
+++ b/registry/remote/auth/client.go
@@ -288,7 +288,7 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 				req.Header.Set(headerAuthorization, "Basic "+token)
 			}
 		case SchemeBearer:
-			scopes := GetAllScopesForHost(ctx, host)
+			scopes := GetScopesForHost(ctx, host)
 			attemptedKey = strings.Join(scopes, " ")
 			token, err := cache.GetToken(ctx, host, SchemeBearer, attemptedKey)
 			if err == nil {
@@ -331,7 +331,7 @@ func (c *Client) Do(originalReq *http.Request) (*http.Response, error) {
 	case SchemeBearer:
 		resp.Body.Close()
 
-		scopes := GetAllScopesForHost(ctx, host)
+		scopes := GetScopesForHost(ctx, host)
 		if paramScope := params["scope"]; paramScope != "" {
 			// merge hinted scopes with challenged scopes
 			scopes = append(scopes, strings.Split(paramScope, " ")...)

--- a/registry/remote/auth/client_test.go
+++ b/registry/remote/auth/client_test.go
@@ -392,7 +392,7 @@ func TestClient_Do_Bearer_AccessToken_Cached(t *testing.T) {
 	}
 
 	// first request
-	ctx := WithScopes(context.Background(), scope)
+	ctx := WithScopesForHost(context.Background(), uri.Host, scope)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
@@ -858,7 +858,7 @@ func TestClient_Do_Bearer_Auth_Cached(t *testing.T) {
 	client.TokenFetcher = NewCompositeTokenFetcher(client.Client, client.Header, client.ClientID, true)
 
 	// first request
-	ctx := WithScopes(context.Background(), scopes...)
+	ctx := WithScopesForHost(context.Background(), uri.Host, scopes...)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
@@ -1467,7 +1467,7 @@ func TestClient_Do_Bearer_OAuth2_Password_Cached(t *testing.T) {
 	}
 
 	// first request
-	ctx := WithScopes(context.Background(), scopes...)
+	ctx := WithScopesForHost(context.Background(), uri.Host, scopes...)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
@@ -2095,7 +2095,7 @@ func TestClient_Do_Bearer_OAuth2_RefreshToken_Cached(t *testing.T) {
 	}
 
 	// first request
-	ctx := WithScopes(context.Background(), scopes...)
+	ctx := WithScopesForHost(context.Background(), uri.Host, scopes...)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
@@ -2568,7 +2568,7 @@ func TestClient_Do_Token_Expire(t *testing.T) {
 	}
 
 	// first request
-	ctx := WithScopes(context.Background(), scopes...)
+	ctx := WithScopesForHost(context.Background(), uri.Host, scopes...)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)
@@ -2975,7 +2975,7 @@ func TestClient_Do_Scope_Hint_Mismatch(t *testing.T) {
 	}
 
 	// first request
-	ctx := WithScopes(context.Background(), scopes...)
+	ctx := WithScopesForHost(context.Background(), uri.Host, scopes...)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create test request: %v", err)

--- a/registry/remote/auth/example_test.go
+++ b/registry/remote/auth/example_test.go
@@ -201,8 +201,8 @@ func ExampleClient_Do_clientConfigurations() {
 		"repository:dst:pull,push",
 		"repository:src:pull",
 	}
-	// WithScopes returns a context with scopes added.
-	ctx := WithScopes(context.Background(), scopes...)
+	// WithScopesForHost returns a context with scopes added for a registry host.
+	ctx := WithScopesForHost(context.Background(), expectedHostAddress, scopes...)
 
 	// clientConfigTargetURL can be any URL. For example, https://registry.wabbit-networks.io/v2/
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, clientConfigTargetURL, nil)

--- a/registry/remote/auth/scope.go
+++ b/registry/remote/auth/scope.go
@@ -78,50 +78,6 @@ func AppendRepositoryScope(ctx context.Context, ref registry.Reference, actions 
 	return AppendScopesForHost(ctx, ref.Host(), scope)
 }
 
-// scopesContextKey is the context key for scopes.
-type scopesContextKey struct{}
-
-// WithScopes returns a context with scopes added. Scopes are de-duplicated.
-// Scopes are used as hints for the auth client to fetch bearer tokens with
-// larger scopes.
-//
-// For example, uploading blob to the repository "hello-world" does HEAD request
-// first then POST and PUT. The HEAD request will return a challenge for scope
-// `repository:hello-world:pull`, and the auth client will fetch a token for
-// that challenge. Later, the POST request will return a challenge for scope
-// `repository:hello-world:push`, and the auth client will fetch a token for
-// that challenge again. By invoking WithScopes with the scope
-// `repository:hello-world:pull,push`, the auth client with cache is hinted to
-// fetch a token via a single token fetch request for all the HEAD, POST, PUT
-// requests.
-//
-// Passing an empty list of scopes will virtually remove the scope hints in the
-// context.
-//
-// Reference: https://distribution.github.io/distribution/spec/auth/scope/
-func WithScopes(ctx context.Context, scopes ...string) context.Context {
-	scopes = CleanScopes(scopes)
-	return context.WithValue(ctx, scopesContextKey{}, scopes)
-}
-
-// AppendScopes appends additional scopes to the existing scopes in the context
-// and returns a new context. The resulted scopes are de-duplicated.
-// The append operation does modify the existing scope in the context passed in.
-func AppendScopes(ctx context.Context, scopes ...string) context.Context {
-	if len(scopes) == 0 {
-		return ctx
-	}
-	return WithScopes(ctx, append(GetScopes(ctx), scopes...)...)
-}
-
-// GetScopes returns the scopes in the context.
-func GetScopes(ctx context.Context) []string {
-	if scopes, ok := ctx.Value(scopesContextKey{}).([]string); ok {
-		return slices.Clone(scopes)
-	}
-	return nil
-}
-
 // scopesForHostContextKey is the context key for per-host scopes.
 type scopesForHostContextKey string
 
@@ -161,30 +117,12 @@ func AppendScopesForHost(ctx context.Context, host string, scopes ...string) con
 	return WithScopesForHost(ctx, host, append(oldScopes, scopes...)...)
 }
 
-// GetScopesForHost returns the scopes in the context for the given host,
-// excluding global scopes added by [WithScopes] and [AppendScopes].
+// GetScopesForHost returns the scopes in the context for the given host.
 func GetScopesForHost(ctx context.Context, host string) []string {
 	if scopes, ok := ctx.Value(scopesForHostContextKey(host)).([]string); ok {
 		return slices.Clone(scopes)
 	}
 	return nil
-}
-
-// GetAllScopesForHost returns the scopes in the context for the given host,
-// including global scopes added by [WithScopes] and [AppendScopes].
-func GetAllScopesForHost(ctx context.Context, host string) []string {
-	scopes := GetScopesForHost(ctx, host)
-	globalScopes := GetScopes(ctx)
-
-	if len(scopes) == 0 {
-		return globalScopes
-	}
-	if len(globalScopes) == 0 {
-		return scopes
-	}
-	// re-clean the scopes
-	allScopes := append(scopes, globalScopes...)
-	return CleanScopes(allScopes)
 }
 
 // CleanScopes merges and sort the actions in ascending order if the scopes have

--- a/registry/remote/auth/scope_test.go
+++ b/registry/remote/auth/scope_test.go
@@ -169,88 +169,7 @@ func TestAppendRepositoryScope(t *testing.T) {
 	}
 }
 
-func TestWithScopes(t *testing.T) {
-	ctx := context.Background()
-
-	// with single scope
-	want := []string{
-		"repository:foo:pull",
-	}
-	ctx = WithScopes(ctx, want...)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(WithScopes()) = %v, want %v", got, want)
-	}
-
-	// overwrite scopes
-	want = []string{
-		"repository:bar:push",
-	}
-	ctx = WithScopes(ctx, want...)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(WithScopes()) = %v, want %v", got, want)
-	}
-
-	// overwrite scopes with de-duplication
-	scopes := []string{
-		"repository:hello-world:push",
-		"repository:alpine:delete",
-		"repository:hello-world:pull",
-		"repository:alpine:delete",
-	}
-	want = []string{
-		"repository:alpine:delete",
-		"repository:hello-world:pull,push",
-	}
-	ctx = WithScopes(ctx, scopes...)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(WithScopes()) = %v, want %v", got, want)
-	}
-
-	// clean scopes
-	want = nil
-	ctx = WithScopes(ctx, want...)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(WithScopes()) = %v, want %v", got, want)
-	}
-}
-
-func TestAppendScopes(t *testing.T) {
-	ctx := context.Background()
-
-	// append single scope
-	want := []string{
-		"repository:foo:pull",
-	}
-	ctx = AppendScopes(ctx, want...)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(AppendScopes()) = %v, want %v", got, want)
-	}
-
-	// append scopes with de-duplication
-	scopes := []string{
-		"repository:hello-world:push",
-		"repository:alpine:delete",
-		"repository:hello-world:pull",
-		"repository:alpine:delete",
-	}
-	want = []string{
-		"repository:alpine:delete",
-		"repository:foo:pull",
-		"repository:hello-world:pull,push",
-	}
-	ctx = AppendScopes(ctx, scopes...)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(AppendScopes()) = %v, want %v", got, want)
-	}
-
-	// append empty scopes
-	ctx = AppendScopes(ctx)
-	if got := GetScopes(ctx); !reflect.DeepEqual(got, want) {
-		t.Errorf("GetScopes(AppendScopes()) = %v, want %v", got, want)
-	}
-}
-
-func TestWithScopesPerHost(t *testing.T) {
+func TestWithScopesForHost(t *testing.T) {
 	ctx := context.Background()
 	reg1 := "registry1.example.com"
 	reg2 := "registry2.example.com"
@@ -269,6 +188,9 @@ func TestWithScopesPerHost(t *testing.T) {
 	}
 	if got := GetScopesForHost(ctx, reg2); !reflect.DeepEqual(got, want2) {
 		t.Errorf("GetScopesPerRegistry(WithScopesPerRegistry()) = %v, want %v", got, want2)
+	}
+	if got := GetScopesForHost(ctx, "registry3.example.com"); got != nil {
+		t.Errorf("GetScopesForHost() = %v for an unrelated host, want nil", got)
 	}
 
 	// overwrite scopes
@@ -329,7 +251,7 @@ func TestWithScopesPerHost(t *testing.T) {
 	}
 }
 
-func TestAppendScopesPerHost(t *testing.T) {
+func TestAppendScopesForHost(t *testing.T) {
 	ctx := context.Background()
 	reg1 := "registry1.example.com"
 	reg2 := "registry2.example.com"
@@ -654,74 +576,6 @@ func Test_cleanActions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cleanActions(tt.actions); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("cleanActions() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_getAllScopesForHost(t *testing.T) {
-	host := "registry.example.com"
-	tests := []struct {
-		name         string
-		scopes       []string
-		globalScopes []string
-		want         []string
-	}{
-		{
-			name:   "Empty per-host scopes",
-			scopes: []string{},
-			globalScopes: []string{
-				"repository:hello-world:push",
-				"repository:alpine:delete",
-				"repository:hello-world:pull",
-				"repository:alpine:delete",
-			},
-			want: []string{
-				"repository:alpine:delete",
-				"repository:hello-world:pull,push",
-			},
-		},
-		{
-			name: "Empty global scopes",
-			scopes: []string{
-				"repository:hello-world:push",
-				"repository:alpine:delete",
-				"repository:hello-world:pull",
-				"repository:alpine:delete",
-			},
-			globalScopes: []string{},
-			want: []string{
-				"repository:alpine:delete",
-				"repository:hello-world:pull,push",
-			},
-		},
-		{
-			name: "Per-host scopes + global scopes",
-			scopes: []string{
-				"repository:hello-world:push",
-				"repository:alpine:delete",
-				"repository:hello-world:pull",
-				"repository:alpine:delete",
-			},
-			globalScopes: []string{
-				"repository:foo:pull",
-				"repository:hello-world:pull",
-				"repository:alpine:pull",
-			},
-			want: []string{
-				"repository:alpine:delete,pull",
-				"repository:foo:pull",
-				"repository:hello-world:pull,push",
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = WithScopesForHost(ctx, host, tt.scopes...)
-			ctx = WithScopes(ctx, tt.globalScopes...)
-			if got := GetAllScopesForHost(ctx, host); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getAllScopesForHost() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- remove the v3 host-less scope context APIs that applied hints to every registry host
- make the auth client read only scopes associated with the request host
- migrate tests and examples to the host-scoped API, including an unrelated-host isolation assertion

Closes #1362

## Testing

- `go test -race ./registry/remote/auth`
- `go test -race ./...` (all relevant packages passed; two environment-dependent tests could not access the macOS user policy path or a system `registries.conf`)

AI-assisted tooling was used for implementation and review.