### PR TITLE
docs: map v2 scope helpers to v3

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -119,7 +119,7 @@ function type explicit.
 | `auth.GetAllScopesForHost(ctx, host)` | `auth.GetScopesForHost(ctx, host)` |
 
 Scope hints are host-specific in v3. Pass the host of the registry request,
-normally from `registry.Reference.Host()`, to the replacement functions. The
+normally from `properties.Reference.Host()`, to the replacement functions. The
 host must match the request host; for example, a `docker.io` reference resolves
 to `registry-1.docker.io`.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -113,6 +113,15 @@ function type explicit.
 | `credentials.ServerAddressFromHostname` | `remote.ServerAddressFromHostname` |
 | `credentials.ServerAddressFromRegistry` | `remote.ServerAddressFromRegistry` |
 | `credentials.ErrClientTypeUnsupported` | `remote.ErrClientTypeUnsupported` |
+| `auth.WithScopes(ctx, scopes...)` | `auth.WithScopesForHost(ctx, host, scopes...)` |
+| `auth.AppendScopes(ctx, scopes...)` | `auth.AppendScopesForHost(ctx, host, scopes...)` |
+| `auth.GetScopes(ctx)` | `auth.GetScopesForHost(ctx, host)` |
+| `auth.GetAllScopesForHost(ctx, host)` | `auth.GetScopesForHost(ctx, host)` |
+
+Scope hints are host-specific in v3. Pass the host of the registry request,
+normally from `registry.Reference.Host()`, to the replacement functions. The
+host must match the request host; for example, a `docker.io` reference resolves
+to `registry-1.docker.io`.
 
 For example:
 


### PR DESCRIPTION
## What changed

- add the four removed v2 scope helpers to the authentication migration table
- map them to the host-specific v3 replacements
- explain that the host should come from `registry.Reference.Host()`
- call out the `docker.io` to `registry-1.docker.io` normalisation case

This keeps the scope API break in the same table as the other authentication
changes, so users hitting the v3 compile errors have a direct replacement
path.

## Verification

- `go test ./...` — Go 1.27.1, `darwin/arm64`
- `git diff --check`
- rendered `MIGRATION_GUIDE.md` through GitHub's GFM renderer and checked the
  table and follow-up note
- confirmed the existing v2 migration-guide link returns HTTP 200

Closes #1375
