### PR TITLE
refactor(remote)!: use properties references in exported APIs

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -212,6 +212,19 @@ fmt.Println(ref.Registry, ref.Repository, ref.Tag)
 
 The parsers also accept `oci://`, `http://`, and `https://` prefixes.
 
+The exported reference surfaces in `registry/remote` use the properties type:
+
+| Deprecated type | Replacement |
+| --- | --- |
+| `remote.Registry.Reference registry.Reference` | `remote.Registry.Reference properties.Reference` |
+| `remote.Repository.Reference() registry.Reference` | `remote.Repository.Reference() properties.Reference` |
+| `remote.Repository.ParseReference(string) (registry.Reference, error)` | `remote.Repository.ParseReference(string) (properties.Reference, error)` |
+
+Custom targets that expose a `ParseReference` method should update its return
+type to `properties.Reference`. ORAS temporarily recognizes the legacy method
+signature when adding authentication scope hints, so existing implementations
+retain that behavior during migration.
+
 ### Repository interfaces, predecessors, and untagging
 
 `registry.Repository` now embeds `content.PredecessorFinder`. Applications

--- a/content.go
+++ b/content.go
@@ -53,6 +53,24 @@ const (
 // DefaultTagNOptions provides the default TagNOptions.
 var DefaultTagNOptions TagNOptions
 
+// parseReferenceForScope parses a reference for the authentication API. The
+// legacy parser case keeps third-party targets using registry.Reference from
+// silently losing scope hints during the properties.Reference migration.
+func parseReferenceForScope(target any, reference string) (registry.Reference, bool, error) {
+	if parser, ok := target.(interfaces.ReferenceParser); ok {
+		ref, err := parser.ParseReference(reference)
+		return registry.Reference{
+			Registry:   ref.Registry,
+			Repository: ref.Repository,
+		}, true, err
+	}
+	if parser, ok := target.(interfaces.LegacyReferenceParser); ok {
+		ref, err := parser.ParseReference(reference)
+		return ref, true, err
+	}
+	return registry.Reference{}, false, nil
+}
+
 // TagNOptions contains parameters for [oras.TagN].
 type TagNOptions struct {
 	// Concurrency limits the maximum number of concurrent tag tasks.
@@ -84,9 +102,8 @@ func TagN(ctx context.Context, target Target, srcReference string, dstReferences
 	_, isRefFetcher := target.(registry.ReferenceFetcher)
 	_, isRefPusher := target.(registry.ReferencePusher)
 	if isRefFetcher && isRefPusher {
-		if repo, ok := target.(interfaces.ReferenceParser); ok {
+		if ref, ok, err := parseReferenceForScope(target, srcReference); ok {
 			// add scope hints to minimize the number of auth requests
-			ref, err := repo.ParseReference(srcReference)
 			if err != nil {
 				return ocispec.Descriptor{}, err
 			}
@@ -142,9 +159,8 @@ func Tag(ctx context.Context, target Target, src, dst string) (ocispec.Descripto
 	refFetcher, okFetch := target.(registry.ReferenceFetcher)
 	refPusher, okPush := target.(registry.ReferencePusher)
 	if okFetch && okPush {
-		if repo, ok := target.(interfaces.ReferenceParser); ok {
+		if ref, ok, err := parseReferenceForScope(target, src); ok {
 			// add scope hints to minimize the number of auth requests
-			ref, err := repo.ParseReference(src)
 			if err != nil {
 				return ocispec.Descriptor{}, err
 			}

--- a/content_internal_test.go
+++ b/content_internal_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
+)
+
+type propertiesReferenceParser struct {
+	ref properties.Reference
+	err error
+}
+
+func (p propertiesReferenceParser) ParseReference(string) (properties.Reference, error) {
+	return p.ref, p.err
+}
+
+type legacyReferenceParser struct {
+	ref registry.Reference
+	err error
+}
+
+func (p legacyReferenceParser) ParseReference(string) (registry.Reference, error) {
+	return p.ref, p.err
+}
+
+func TestParseReferenceForScope(t *testing.T) {
+	legacyRef := registry.Reference{
+		Registry:   "registry.example.com",
+		Repository: "library/test",
+		Reference:  "latest",
+	}
+	tests := []struct {
+		name      string
+		parser    any
+		want      registry.Reference
+		wantMatch bool
+		wantErr   error
+	}{
+		{
+			name: "properties reference parser",
+			parser: propertiesReferenceParser{ref: properties.Reference{
+				Registry:   legacyRef.Registry,
+				Repository: legacyRef.Repository,
+				Tag:        legacyRef.Reference,
+			}},
+			want: registry.Reference{
+				Registry:   legacyRef.Registry,
+				Repository: legacyRef.Repository,
+			},
+			wantMatch: true,
+		},
+		{
+			name:      "legacy reference parser",
+			parser:    legacyReferenceParser{ref: legacyRef},
+			want:      legacyRef,
+			wantMatch: true,
+		},
+		{
+			name:      "parser error",
+			parser:    propertiesReferenceParser{err: errdefTest},
+			want:      registry.Reference{},
+			wantMatch: true,
+			wantErr:   errdefTest,
+		},
+		{
+			name:   "unsupported target",
+			parser: struct{}{},
+			want:   registry.Reference{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, matched, err := parseReferenceForScope(tt.parser, "latest")
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("parseReferenceForScope() error = %v, want %v", err, tt.wantErr)
+			}
+			if matched != tt.wantMatch {
+				t.Errorf("parseReferenceForScope() matched = %v, want %v", matched, tt.wantMatch)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseReferenceForScope() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var errdefTest = errors.New("test error")

--- a/internal/interfaces/registry.go
+++ b/internal/interfaces/registry.go
@@ -15,10 +15,21 @@ limitations under the License.
 
 package interfaces
 
-import "github.com/oras-project/oras-go/v3/registry"
+import (
+	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
+)
 
 // ReferenceParser provides reference parsing.
 type ReferenceParser interface {
+	// ParseReference parses a reference to a fully qualified reference.
+	ParseReference(reference string) (properties.Reference, error)
+}
+
+// LegacyReferenceParser provides reference parsing using the deprecated
+// registry.Reference type. It is retained so that third-party targets keep
+// receiving authentication scope hints while migrating to ReferenceParser.
+type LegacyReferenceParser interface {
 	// ParseReference parses a reference to a fully qualified reference.
 	ParseReference(reference string) (registry.Reference, error)
 }

--- a/registry/remote/builder.go
+++ b/registry/remote/builder.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/auth"
 	"github.com/oras-project/oras-go/v3/registry/remote/credentials"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
@@ -303,7 +302,7 @@ func NewRegistryWithProperties(props *properties.Registry, builder *ClientBuilde
 	// Create registry
 	reg := &Registry{
 		Client:    client,
-		Reference: registry.Reference{Registry: props.Reference.Registry},
+		Reference: properties.Reference{Registry: props.Reference.Registry},
 		PlainHTTP: props.Transport.PlainHTTP,
 		Policy:    builder.PolicyEvaluator,
 	}
@@ -385,7 +384,7 @@ func buildMirrorRepositories(props *properties.Registry, builder *ClientBuilder)
 
 		mirrorReg := &Registry{
 			Client:    mirrorClient,
-			Reference: registry.Reference{Registry: m.Location},
+			Reference: properties.Reference{Registry: m.Location},
 			PlainHTTP: m.Transport.PlainHTTP,
 		}
 		if logger := builder.warningLogger(); logger != nil {

--- a/registry/remote/mirror_test.go
+++ b/registry/remote/mirror_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/oras-project/oras-go/v3/registry"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 )
 
 func Test_isDigestReference(t *testing.T) {
@@ -141,7 +141,7 @@ func repoFromServer(t *testing.T, server *httptest.Server) *Repository {
 	return &Repository{
 		Registry: &Registry{
 			Client:    server.Client(),
-			Reference: registry.Reference{Registry: host},
+			Reference: properties.Reference{Registry: host},
 			PlainHTTP: true,
 		},
 		RepositoryName: "test/repo",

--- a/registry/remote/registry.go
+++ b/registry/remote/registry.go
@@ -39,7 +39,7 @@ type Registry struct {
 	Client Client
 
 	// Reference contains registry host information.
-	Reference registry.Reference
+	Reference properties.Reference
 
 	// PlainHTTP signals the transport to access the registry via HTTP
 	// instead of HTTPS.
@@ -113,7 +113,7 @@ func NewRegistry(name string) (*Registry, error) {
 		return nil, err
 	}
 	return &Registry{
-		Reference: registry.Reference{Registry: ref.Registry},
+		Reference: ref,
 	}, nil
 }
 

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -183,7 +183,7 @@ type Repository struct {
 // carrying one is rejected with an error wrapping
 // [errdef.ErrInvalidReference].
 func NewRepository(reference string) (*Repository, error) {
-	ref, err := registry.ParseReference(reference)
+	ref, err := properties.NewReference(reference)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func NewRepository(reference string) (*Repository, error) {
 
 	// Create a default Registry
 	reg := &Registry{
-		Reference: registry.Reference{
+		Reference: properties.Reference{
 			Registry: ref.Registry,
 		},
 	}
@@ -213,25 +213,6 @@ func (r *Repository) reference() properties.Reference {
 	return ref
 }
 
-// toPropertiesReference converts a legacy registry reference at an exported
-// API boundary to the reference representation used internally by remote.
-func toPropertiesReference(ref registry.Reference) properties.Reference {
-	propertiesRef := properties.Reference{
-		Registry:   ref.Registry,
-		Repository: ref.Repository,
-		Tag:        ref.Tag,
-		Digest:     ref.Digest,
-	}
-	if propertiesRef.GetReference() == "" && ref.Reference != "" {
-		if d, err := digest.Parse(ref.Reference); err == nil {
-			propertiesRef.Digest = d.String()
-		} else {
-			propertiesRef.Tag = ref.Reference
-		}
-	}
-	return propertiesRef
-}
-
 // appendRepositoryScope adapts the internal reference representation to the
 // legacy authentication API.
 func appendRepositoryScope(ctx context.Context, ref properties.Reference, actions ...string) context.Context {
@@ -241,13 +222,9 @@ func appendRepositoryScope(ctx context.Context, ref properties.Reference, action
 	}, actions...)
 }
 
-// Reference returns the full registry.Reference for this repository.
-func (r *Repository) Reference() registry.Reference {
-	ref := r.reference()
-	return registry.Reference{
-		Registry:   ref.Registry,
-		Repository: ref.Repository,
-	}
+// Reference returns the full properties.Reference for this repository.
+func (r *Repository) Reference() properties.Reference {
+	return r.reference()
 }
 
 // clone makes a copy of the Repository being careful not to copy non-copyable fields (sync.Mutex and syncutil.Pool types)
@@ -573,7 +550,7 @@ func (r *Repository) policyDigest(reference string) digest.Digest {
 	if err != nil {
 		return ""
 	}
-	d, err := digest.Parse(ref.Reference)
+	d, err := digest.Parse(ref.GetReference())
 	if err != nil {
 		return ""
 	}
@@ -757,37 +734,40 @@ func (r *Repository) FetchReference(ctx context.Context, reference string) (ocis
 // and returns the parsed reference. If the parsed reference does not share
 // the same base reference with the Repository r, ParseReference returns a
 // wrapped error ErrInvalidReference.
-func (r *Repository) ParseReference(reference string) (registry.Reference, error) {
+func (r *Repository) ParseReference(reference string) (properties.Reference, error) {
 	repoRef := r.reference()
-	ref, err := registry.ParseReference(reference)
+	ref, err := properties.NewReference(reference)
 	if err != nil {
-		ref = registry.Reference{
+		ref = properties.Reference{
 			Registry:   repoRef.Registry,
 			Repository: repoRef.Repository,
-			Reference:  reference,
 		}
 
 		// reference is not a FQDN
 		if index := strings.IndexByte(reference, '@'); index != -1 {
 			// `@` implies *digest*, so drop the *tag* (irrespective of what it is).
-			ref.Reference = reference[index+1:]
-			err = ref.ValidateReferenceAsDigest()
+			ref.Digest = reference[index+1:]
+			err = ref.ValidateDigest()
+		} else if d, digestErr := digest.Parse(reference); digestErr == nil {
+			ref.Digest = d.String()
+			err = nil
 		} else {
-			err = ref.ValidateReference()
+			ref.Tag = reference
+			err = ref.ValidateTag()
 		}
 
 		if err != nil {
-			return registry.Reference{}, err
+			return properties.Reference{}, err
 		}
 	} else if ref.Registry != repoRef.Registry || ref.Repository != repoRef.Repository {
-		return registry.Reference{}, fmt.Errorf(
+		return properties.Reference{}, fmt.Errorf(
 			"%w: mismatch between received %q and expected %q",
 			errdef.ErrInvalidReference, ref, repoRef,
 		)
 	}
 
-	if len(ref.Reference) == 0 {
-		return registry.Reference{}, errdef.ErrInvalidReference
+	if ref.GetReference() == "" {
+		return properties.Reference{}, errdef.ErrInvalidReference
 	}
 
 	return ref, nil
@@ -1429,13 +1409,12 @@ func (s *blobStore) Resolve(ctx context.Context, reference string) (ocispec.Desc
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	refDigest, err := ref.GetDigest()
+	refDigest, err := digest.Parse(ref.GetReference())
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	propertiesRef := toPropertiesReference(ref)
-	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.plainHTTP(), propertiesRef)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -1467,14 +1446,13 @@ func (s *blobStore) FetchReference(ctx context.Context, reference string) (desc 
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
-	refDigest, err := ref.GetDigest()
+	refDigest, err := digest.Parse(ref.GetReference())
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
 	}
 
-	propertiesRef := toPropertiesReference(ref)
-	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
-	url := buildRepositoryBlobURL(s.repo.plainHTTP(), propertiesRef)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
+	url := buildRepositoryBlobURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
@@ -1692,9 +1670,8 @@ func (s *manifestStore) Resolve(ctx context.Context, reference string) (ocispec.
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
-	propertiesRef := toPropertiesReference(ref)
-	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.plainHTTP(), propertiesRef)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, err
@@ -1709,7 +1686,7 @@ func (s *manifestStore) Resolve(ctx context.Context, reference string) (ocispec.
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		desc, err := s.generateDescriptor(resp, propertiesRef, req.Method)
+		desc, err := s.generateDescriptor(resp, ref, req.Method)
 		if err != nil {
 			return ocispec.Descriptor{}, err
 		}
@@ -1735,9 +1712,8 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 		return ocispec.Descriptor{}, nil, err
 	}
 
-	propertiesRef := toPropertiesReference(ref)
-	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull)
-	url := buildRepositoryManifestURL(s.repo.plainHTTP(), propertiesRef)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return ocispec.Descriptor{}, nil, err
@@ -1761,7 +1737,7 @@ func (s *manifestStore) FetchReference(ctx context.Context, reference string) (d
 			// skip the redundant evaluation in Resolve.
 			desc, err = s.Resolve(withPolicyChecked(ctx), reference)
 		} else {
-			desc, err = s.generateDescriptor(resp, propertiesRef, req.Method)
+			desc, err = s.generateDescriptor(resp, ref, req.Method)
 		}
 		if err != nil {
 			return ocispec.Descriptor{}, nil, err
@@ -1788,15 +1764,14 @@ func (s *manifestStore) Tag(ctx context.Context, desc ocispec.Descriptor, refere
 		return err
 	}
 
-	propertiesRef := toPropertiesReference(ref)
-	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionPull, auth.ActionPush)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
 	rc, err := s.Fetch(ctx, desc)
 	if err != nil {
 		return err
 	}
 	defer rc.Close()
 
-	return s.push(ctx, desc, rc, propertiesRef.GetReference())
+	return s.push(ctx, desc, rc, ref.GetReference())
 }
 
 // Untag removes the association between the given tag and the manifest it currently points to.
@@ -1808,12 +1783,11 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 	if err != nil {
 		return err
 	}
-	if err := ref.ValidateReferenceAsTag(); err != nil {
-		return err
+	if ref.Tag == "" || ref.Digest != "" {
+		return fmt.Errorf("%w: invalid tag %q", errdef.ErrInvalidReference, ref.GetReference())
 	}
-	propertiesRef := toPropertiesReference(ref)
-	ctx = appendRepositoryScope(ctx, propertiesRef, auth.ActionDelete)
-	url := buildRepositoryManifestURL(s.repo.plainHTTP(), propertiesRef)
+	ctx = appendRepositoryScope(ctx, ref, auth.ActionDelete)
+	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
 		return err
@@ -1844,7 +1818,7 @@ func (s *manifestStore) PushReference(ctx context.Context, expected ocispec.Desc
 	if err != nil {
 		return err
 	}
-	return s.pushWithIndexing(ctx, expected, content, toPropertiesReference(ref).GetReference())
+	return s.pushWithIndexing(ctx, expected, content, ref.GetReference())
 }
 
 // push pushes the manifest content, matching the expected descriptor.
@@ -2089,7 +2063,7 @@ func (s *manifestStore) updateReferrersIndex(ctx context.Context, subject ocispe
 }
 
 // ParseReference parses a reference to a fully qualified reference.
-func (s *manifestStore) ParseReference(reference string) (registry.Reference, error) {
+func (s *manifestStore) ParseReference(reference string) (properties.Reference, error) {
 	return s.repo.ParseReference(reference)
 }
 

--- a/registry/remote/repository.go
+++ b/registry/remote/repository.go
@@ -529,6 +529,10 @@ func (r *Repository) policyImageReference(reference string) policy.ImageReferenc
 	ref := repoRef.String()
 	if reference != "" {
 		if parsed, err := r.ParseReference(reference); err == nil {
+			// Policy verifiers historically receive the digest without a tag.
+			if parsed.Digest != "" {
+				parsed.Tag = ""
+			}
 			ref = parsed.String()
 		} else {
 			ref = reference
@@ -1783,8 +1787,11 @@ func (s *manifestStore) Untag(ctx context.Context, reference string) error {
 	if err != nil {
 		return err
 	}
-	if ref.Tag == "" || ref.Digest != "" {
+	if ref.Digest != "" {
 		return fmt.Errorf("%w: invalid tag %q", errdef.ErrInvalidReference, ref.GetReference())
+	}
+	if err := ref.ValidateTag(); err != nil {
+		return err
 	}
 	ctx = appendRepositoryScope(ctx, ref, auth.ActionDelete)
 	url := buildRepositoryManifestURL(s.repo.plainHTTP(), ref)

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -32,6 +32,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/oras-project/oras-go/v3/registry"
 	"github.com/oras-project/oras-go/v3/registry/remote/policy"
+	"github.com/oras-project/oras-go/v3/registry/remote/properties"
 	"github.com/oras-project/oras-go/v3/registry/remote/signature"
 )
 
@@ -50,7 +51,7 @@ func newRejectPolicyRepo(t *testing.T) *Repository {
 		t.Fatalf("failed to create evaluator: %v", err)
 	}
 	reg := &Registry{
-		Reference: registry.Reference{Registry: testReference.Registry},
+		Reference: properties.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
 	}
 	return &Repository{
@@ -72,7 +73,7 @@ func assertPolicyDenied(t *testing.T, err error, operation string) {
 
 func TestRepository_PolicyEnforcement(t *testing.T) {
 	reg := &Registry{
-		Reference: registry.Reference{Registry: testReference.Registry},
+		Reference: properties.Reference{Registry: testReference.Registry},
 	}
 	repo := &Repository{
 		Registry:       reg,
@@ -159,7 +160,7 @@ func TestRepository_PolicyScope(t *testing.T) {
 	}
 
 	reg := &Registry{
-		Reference: registry.Reference{Registry: testReference.Registry},
+		Reference: properties.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
 	}
 	repo := &Repository{
@@ -184,7 +185,7 @@ func TestRepository_Clone_Policy(t *testing.T) {
 	}
 
 	reg := &Registry{
-		Reference: registry.Reference{Registry: testReference.Registry},
+		Reference: properties.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
 	}
 	original := &Repository{
@@ -386,7 +387,7 @@ func TestRepository_ScopeSpecificPolicy(t *testing.T) {
 	}
 
 	reg := &Registry{
-		Reference: registry.Reference{Registry: testReference.Registry},
+		Reference: properties.Reference{Registry: testReference.Registry},
 		Policy:    evaluator,
 	}
 	repo := &Repository{
@@ -441,7 +442,7 @@ func newSignedByEvaluator(t *testing.T, verifier policy.SignedByVerifier) *polic
 func newSignedByPolicyRepo(t *testing.T, verifier policy.SignedByVerifier) *Repository {
 	t.Helper()
 	reg := &Registry{
-		Reference: registry.Reference{Registry: testReference.Registry},
+		Reference: properties.Reference{Registry: testReference.Registry},
 		Policy:    newSignedByEvaluator(t, verifier),
 	}
 	return &Repository{

--- a/registry/remote/repository_policy_test.go
+++ b/registry/remote/repository_policy_test.go
@@ -425,6 +425,29 @@ func (v *recordingSignedByVerifier) Verify(ctx context.Context, req *policy.PRSi
 	return v.allow, nil
 }
 
+func TestRepository_PolicyTagAndDigestReference(t *testing.T) {
+	d := digest.FromString("hello world")
+	for _, reference := range []string{
+		"signed@" + d.String(),
+		testReference.String() + ":signed@" + d.String(),
+	} {
+		t.Run(reference, func(t *testing.T) {
+			verifier := &recordingSignedByVerifier{allow: true}
+			repo := newSignedByPolicyRepo(t, verifier)
+			if err := repo.checkPolicy(context.Background(), reference); err != nil {
+				t.Fatal(err)
+			}
+			if len(verifier.seen) != 1 {
+				t.Fatalf("verifier called %d times, want 1", len(verifier.seen))
+			}
+			want := testReference.String() + "@" + d.String()
+			if got := verifier.seen[0]; got.Reference != want || got.Digest != d {
+				t.Errorf("verifier image = %+v, want reference %q and digest %q", got, want, d)
+			}
+		})
+	}
+}
+
 func newSignedByEvaluator(t *testing.T, verifier policy.SignedByVerifier) *policy.Evaluator {
 	t.Helper()
 	pol := &policy.Policy{

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -7528,106 +7528,103 @@ func TestRepository_ParseReference(t *testing.T) {
 	}
 	tests := []struct {
 		name    string
-		repoRef registry.Reference
+		repoRef properties.Reference
 		args    args
-		want    registry.Reference
+		want    properties.Reference
 		wantErr error
 	}{
 		{
 			name: "parse tag",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "foobar",
 			},
-			want: registry.Reference{
+			want: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  "foobar",
+				Tag:        "foobar",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "parse digest",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
-			want: registry.Reference{
+			want: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+				Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "parse tag@digest",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "foobar@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
-			want: registry.Reference{
+			want: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+				Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "parse FQDN tag",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com/hello-world:foobar",
 			},
-			want: registry.Reference{
+			want: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  "foobar",
 				Tag:        "foobar",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "parse FQDN digest",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com/hello-world@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
-			want: registry.Reference{
+			want: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 				Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: nil,
 		},
 		{
 			name: "parse FQDN tag@digest",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com/hello-world:foobar@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
-			want: registry.Reference{
+			want: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
-				Reference:  "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 				Tag:        "foobar",
 				Digest:     "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
@@ -7635,131 +7632,131 @@ func TestRepository_ParseReference(t *testing.T) {
 		},
 		{
 			name: "empty reference",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "missing repository",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "myregistry.example.com:hello-world",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "missing reference",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com/hello-world",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "registry mismatch",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "myregistry.example.com/hello-world:foobar@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "repository mismatch",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com/goodbye-world:foobar@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "digest posing as a tag",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com:5000/hello-world:sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "missing reference after the at sign",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry:   "registry.example.com",
 				Repository: "hello-world",
 			},
 			args: args{
 				reference: "registry.example.com/hello-world@",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name: "missing reference after the colon",
-			repoRef: registry.Reference{
+			repoRef: properties.Reference{
 				Registry: "localhost",
 			},
 			args: args{
 				reference: "localhost:5000/hello:",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name:    "zero-size tag, zero-size digest",
-			repoRef: registry.Reference{},
+			repoRef: properties.Reference{},
 			args: args{
 				reference: "localhost:5000/hello:@",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name:    "zero-size tag with valid digest",
-			repoRef: registry.Reference{},
+			repoRef: properties.Reference{},
 			args: args{
 				reference: "localhost:5000/hello:@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 		{
 			name:    "valid tag with zero-size digest",
-			repoRef: registry.Reference{},
+			repoRef: properties.Reference{},
 			args: args{
 				reference: "localhost:5000/hello:foobar@",
 			},
-			want:    registry.Reference{},
+			want:    properties.Reference{},
 			wantErr: errdef.ErrInvalidReference,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := &Registry{
-				Reference: registry.Reference{Registry: tt.repoRef.Registry},
+				Reference: properties.Reference{Registry: tt.repoRef.Registry},
 			}
 			r := &Repository{
 				Registry:       reg,
@@ -8370,37 +8367,37 @@ func TestManifestStore_ParseReference(t *testing.T) {
 	tests := []struct {
 		name      string
 		reference string
-		want      registry.Reference
+		want      properties.Reference
 		wantErr   bool
 	}{
 		{
 			name:      "valid tag",
 			reference: "foobar",
-			want: registry.Reference{
-				Reference: "foobar",
+			want: properties.Reference{
+				Tag: "foobar",
 			},
 			wantErr: false,
 		},
 		{
 			name:      "valid digest",
 			reference: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-			want: registry.Reference{
-				Reference: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+			want: properties.Reference{
+				Digest: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: false,
 		},
 		{
 			name:      "valid tag@digest",
 			reference: "foobar@sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
-			want: registry.Reference{
-				Reference: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+			want: properties.Reference{
+				Digest: "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
 			},
 			wantErr: false,
 		},
 		{
 			name:      "invalid reference",
 			reference: "invalid@reference",
-			want:      registry.Reference{},
+			want:      properties.Reference{},
 			wantErr:   true,
 		},
 	}


### PR DESCRIPTION
## What

- migrate `remote.Registry.Reference`, `Repository.Reference`, and both `ParseReference` implementations to `properties.Reference`
- remove the legacy conversion layer from remote repository operations
- retain a temporary structural fallback for third-party targets whose `ParseReference` method still returns `registry.Reference`
- document the exported API migration and the compatibility window

## Why

This completes the exported half of the reference migration after #1392 while preventing existing third-party targets from silently losing authentication scope hints.

Closes #1387.

## Testing

- `go test -mod=mod ./registry/remote .`
- `go test -mod=mod -race -cover ./registry/remote .` (90.0% / 89.5% statement coverage)
- the remaining packages compile and their tests pass except two host-configuration tests that require access to system config paths unavailable in the local sandbox