### PR TITLE
ci: trigger v2 releases from a release label

### DIFF
--- a/.github/act/release-event.json
+++ b/.github/act/release-event.json
@@ -3,10 +3,15 @@
   "pull_request": {
     "merged": true,
     "number": 999,
-    "title": "chore: prepare release v2.7.0",
+    "title": "release: v2.7.0",
     "body": "## New Features\n\n* Test feature\n\n## Bug Fixes\n\n* Test fix",
+    "labels": [
+      {
+        "name": "release"
+      }
+    ],
     "head": {
-      "ref": "release/v2.7.0",
+      "ref": "chore/release-v2.7.0",
       "sha": "abc123def456"
     },
     "base": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -41,12 +44,17 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Extract version from branch name
+      - name: Extract version from PR title
         id: version
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          BRANCH="${{ github.head_ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ ! "$TITLE" =~ ^release:[[:space:]]+(v[0-9A-Za-z.-]+)[[:space:]]*$ ]]; then
+            echo "Error: PR is labelled 'release' but its title is not 'release: vX.Y.Z'"
+            echo "Title was: $TITLE"
+            exit 1
+          fi
+          echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
 
       - name: Validate semantic version
         run: |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,25 @@
 # Releasing oras-go
 
-Releases are created via a GitOps workflow. Merging a `release/vX.Y.Z` branch
-into `v2` automatically tags the commit and publishes the GitHub Release.
+Releases are created via a GitOps workflow. Merging a pull request labelled
+`release` into `v2` automatically tags the commit and publishes the GitHub
+Release.
+
+There is no long-lived release branch: `v2` is always the latest v2, and a
+release simply tags its tip.
+
+## Automated proposals
+
+The [release-propose workflow](https://github.com/oras-project/oras-go/blob/main/.github/workflows/release-propose.yml)
+runs weekly on `main` and opens the release PR for you once the previous v2 tag
+is at least 14 days old and there are unreleased commits on `v2`. It picks the
+next version, drafts the release notes from the commit log, and applies the
+`release` label. Owners still review and merge — the automation only proposes.
+
+It can also be triggered by hand from the Actions tab, optionally with an
+explicit version.
+
+The steps below describe the same process done manually, which is still
+supported.
 
 ## Steps
 
@@ -12,10 +30,15 @@ opened. Use an empty commit as a lightweight marker:
 
 ```bash
 git fetch upstream
-git checkout -b release/v2.7.0 upstream/v2
-git commit --allow-empty -s -m "chore: prepare release v2.7.0"
-git push origin release/v2.7.0
+git checkout -b chore/release-v2.7.0 upstream/v2
+git commit --allow-empty -s -m "chore: release v2.7.0"
+git push upstream chore/release-v2.7.0
 ```
+
+The branch name is not part of the trigger — the `release` label is. The branch
+must be pushed to `oras-project/oras-go` rather than to a fork: the release
+workflow ignores PRs from forks, so a release branch pushed to a personal fork
+will merge without tagging anything.
 
 The release does not need to contain the changes being released — those are
 already on `v2`. The PR is a trigger: when it merges, the workflow tags the
@@ -24,8 +47,12 @@ all prior work on the branch.
 
 ### 2. Open a pull request
 
-Open a PR from `release/v2.7.0` targeting the `v2` branch. Write the release
-notes directly in the PR description using the format from prior releases:
+Open a PR from `chore/release-v2.7.0` targeting the `v2` branch.
+
+- **Title:** `release: v2.7.0` — the version is read from here, and it must
+  match exactly.
+- **Label:** `release` — this is what triggers the release workflow.
+- **Body:** the release notes, in the format used by prior releases:
 
 ```markdown
 ## New Features
@@ -46,10 +73,12 @@ its final form.
 
 ### 3. Get approvals
 
-Branch protection on `v2` requires approval from at least 3 of the 4 owners
-listed in [OWNERS.md](OWNERS.md). Reviewers should verify:
+Branch protection on `v2` requires code owner approval. Convention is to get
+approval from at least 3 of the 4 owners listed in [OWNERS.md](OWNERS.md).
+Reviewers should verify:
 
 - The target commit is correct
+- The PR title carries the intended version
 - The release notes are accurate and complete
 - All CI checks pass
 
@@ -58,15 +87,19 @@ listed in [OWNERS.md](OWNERS.md). Reviewers should verify:
 Merge the PR. The [release workflow](.github/workflows/release.yml)
 automatically:
 
-1. Extracts the version from the branch name (`release/v2.7.0` → `v2.7.0`)
+1. Extracts the version from the PR title (`release: v2.7.0` → `v2.7.0`)
 2. Creates and pushes the git tag
 3. Publishes the GitHub Release with the PR body as release notes
+
+If the PR carries the `release` label but the title does not parse, the
+workflow fails loudly rather than releasing the wrong version.
 
 ## Pre-releases
 
 Tags containing `-alpha`, `-beta`, or `-rc` (e.g., `v2.7.0-rc.1`) are
-automatically marked as pre-release on GitHub. Use the same branch naming
-convention: `release/v2.7.0-rc.1`.
+automatically marked as pre-release on GitHub. Use the same PR title
+convention: `release: v2.7.0-rc.1`. The automated proposer never proposes a
+pre-release; cut those by hand.
 
 ## Testing the workflow locally
 
@@ -99,7 +132,8 @@ act pull_request \
 This runs all steps up to and including version extraction (`version=vX.Y.Z` will
 appear in the output). The `git push` step then fails with a permission error —
 that is expected and confirms no tag was pushed. The mock event payload is at
-`.github/act/release-event.json`.
+`.github/act/release-event.json`; it carries the `release` label and a matching
+title.
 
 ## Updating the documentation site
 


### PR DESCRIPTION
## What

Replaces the `release/vX.Y.Z` head-branch trigger on the v2 release workflow with a `release` label, and reads the version from the PR title (`release: v2.7.0`).

We no longer maintain `release/v2.x.y` branches — `v2` is the latest v2, and a release just tags its tip — so keying the release on a branch name no longer makes sense.

## Changes

- `.github/workflows/release.yml`: job condition gates on `contains(labels.*.name, 'release')`; version comes from the PR title, passed via `env` rather than interpolated into the script. A labelled PR whose title does not parse fails loudly instead of tagging something unintended.
- `RELEASES.md`: documents the label + title convention, and adds a warning that the release branch must be pushed to `oras-project/oras-go` — the workflow ignores PRs from forks, so a fork branch merges without tagging anything.
- `.github/act/release-event.json`: fixture carries the label and the new title.

Nothing about tagging, GoReleaser, or the release body changes: the PR description is still used verbatim as the release notes.

## Follow-up

A companion PR against `main` adds a scheduled workflow that opens these release PRs automatically. **This PR should merge first** — until it does, a labelled release PR would merge without tagging.
