### PR TITLE
docs: format migration guide links as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ This project follows [Semantic Versioning](https://semver.org/) (`MAJOR`.`MINOR`
 
 ## Branches
 
-To migrate from `v2` to `v3`, see [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md).
-To migrate from `v1` to `v2`, see the
-[`v2` branch migration guide](https://github.com/oras-project/oras-go/blob/v2/MIGRATION_GUIDE.md).
+- To migrate from `v2` to `v3`, see [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md).
+- To migrate from `v1` to `v2`, see the [`v2` branch migration guide](https://github.com/oras-project/oras-go/blob/v2/MIGRATION_GUIDE.md).
 
 ### main (v3 development)
 


### PR DESCRIPTION
The two migration pointers under the `## Branches` heading sit on adjacent lines, so Markdown joins them into one run-on paragraph. This formats them as a bullet list so each pointer renders on its own line.

Both links are unchanged and still resolve (`MIGRATION_GUIDE.md` on `main`, and the `v2` branch migration guide).

Fixes #1373

🤖 Generated with [Claude Code](https://claude.com/claude-code)