### PR TITLE
auth: add a Resource type for registry scopes

### DIFF
--- a/registry/remote/properties/resource.go
+++ b/registry/remote/properties/resource.go
@@ -1,0 +1,66 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package properties
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oras-project/oras-go/v3/errdef"
+)
+
+// Resource represents a registry host, optionally narrowed to a namespace or
+// repository. It never carries a tag or digest.
+type Resource struct {
+	// Host is the name of the registry, usually a domain name optionally with a
+	// port.
+	Host string
+
+	// Path is the namespace or repository path, or empty for the whole registry.
+	Path string
+}
+
+// ParseResource parses a registry resource. The resource may contain an
+// optional oci://, http://, or https:// scheme, and may be narrowed to a
+// namespace or repository path. Tags and digests are not accepted.
+func ParseResource(resource string) (Resource, error) {
+	resource = strings.TrimPrefix(resource, "oci://")
+	resource = strings.TrimPrefix(resource, "http://")
+	resource = strings.TrimPrefix(resource, "https://")
+	if strings.HasSuffix(resource, "/") {
+		return Resource{}, fmt.Errorf("%w: invalid resource path %q", errdef.ErrInvalidReference, resource)
+	}
+
+	host, path := splitRegistry(resource)
+	if host == "" {
+		return Resource{}, fmt.Errorf("%w: invalid registry resource %q", errdef.ErrInvalidReference, resource)
+	}
+
+	// Validate the host independently so a port is not mistaken for a tag.
+	if err := (Reference{Registry: host}).ValidateRegistry(); err != nil {
+		return Resource{}, err
+	}
+	if path == "" {
+		return Resource{Host: host}, nil
+	}
+	if strings.ContainsAny(path, ":@") {
+		return Resource{}, fmt.Errorf("%w: resource must not include a tag or digest", errdef.ErrInvalidReference)
+	}
+	if err := (Reference{Repository: path}).ValidateRepository(); err != nil {
+		return Resource{}, err
+	}
+	return Resource{Host: host, Path: path}, nil
+}

--- a/registry/remote/properties/resource.go
+++ b/registry/remote/properties/resource.go
@@ -25,9 +25,9 @@ import (
 // Resource represents a registry host, optionally narrowed to a namespace or
 // repository. It never carries a tag or digest.
 type Resource struct {
-	// Host is the name of the registry, usually a domain name optionally with a
-	// port.
-	Host string
+	// Registry is the name of the registry, usually a domain name optionally
+	// with a port.
+	Registry string
 
 	// Path is the namespace or repository path, or empty for the whole registry.
 	Path string
@@ -54,7 +54,7 @@ func ParseResource(resource string) (Resource, error) {
 		return Resource{}, err
 	}
 	if path == "" {
-		return Resource{Host: host}, nil
+		return Resource{Registry: host}, nil
 	}
 	if strings.ContainsAny(path, ":@") {
 		return Resource{}, fmt.Errorf("%w: resource must not include a tag or digest", errdef.ErrInvalidReference)
@@ -62,5 +62,23 @@ func ParseResource(resource string) (Resource, error) {
 	if err := (Reference{Repository: path}).ValidateRepository(); err != nil {
 		return Resource{}, err
 	}
-	return Resource{Host: host, Path: path}, nil
+	return Resource{Registry: host, Path: path}, nil
+}
+
+// Host returns the host name of the registry.
+//
+// For docker.io, it returns registry-1.docker.io.
+func (r Resource) Host() string {
+	if r.Registry == "docker.io" {
+		return "registry-1.docker.io"
+	}
+	return r.Registry
+}
+
+// String returns the resource as a string.
+func (r Resource) String() string {
+	if r.Path == "" {
+		return r.Registry
+	}
+	return r.Registry + "/" + r.Path
 }

--- a/registry/remote/properties/resource.go
+++ b/registry/remote/properties/resource.go
@@ -38,15 +38,16 @@ type Resource struct {
 // optional oci://, http://, or https:// scheme, and may be narrowed to a
 // namespace or repository path. Tags and digests are not accepted.
 func ParseResource(resource string) (Resource, error) {
-	resource = strings.TrimPrefix(resource, "oci://")
-	resource = strings.TrimPrefix(resource, "http://")
-	resource = strings.TrimPrefix(resource, "https://")
-	resource = strings.TrimSuffix(resource, "/")
-	if strings.HasSuffix(resource, "/") {
+	trimmed := strings.TrimPrefix(resource, "oci://")
+	trimmed = strings.TrimPrefix(trimmed, "http://")
+	trimmed = strings.TrimPrefix(trimmed, "https://")
+	// A single trailing slash is tolerated; more than one is not a valid path.
+	trimmed = strings.TrimSuffix(trimmed, "/")
+	if strings.HasSuffix(trimmed, "/") {
 		return Resource{}, fmt.Errorf("%w: invalid resource path %q", errdef.ErrInvalidReference, resource)
 	}
 
-	host, path := splitRegistry(resource)
+	host, path := splitRegistry(trimmed)
 	if host == "" {
 		return Resource{}, fmt.Errorf("%w: invalid registry resource %q", errdef.ErrInvalidReference, resource)
 	}

--- a/registry/remote/properties/resource.go
+++ b/registry/remote/properties/resource.go
@@ -25,8 +25,9 @@ import (
 // Resource represents a registry host, optionally narrowed to a namespace or
 // repository. It never carries a tag or digest.
 type Resource struct {
-	// Registry is the name of the registry, usually a domain name optionally
-	// with a port.
+	// Registry is the normalized name of the registry. The host portion is
+	// lowercase because registry hostnames are case-insensitive; a port, if
+	// present, is preserved.
 	Registry string
 
 	// Path is the namespace or repository path, or empty for the whole registry.
@@ -40,6 +41,7 @@ func ParseResource(resource string) (Resource, error) {
 	resource = strings.TrimPrefix(resource, "oci://")
 	resource = strings.TrimPrefix(resource, "http://")
 	resource = strings.TrimPrefix(resource, "https://")
+	resource = strings.TrimSuffix(resource, "/")
 	if strings.HasSuffix(resource, "/") {
 		return Resource{}, fmt.Errorf("%w: invalid resource path %q", errdef.ErrInvalidReference, resource)
 	}
@@ -48,6 +50,7 @@ func ParseResource(resource string) (Resource, error) {
 	if host == "" {
 		return Resource{}, fmt.Errorf("%w: invalid registry resource %q", errdef.ErrInvalidReference, resource)
 	}
+	host = strings.ToLower(host)
 
 	// Validate the host independently so a port is not mistaken for a tag.
 	if err := (Reference{Registry: host}).ValidateRegistry(); err != nil {

--- a/registry/remote/properties/resource_test.go
+++ b/registry/remote/properties/resource_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package properties
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseResource(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Resource
+	}{
+		{name: "registry", input: "example.com", want: Resource{Host: "example.com"}},
+		{name: "namespace", input: "example.com/myspace", want: Resource{Host: "example.com", Path: "myspace"}},
+		{name: "repository", input: "example.com/myspace/app", want: Resource{Host: "example.com", Path: "myspace/app"}},
+		{name: "port", input: "localhost:5000/ns", want: Resource{Host: "localhost:5000", Path: "ns"}},
+		{name: "oci scheme", input: "oci://example.com/ns", want: Resource{Host: "example.com", Path: "ns"}},
+		{name: "http scheme", input: "http://example.com/ns", want: Resource{Host: "example.com", Path: "ns"}},
+		{name: "https scheme", input: "https://example.com/ns", want: Resource{Host: "example.com", Path: "ns"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseResource(tt.input)
+			if err != nil {
+				t.Fatalf("ParseResource() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseResource() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseResourceRejectsReferencesAndInvalidPaths(t *testing.T) {
+	tests := []string{
+		"example.com/myspace:v1",
+		"example.com/myspace@sha256:deadbeef",
+		"example.com/",
+		"example.com/UPPER",
+		"example.com/a//b",
+		"example.com/a b",
+		"invalid host/ns",
+		"",
+	}
+	for _, input := range tests {
+		t.Run(strings.ReplaceAll(input, "/", "_"), func(t *testing.T) {
+			if _, err := ParseResource(input); err == nil {
+				t.Fatalf("ParseResource(%q) expected an error", input)
+			}
+		})
+	}
+}
+
+func TestParseResourceTagDigestError(t *testing.T) {
+	for _, input := range []string{"example.com/myspace:v1", "example.com/myspace@sha256:deadbeef"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := ParseResource(input)
+			if err == nil || !strings.Contains(err.Error(), "must not include a tag or digest") {
+				t.Fatalf("ParseResource(%q) error = %v, want tag/digest error", input, err)
+			}
+		})
+	}
+}

--- a/registry/remote/properties/resource_test.go
+++ b/registry/remote/properties/resource_test.go
@@ -26,13 +26,13 @@ func TestParseResource(t *testing.T) {
 		input string
 		want  Resource
 	}{
-		{name: "registry", input: "example.com", want: Resource{Host: "example.com"}},
-		{name: "namespace", input: "example.com/myspace", want: Resource{Host: "example.com", Path: "myspace"}},
-		{name: "repository", input: "example.com/myspace/app", want: Resource{Host: "example.com", Path: "myspace/app"}},
-		{name: "port", input: "localhost:5000/ns", want: Resource{Host: "localhost:5000", Path: "ns"}},
-		{name: "oci scheme", input: "oci://example.com/ns", want: Resource{Host: "example.com", Path: "ns"}},
-		{name: "http scheme", input: "http://example.com/ns", want: Resource{Host: "example.com", Path: "ns"}},
-		{name: "https scheme", input: "https://example.com/ns", want: Resource{Host: "example.com", Path: "ns"}},
+		{name: "registry", input: "example.com", want: Resource{Registry: "example.com"}},
+		{name: "namespace", input: "example.com/myspace", want: Resource{Registry: "example.com", Path: "myspace"}},
+		{name: "repository", input: "example.com/myspace/app", want: Resource{Registry: "example.com", Path: "myspace/app"}},
+		{name: "port", input: "localhost:5000/ns", want: Resource{Registry: "localhost:5000", Path: "ns"}},
+		{name: "oci scheme", input: "oci://example.com/ns", want: Resource{Registry: "example.com", Path: "ns"}},
+		{name: "http scheme", input: "http://example.com/ns", want: Resource{Registry: "example.com", Path: "ns"}},
+		{name: "https scheme", input: "https://example.com/ns", want: Resource{Registry: "example.com", Path: "ns"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,6 +73,44 @@ func TestParseResourceTagDigestError(t *testing.T) {
 			_, err := ParseResource(input)
 			if err == nil || !strings.Contains(err.Error(), "must not include a tag or digest") {
 				t.Fatalf("ParseResource(%q) error = %v, want tag/digest error", input, err)
+			}
+		})
+	}
+}
+
+func TestResourceHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource Resource
+		want     string
+	}{
+		{name: "docker hub", resource: Resource{Registry: "docker.io"}, want: "registry-1.docker.io"},
+		{name: "other registry", resource: Resource{Registry: "ghcr.io"}, want: "ghcr.io"},
+		{name: "registry port", resource: Resource{Registry: "localhost:5000"}, want: "localhost:5000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resource.Host(); got != tt.want {
+				t.Errorf("Resource.Host() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceString(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource Resource
+		want     string
+	}{
+		{name: "registry", resource: Resource{Registry: "example.com"}, want: "example.com"},
+		{name: "namespace", resource: Resource{Registry: "example.com", Path: "myspace"}, want: "example.com/myspace"},
+		{name: "repository", resource: Resource{Registry: "example.com", Path: "myspace/app"}, want: "example.com/myspace/app"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.resource.String(); got != tt.want {
+				t.Errorf("Resource.String() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/registry/remote/properties/resource_test.go
+++ b/registry/remote/properties/resource_test.go
@@ -16,8 +16,11 @@ limitations under the License.
 package properties
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/oras-project/oras-go/v3/errdef"
 )
 
 func TestParseResource(t *testing.T) {
@@ -33,6 +36,10 @@ func TestParseResource(t *testing.T) {
 		{name: "oci scheme", input: "oci://example.com/ns", want: Resource{Registry: "example.com", Path: "ns"}},
 		{name: "http scheme", input: "http://example.com/ns", want: Resource{Registry: "example.com", Path: "ns"}},
 		{name: "https scheme", input: "https://example.com/ns", want: Resource{Registry: "example.com", Path: "ns"}},
+		{name: "trailing slash", input: "https://example.com/", want: Resource{Registry: "example.com"}},
+		{name: "trailing slash on path", input: "example.com/myspace/app/", want: Resource{Registry: "example.com", Path: "myspace/app"}},
+		{name: "uppercase registry", input: "EXAMPLE.com/ns/app", want: Resource{Registry: "example.com", Path: "ns/app"}},
+		{name: "uppercase registry with port", input: "LOCALHOST:5000/ns", want: Resource{Registry: "localhost:5000", Path: "ns"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -51,7 +58,9 @@ func TestParseResourceRejectsReferencesAndInvalidPaths(t *testing.T) {
 	tests := []string{
 		"example.com/myspace:v1",
 		"example.com/myspace@sha256:deadbeef",
-		"example.com/",
+		"/",
+		"example.com//",
+		"example.com/myspace//",
 		"example.com/UPPER",
 		"example.com/a//b",
 		"example.com/a b",
@@ -62,6 +71,8 @@ func TestParseResourceRejectsReferencesAndInvalidPaths(t *testing.T) {
 		t.Run(strings.ReplaceAll(input, "/", "_"), func(t *testing.T) {
 			if _, err := ParseResource(input); err == nil {
 				t.Fatalf("ParseResource(%q) expected an error", input)
+			} else if !errors.Is(err, errdef.ErrInvalidReference) {
+				t.Errorf("ParseResource(%q) error = %v, want errors.Is(err, ErrInvalidReference)", input, err)
 			}
 		})
 	}
@@ -73,6 +84,9 @@ func TestParseResourceTagDigestError(t *testing.T) {
 			_, err := ParseResource(input)
 			if err == nil || !strings.Contains(err.Error(), "must not include a tag or digest") {
 				t.Fatalf("ParseResource(%q) error = %v, want tag/digest error", input, err)
+			}
+			if !errors.Is(err, errdef.ErrInvalidReference) {
+				t.Errorf("ParseResource(%q) error = %v, want errors.Is(err, ErrInvalidReference)", input, err)
 			}
 		})
 	}


### PR DESCRIPTION
Resolves #1380

Adds a Resource value and parser for a registry host optionally narrowed to a namespace or repository, without tags or digests. Includes focused acceptance and edge-case tests.