### PR TITLE
ci: authenticate v2 release tag push with RELEASE_PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # Must belong to an org owner so the protected-tag ruleset bypass applies.
+          # Rotate the repository secret before its PAT expires.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0


### PR DESCRIPTION
Refs #1361.

The v2 release workflow currently checks out with the default `GITHUB_TOKEN`, whose `github-actions[bot]` identity cannot bypass the repository's protected-tag ruleset. This makes the release job fail when it pushes the version tag.

Configure `actions/checkout` to persist `secrets.RELEASE_PAT` for the tag push. Inline guidance records that the PAT must belong to an organization owner covered by the ruleset bypass and must be rotated before expiration. GoReleaser continues to use `GITHUB_TOKEN`.

Validation: parsed `.github/workflows/release.yml` successfully, asserted the checkout token is `secrets.RELEASE_PAT`, and passed `git diff --check`. `actionlint` and `go` are not installed on this host, so no actionlint run was performed.
