### PR TITLE
docs: clarify repository constructor migration

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -51,8 +51,8 @@ sizes remain on `remote.Repository`.
 Note that `Reference()` is a read-only getter; the reference can no longer be
 set through it. The v2 struct-literal pattern
 `&remote.Repository{Reference: ref, Client: c}` does not compile in v3;
-construct repositories with `remote.NewRepository` or
-`remote.NewRepositoryWithProperties` instead.
+construct the repository with `remote.NewRepository`, then configure its
+shared client through `repo.Registry.Client`, as shown below.
 
 For example:
 


### PR DESCRIPTION
## What changed

The migration note now points the v2 repository struct-literal example at the
actual v3 replacement shown immediately below it:

1. construct the repository with `remote.NewRepository(...)`
2. configure the shared client through `repo.Registry.Client`

`remote.NewRepositoryWithProperties` is no longer presented as a drop-in
replacement for a literal containing `Client: c`. Its separate, correct use
for configuration-file-driven setup remains documented later in the section.

## Verification

- `go test ./...` — Go 1.27.1, `darwin/arm64`
- `git diff --check`
- rendered `MIGRATION_GUIDE.md` through GitHub's GFM renderer and checked the
  corrected note and the later `NewRepositoryWithProperties` guidance

Closes #1372
