### PR TITLE
refactor(remote): use properties references internally

### DIFF
--- a/registry/remote/builder.go
+++ b/registry/remote/builder.go
@@ -246,7 +246,7 @@ func (b *ClientBuilder) buildCredentialFunc(props *properties.Registry) credenti
 	// Match what the transport actually dials: Host() maps the "docker.io"
 	// alias onto "registry-1.docker.io", and the credential func is called with
 	// the request host.
-	host := registry.Reference{Registry: props.Reference.Registry}.Host()
+	host := props.Reference.Host()
 
 	return func(ctx context.Context, reg string) (credentials.Credential, error) {
 		// Credential specified in properties, for its own registry only.

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -29,6 +29,7 @@ import (
 	"github.com/oras-project/oras-go/v3/registry/remote/auth"
 	"github.com/oras-project/oras-go/v3/registry/remote/internal/errutil"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 // Registry is an HTTP client to a remote registry.
@@ -105,14 +106,14 @@ type Registry struct {
 // name.
 // Example: localhost:5000
 func NewRegistry(name string) (*Registry, error) {
-	ref := registry.Reference{
+	ref := properties.Reference{
 		Registry: name,
 	}
 	if err := ref.ValidateRegistry(); err != nil {
 		return nil, err
 	}
 	return &Registry{
-		Reference: ref,
+		Reference: registry.Reference{Registry: ref.Registry},
 	}, nil
 }
 
@@ -153,7 +154,8 @@ func (r *Registry) do(req *http.Request) (*http.Response, error) {
 //   - https://distribution.github.io/distribution/spec/api/#base
 //   - https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#api
 func (r *Registry) Ping(ctx context.Context) error {
-	url := buildRegistryBaseURL(r.PlainHTTP, r.Reference)
+	ref := properties.Reference{Registry: r.Reference.Registry}
+	url := buildRegistryBaseURL(r.PlainHTTP, ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
@@ -185,7 +187,8 @@ func (r *Registry) Ping(ctx context.Context) error {
 // Reference: https://distribution.github.io/distribution/spec/api/#catalog
 func (r *Registry) Repositories(ctx context.Context, last string, fn func(repos []string) error) error {
 	ctx = auth.AppendScopesForHost(ctx, r.Reference.Host(), auth.ScopeRegistryCatalog)
-	url := buildRegistryCatalogURL(r.PlainHTTP, r.Reference)
+	ref := properties.Reference{Registry: r.Reference.Registry}
+	url := buildRegistryCatalogURL(r.PlainHTTP, ref)
 	var err error
 	maxPages := r.RepositoryListMaxPages
 	for page := 0; err == nil; page++ {
@@ -248,7 +251,7 @@ func (r *Registry) Repository(ctx context.Context, name string) (registry.Reposi
 
 // newRepository creates a new Repository with the given name.
 func (r *Registry) newRepository(name string) (*Repository, error) {
-	ref := registry.Reference{
+	ref := properties.Reference{
 		Registry:   r.Reference.Registry,
 		Repository: name,
 	}

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -204,13 +204,50 @@ func NewRepository(reference string) (*Repository, error) {
 	}, nil
 }
 
-// Reference returns the full registry.Reference for this repository.
-func (r *Repository) Reference() registry.Reference {
-	ref := registry.Reference{Repository: r.RepositoryName}
+// reference returns the properties reference for this repository.
+func (r *Repository) reference() properties.Reference {
+	ref := properties.Reference{Repository: r.RepositoryName}
 	if r.Registry != nil {
 		ref.Registry = r.Registry.Reference.Registry
 	}
 	return ref
+}
+
+// toPropertiesReference converts a legacy registry reference at an exported
+// API boundary to the reference representation used internally by remote.
+func toPropertiesReference(ref registry.Reference) properties.Reference {
+	propertiesRef := properties.Reference{
+		Registry:   ref.Registry,
+		Repository: ref.Repository,
+		Tag:        ref.Tag,
+		Digest:     ref.Digest,
+	}
+	if propertiesRef.GetReference() == "" && ref.Reference != "" {
+		if d, err := digest.Parse(ref.Reference); err == nil {
+			propertiesRef.Digest = d.String()
+		} else {
+			propertiesRef.Tag = ref.Reference
+		}
+	}
+	return propertiesRef
+}
+
+// appendRepositoryScope adapts the internal reference representation to the
+// legacy authentication API.
+func appendRepositoryScope(ctx context.Context, ref properties.Reference, actions ...string) context.Context {
+	return auth.AppendRepositoryScope(ctx, registry.Reference{
+		Registry:   ref.Registry,
+		Repository: ref.Repository,
+	}, actions...)
+}
+
+// Reference returns the full registry.Reference for this repository.
+func (r *Repository) Reference() registry.Reference {
+	ref := r.reference()
+	return registry.Reference{
+		Registry:   ref.Registry,
+		Repository: ref.Repository,
+	}
 }
 
 // clone makes a copy of the Repository being careful not to copy non-copyable fields (sync.Mutex and syncutil.Pool types)
@@ -721,7 +758,7 @@ func (r *Repository) FetchReference(ctx context.Context, reference string) (ocis
 // the same base reference with the Repository r, ParseReference returns a
 // wrapped error ErrInvalidReference.
 func (r *Repository) ParseReference(reference string) (registry.Reference, error) {
-	repoRef := r.Reference()
+	repoRef := r.reference()
 	ref, err := registry.ParseReference(reference)
 	if err != nil {
 		ref = registry.Reference{
@@ -769,8 +806,8 @@ func (r *Repository) Tags(ctx context.Context, last string, fn func(tags []strin
 	if err := r.checkPolicy(ctx, ""); err != nil {
 		return err
 	}
-	repoRef := r.Reference()
-	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull)
+	repoRef := r.reference()
+	ctx = appendRepositoryScope(ctx, repoRef, auth.ActionPull)
 	url := buildRepositoryTagListURL(r.plainHTTP(), repoRef)
 	var err error
 	maxPages := r.tagListMaxPages()
@@ -891,10 +928,10 @@ func (r *Repository) Referrers(ctx context.Context, desc ocispec.Descriptor, art
 // fn is called for the referrers result. If artifactType is not empty,
 // only referrers of the same artifact type are fed to fn.
 func (r *Repository) referrersByAPI(ctx context.Context, desc ocispec.Descriptor, artifactType string, fn func(referrers []ocispec.Descriptor) error) error {
-	repoRef := r.Reference()
+	repoRef := r.reference()
 	ref := repoRef
-	ref.Reference = desc.Digest.String()
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
+	ref.Digest = desc.Digest.String()
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
 
 	url := buildReferrersURL(r.plainHTTP(), ref, artifactType)
 	var err error
@@ -1048,10 +1085,10 @@ func (r *Repository) pingReferrers(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	repoRef := r.Reference()
+	repoRef := r.reference()
 	ref := repoRef
-	ref.Reference = zeroDigest
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
+	ref.Digest = zeroDigest
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
 
 	url := buildReferrersURL(r.plainHTTP(), ref, "")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -1084,10 +1121,10 @@ func (r *Repository) pingReferrers(ctx context.Context) (bool, error) {
 // delete removes the content identified by the descriptor in the entity "blobs"
 // or "manifests".
 func (r *Repository) delete(ctx context.Context, target ocispec.Descriptor, isManifest bool) error {
-	repoRef := r.Reference()
+	repoRef := r.reference()
 	ref := repoRef
-	ref.Reference = target.Digest.String()
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
+	ref.Digest = target.Digest.String()
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionDelete)
 	buildURL := buildRepositoryBlobURL
 	if isManifest {
 		buildURL = buildRepositoryManifestURL
@@ -1124,10 +1161,10 @@ func (s *blobStore) Fetch(ctx context.Context, target ocispec.Descriptor) (rc io
 	if err := s.repo.checkPolicy(ctx, ""); err != nil {
 		return nil, err
 	}
-	repoRef := s.repo.Reference()
+	repoRef := s.repo.reference()
 	ref := repoRef
-	ref.Reference = target.Digest.String()
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
+	ref.Digest = target.Digest.String()
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
 	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -1175,13 +1212,13 @@ func (s *blobStore) Mount(ctx context.Context, desc ocispec.Descriptor, fromRepo
 	}
 	// pushing usually requires both pull and push actions.
 	// Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-	repoRef := s.repo.Reference()
-	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull, auth.ActionPush)
+	repoRef := s.repo.reference()
+	ctx = appendRepositoryScope(ctx, repoRef, auth.ActionPull, auth.ActionPush)
 
 	// We also need pull access to the source repo.
 	fromRef := repoRef
 	fromRef.Repository = fromRepo
-	ctx = auth.AppendRepositoryScope(ctx, fromRef, auth.ActionPull)
+	ctx = appendRepositoryScope(ctx, fromRef, auth.ActionPull)
 
 	url := buildRepositoryBlobMountURL(s.repo.plainHTTP(), repoRef, desc.Digest, fromRepo)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
@@ -1257,8 +1294,8 @@ func (s *blobStore) Push(ctx context.Context, expected ocispec.Descriptor, conte
 	// start an upload
 	// pushing usually requires both pull and push actions.
 	// Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-	repoRef := s.repo.Reference()
-	ctx = auth.AppendRepositoryScope(ctx, repoRef, auth.ActionPull, auth.ActionPush)
+	repoRef := s.repo.reference()
+	ctx = appendRepositoryScope(ctx, repoRef, auth.ActionPull, auth.ActionPush)
 	url := buildRepositoryBlobUploadURL(s.repo.plainHTTP(), repoRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
@@ -1396,8 +1433,9 @@ func (s *blobStore) Resolve(ctx context.Context, reference string) (ocispec.Desc
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
+	propertiesRef := toPropertiesReference(ref)
+	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), propertiesRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -1434,8 +1472,9 @@ func (s *blobStore) FetchReference(ctx context.Context, reference string) (desc 
 		return ocispec.Descriptor{}, nil, err
 	}
 
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
+	propertiesRef := toPropertiesReference(ref)
+	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), propertiesRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
@@ -1510,10 +1549,10 @@ func (s *manifestStore) Fetch(ctx context.Context, target ocispec.Descriptor) (r
 	if err := s.repo.checkManifestPolicy(ctx, "", target); err != nil {
 		return nil, err
 	}
-	repoRef := s.repo.Reference()
+	repoRef := s.repo.reference()
 	ref := repoRef
-	ref.Reference = target.Digest.String()
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
+	ref.Digest = target.Digest.String()
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
 	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -1600,7 +1639,7 @@ func (s *manifestStore) deleteWithIndexing(ctx context.Context, target ocispec.D
 		if err := limitSize(target, s.repo.maxMetadataBytes()); err != nil {
 			return err
 		}
-		ctx = auth.AppendRepositoryScope(ctx, s.repo.Reference(), auth.ActionPull, auth.ActionDelete)
+		ctx = appendRepositoryScope(ctx, s.repo.reference(), auth.ActionPull, auth.ActionDelete)
 		manifestJSON, err := content.FetchAll(ctx, s, target)
 		if err != nil {
 			return err
@@ -1653,8 +1692,9 @@ func (s *manifestStore) Resolve(ctx context.Context, reference string) (ocispec.
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
+	propertiesRef := toPropertiesReference(ref)
+	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), propertiesRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -1669,7 +1709,7 @@ func (s *manifestStore) Resolve(ctx context.Context, reference string) (ocispec.
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		desc, err := s.generateDescriptor(resp, ref, req.Method)
+		desc, err := s.generateDescriptor(resp, propertiesRef, req.Method)
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}
@@ -1695,8 +1735,9 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 		return ocispec.Descriptor{}, nil, err
 	}
 
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
+	propertiesRef := toPropertiesReference(ref)
+	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), propertiesRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
@@ -1720,7 +1761,7 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 			// skip the redundant evaluation in Resolve.
 			desc, err = s.Resolve(withPolicyChecked(ctx), reference)
 		} else {
-			desc, err = s.generateDescriptor(resp, ref, req.Method)
+			desc, err = s.generateDescriptor(resp, propertiesRef, req.Method)
 		}
 		if err != nil {
 			return ocispec.Descriptor{}, nil, err
@@ -1747,14 +1788,15 @@ func (s *manifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, refere
 		return err
 	}
 
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
+	propertiesRef := toPropertiesReference(ref)
+	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull, auth.ActionPush)
 	rc, err := s.Fetch(ctx, desc)
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
 
-	return s.push(ctx, desc, rc, ref.Reference)
+	return s.push(ctx, desc, rc, propertiesRef.GetReference())
 }
 
 // Untag removes the association between the given tag and the manifest it currently points to.
@@ -1769,8 +1811,9 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 	if err := ref.ValidateReferenceAsTag(); err != nil {
 		return err
 	}
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionDelete)
-	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
+	propertiesRef := toPropertiesReference(ref)
+	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionDelete)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), propertiesRef)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err
@@ -1801,17 +1844,21 @@ func (s *manifestStore) PushReference(ctx context.Context, expected ocispec.Desc
 	if err != nil {
 		return err
 	}
-	return s.pushWithIndexing(ctx, expected, content, ref.Reference)
+	return s.pushWithIndexing(ctx, expected, content, toPropertiesReference(ref).GetReference())
 }
 
 // push pushes the manifest content, matching the expected descriptor.
 func (s *manifestStore) push(ctx context.Context, expected ocispec.Descriptor, content io.Reader, reference string) error {
-	repoRef := s.repo.Reference()
+	repoRef := s.repo.reference()
 	ref := repoRef
-	ref.Reference = reference
+	if d, err := digest.Parse(reference); err == nil {
+		ref.Digest = d.String()
+	} else {
+		ref.Tag = reference
+	}
 	// pushing usually requires both pull and push actions.
 	// Reference: https://github.com/distribution/distribution/blob/v2.7.1/registry/handlers/app.go#L921-L930
-	ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
 	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	// unwrap the content for optimizations of built-in types.
 	body := ioutil.UnwrapNopCloser(content)
@@ -2048,7 +2095,7 @@ func (s *manifestStore) ParseReference(reference string) (registry.Reference, er
 
 // generateDescriptor returns a descriptor generated from the response.
 // See the truth table at the top of `repository_test.go`
-func (s *manifestStore) generateDescriptor(resp *http.Response, ref registry.Reference, httpMethod string) (ocispec.Descriptor, error) {
+func (s *manifestStore) generateDescriptor(resp *http.Response, ref properties.Reference, httpMethod string) (ocispec.Descriptor, error) {
 	// 1. Validate Content-Type
 	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if err != nil {

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -7096,9 +7096,8 @@ func Test_ManifestStore_PushReference_ReferrersAPIUnavailable(t *testing.T) {
 }
 
 func Test_ManifestStore_generateDescriptorWithVariousDockerContentDigestHeaders(t *testing.T) {
-	reference := registry.Reference{
+	reference := properties.Reference{
 		Registry:   "eastern.haan.com",
-		Reference:  "<calculate>",
 		Repository: "from25to220ce",
 	}
 
@@ -7112,7 +7111,13 @@ func Test_ManifestStore_generateDescriptorWithVariousDockerContentDigestHeaders(
 		s := manifestStore{repo: repo}
 
 		for i, method := range []string{http.MethodGet, http.MethodHead} {
-			reference.Reference = dcdIOStruct.clientSuppliedReference
+			reference.Tag = ""
+			reference.Digest = ""
+			if dcdIOStruct.isTag {
+				reference.Tag = dcdIOStruct.clientSuppliedReference
+			} else {
+				reference.Digest = dcdIOStruct.clientSuppliedReference
+			}
 
 			resp := http.Response{
 				Header: http.Header{
@@ -8426,7 +8431,7 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 	tests := []struct {
 		name           string
 		resp           *http.Response
-		ref            registry.Reference
+		ref            properties.Reference
 		httpMethod     string
 		wantDescriptor ocispec.Descriptor
 		wantErr        bool
@@ -8444,10 +8449,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 					URL:    &url.URL{Path: "/test"},
 				},
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  dataDigest.String(),
+				Digest:     dataDigest.String(),
 			},
 			httpMethod: http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{
@@ -8470,10 +8475,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 					URL:    &url.URL{Path: "/test"},
 				},
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  dataDigest.String(),
+				Digest:     dataDigest.String(),
 			},
 			httpMethod:     http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{},
@@ -8492,10 +8497,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 					URL:    &url.URL{Path: "/test"},
 				},
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  dataDigest.String(),
+				Digest:     dataDigest.String(),
 			},
 			httpMethod:     http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{},
@@ -8514,10 +8519,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 					URL:    &url.URL{Path: "/test"},
 				},
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  dataDigest.String(),
+				Digest:     dataDigest.String(),
 			},
 			httpMethod:     http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{},
@@ -8536,10 +8541,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 				},
 				Body: io.NopCloser(bytes.NewReader(data)),
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  dataDigest.String(),
+				Digest:     dataDigest.String(),
 			},
 			httpMethod: http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{
@@ -8562,10 +8567,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 				},
 				Body: &badReader{},
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  dataDigest.String(),
+				Digest:     dataDigest.String(),
 			},
 			httpMethod:     http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{},
@@ -8584,10 +8589,10 @@ func TestManifestStore_generateDescriptor(t *testing.T) {
 					URL:    &url.URL{Path: "/test"},
 				},
 			},
-			ref: registry.Reference{
+			ref: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  string(digest.FromBytes([]byte("whatever"))),
+				Digest:     string(digest.FromBytes([]byte("whatever"))),
 			},
 			httpMethod:     http.MethodGet,
 			wantDescriptor: ocispec.Descriptor{},

--- a/registry/remote/url.go
+++ b/registry/remote/url.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/go-digest"
-	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 // buildScheme returns HTTP scheme used to access the remote registry.
@@ -35,63 +35,63 @@ func buildScheme(plainHTTP bool) string {
 // buildRegistryBaseURL builds the URL for accessing the base API.
 // Format: <scheme>://<registry>/v2/
 // Reference: https://distribution.github.io/distribution/spec/api/#base
-func buildRegistryBaseURL(plainHTTP bool, ref registry.Reference) string {
+func buildRegistryBaseURL(plainHTTP bool, ref properties.Reference) string {
 	return fmt.Sprintf("%s://%s/v2/", buildScheme(plainHTTP), ref.Host())
 }
 
 // buildRegistryCatalogURL builds the URL for accessing the catalog API.
 // Format: <scheme>://<registry>/v2/_catalog
 // Reference: https://distribution.github.io/distribution/spec/api/#catalog
-func buildRegistryCatalogURL(plainHTTP bool, ref registry.Reference) string {
+func buildRegistryCatalogURL(plainHTTP bool, ref properties.Reference) string {
 	return fmt.Sprintf("%s://%s/v2/_catalog", buildScheme(plainHTTP), ref.Host())
 }
 
 // buildRepositoryBaseURL builds the base endpoint of the remote repository.
 // Format: <scheme>://<registry>/v2/<repository>
-func buildRepositoryBaseURL(plainHTTP bool, ref registry.Reference) string {
+func buildRepositoryBaseURL(plainHTTP bool, ref properties.Reference) string {
 	return fmt.Sprintf("%s://%s/v2/%s", buildScheme(plainHTTP), ref.Host(), ref.Repository)
 }
 
 // buildRepositoryTagListURL builds the URL for accessing the tag list API.
 // Format: <scheme>://<registry>/v2/<repository>/tags/list
 // Reference: https://distribution.github.io/distribution/spec/api/#tags
-func buildRepositoryTagListURL(plainHTTP bool, ref registry.Reference) string {
+func buildRepositoryTagListURL(plainHTTP bool, ref properties.Reference) string {
 	return buildRepositoryBaseURL(plainHTTP, ref) + "/tags/list"
 }
 
 // buildRepositoryManifestURL builds the URL for accessing the manifest API.
 // Format: <scheme>://<registry>/v2/<repository>/manifests/<digest_or_tag>
 // Reference: https://distribution.github.io/distribution/spec/api/#manifest
-func buildRepositoryManifestURL(plainHTTP bool, ref registry.Reference) string {
+func buildRepositoryManifestURL(plainHTTP bool, ref properties.Reference) string {
 	return strings.Join([]string{
 		buildRepositoryBaseURL(plainHTTP, ref),
 		"manifests",
-		ref.Reference,
+		ref.GetReference(),
 	}, "/")
 }
 
 // buildRepositoryBlobURL builds the URL for accessing the blob API.
 // Format: <scheme>://<registry>/v2/<repository>/blobs/<digest>
 // Reference: https://distribution.github.io/distribution/spec/api/#blob
-func buildRepositoryBlobURL(plainHTTP bool, ref registry.Reference) string {
+func buildRepositoryBlobURL(plainHTTP bool, ref properties.Reference) string {
 	return strings.Join([]string{
 		buildRepositoryBaseURL(plainHTTP, ref),
 		"blobs",
-		ref.Reference,
+		ref.GetReference(),
 	}, "/")
 }
 
 // buildRepositoryBlobUploadURL builds the URL for blob uploading.
 // Format: <scheme>://<registry>/v2/<repository>/blobs/uploads/
 // Reference: https://distribution.github.io/distribution/spec/api/#initiate-blob-upload
-func buildRepositoryBlobUploadURL(plainHTTP bool, ref registry.Reference) string {
+func buildRepositoryBlobUploadURL(plainHTTP bool, ref properties.Reference) string {
 	return buildRepositoryBaseURL(plainHTTP, ref) + "/blobs/uploads/"
 }
 
 // buildRepositoryBlobMountURL builds the URL for cross-repository mounting.
 // Format: <scheme>://<registry>/v2/<repository>/blobs/uploads/?mount=<digest>&from=<other_repository>
 // Reference: https://distribution.github.io/distribution/spec/api/#blob
-func buildRepositoryBlobMountURL(plainHTTP bool, ref registry.Reference, d digest.Digest, fromRepo string) string {
+func buildRepositoryBlobMountURL(plainHTTP bool, ref properties.Reference, d digest.Digest, fromRepo string) string {
 	return fmt.Sprintf("%s?mount=%s&from=%s",
 		buildRepositoryBlobUploadURL(plainHTTP, ref),
 		d,
@@ -102,7 +102,7 @@ func buildRepositoryBlobMountURL(plainHTTP bool, ref registry.Reference, d diges
 // buildReferrersURL builds the URL for querying the Referrers API.
 // Format: <scheme>://<registry>/v2/<repository>/referrers/<digest>?artifactType=<artifactType>
 // Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#listing-referrers
-func buildReferrersURL(plainHTTP bool, ref registry.Reference, artifactType string) string {
+func buildReferrersURL(plainHTTP bool, ref properties.Reference, artifactType string) string {
 	var query string
 	if artifactType != "" {
 		v := url.Values{}
@@ -113,7 +113,7 @@ func buildReferrersURL(plainHTTP bool, ref registry.Reference, artifactType stri
 	return fmt.Sprintf(
 		"%s/referrers/%s%s",
 		buildRepositoryBaseURL(plainHTTP, ref),
-		ref.Reference,
+		ref.GetReference(),
 		query,
 	)
 }

--- a/registry/remote/url_test.go
+++ b/registry/remote/url_test.go
@@ -20,14 +20,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 func Test_buildReferrersURL(t *testing.T) {
-	ref := registry.Reference{
+	ref := properties.Reference{
 		Registry:   "localhost",
 		Repository: "hello-world",
-		Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 	}
 
 	params := []struct {


### PR DESCRIPTION
## Summary

- migrate internal remote URL, repository, registry, and builder code to `registry/remote/properties.Reference`
- preserve the public legacy reference APIs and the existing auth scope compatibility boundary
- update regression coverage for the internal reference flow

Fixes #1386

## Tests

- `make test`