### PR TITLE
fix(remote): normalize registry host case in references and registries.conf matching

### DIFF
--- a/registry/remote/config/registries.go
+++ b/registry/remote/config/registries.go
@@ -471,7 +471,11 @@ func extractHost(ref string) string {
 // case-sensitive repository, tag and digest untouched.
 func lowerHost(ref string) string {
 	host := extractHost(ref)
-	return strings.ToLower(host) + ref[len(host):]
+	// extractHost cannot tell a port from a tag in a slash-less reference, so
+	// it hands back "myimage:V1" whole. Fold only up to the ":" so a short-name
+	// tag survives; a port is digits, and folding it would be a no-op anyway.
+	name, _, _ := strings.Cut(host, ":")
+	return strings.ToLower(name) + ref[len(name):]
 }
 
 // ResolveAlias resolves a short name to a fully qualified reference.

--- a/registry/remote/config/registries.go
+++ b/registry/remote/config/registries.go
@@ -410,7 +410,11 @@ func (rc *RegistriesConfig) FindRegistry(ref string) *Registry {
 
 // matchesPrefix checks if the reference matches the given prefix.
 // Supports wildcard prefixes like "*.example.com".
+// The host part is compared case-insensitively on both sides, since the
+// prefix comes from user-authored TOML and the reference from the caller.
 func matchesPrefix(ref, prefix string) bool {
+	ref, prefix = lowerHost(ref), lowerHost(prefix)
+
 	// Handle wildcard prefix
 	if strings.HasPrefix(prefix, "*.") {
 		suffix := prefix[1:] // Remove the "*", keep the "."
@@ -461,6 +465,13 @@ func extractHost(ref string) string {
 	}
 
 	return ref
+}
+
+// lowerHost lower-cases the host part of a reference or prefix, leaving the
+// case-sensitive repository, tag and digest untouched.
+func lowerHost(ref string) string {
+	host := extractHost(ref)
+	return strings.ToLower(host) + ref[len(host):]
 }
 
 // ResolveAlias resolves a short name to a fully qualified reference.
@@ -514,8 +525,8 @@ func (rc *RegistriesConfig) RewriteReference(ref string) string {
 	}
 
 	// Replace prefix with location
-	if strings.HasPrefix(ref, prefix) {
-		return location + ref[len(prefix):]
+	if lref, lprefix := lowerHost(ref), lowerHost(prefix); strings.HasPrefix(lref, lprefix) {
+		return location + lref[len(lprefix):]
 	}
 
 	return ref

--- a/registry/remote/config/registries_test.go
+++ b/registry/remote/config/registries_test.go
@@ -427,6 +427,16 @@ func TestRegistriesConfig_IsBlocked(t *testing.T) {
 			ref:  "unknown.registry.com/image:tag",
 			want: false,
 		},
+		{
+			name: "blocked registry mixed-case host",
+			ref:  "Blocked.Registry.COM/image:tag",
+			want: true,
+		},
+		{
+			name: "wildcard blocked mixed-case host",
+			ref:  "Sub.Blocked.Example.COM/image:tag",
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -528,6 +538,11 @@ func TestRegistriesConfig_RewriteReference(t *testing.T) {
 			ref:  "gcr.io/myproject/image:v1",
 			want: "gcr.io/myproject/image:v1",
 		},
+		{
+			name: "rewrite mixed-case host",
+			ref:  "Docker.IO/library/alpine:Latest",
+			want: "library-mirror.example.com/alpine:Latest",
+		},
 	}
 
 	for _, tt := range tests {
@@ -621,6 +636,30 @@ func TestMatchesPrefix(t *testing.T) {
 			name:   "partial string no match",
 			ref:    "docker.io.evil.com/image",
 			prefix: "docker.io",
+			want:   false,
+		},
+		{
+			name:   "mixed-case ref host",
+			ref:    "Docker.IO/nginx",
+			prefix: "docker.io",
+			want:   true,
+		},
+		{
+			name:   "mixed-case prefix host",
+			ref:    "localhost:5000/nginx",
+			prefix: "LocalHost:5000",
+			want:   true,
+		},
+		{
+			name:   "wildcard mixed-case host",
+			ref:    "Sub.Example.COM/image",
+			prefix: "*.example.com",
+			want:   true,
+		},
+		{
+			name:   "tag case is significant",
+			ref:    "docker.io/nginx:Latest",
+			prefix: "docker.io/nginx:latest",
 			want:   false,
 		},
 	}

--- a/registry/remote/properties/reference.go
+++ b/registry/remote/properties/reference.go
@@ -89,6 +89,9 @@ type Reference struct {
 //	Form D: registry/repository               (no tag or digest)
 //
 // In Form B, both Tag and Digest fields are populated.
+//
+// The registry host is case-insensitive (DNS), so it is lower-cased during
+// parsing. Repository, tag and digest are preserved as written.
 func NewReference(artifact string) (Reference, error) {
 	// Strip URI schemes if present
 	artifact = strings.TrimPrefix(artifact, "oci://")
@@ -103,7 +106,7 @@ func NewReference(artifact string) (Reference, error) {
 	repository, digestStr, tag := splitRepository(path)
 
 	ref := Reference{
-		Registry:   registry,
+		Registry:   strings.ToLower(registry),
 		Repository: repository,
 		Tag:        tag,
 		Digest:     digestStr,

--- a/registry/remote/properties/reference_test.go
+++ b/registry/remote/properties/reference_test.go
@@ -86,6 +86,13 @@ func TestNewReference(t *testing.T) {
 			wantRepo: "library/alpine",
 		},
 		{
+			name:     "mixed-case registry host is lower-cased, tag preserved",
+			input:    "LocalHost:5000/repo:V1",
+			wantReg:  "localhost:5000",
+			wantRepo: "repo",
+			wantTag:  "V1",
+		},
+		{
 			name:    "invalid - missing repository",
 			input:   "docker.io",
 			wantErr: true,

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -7522,6 +7522,17 @@ func TestRepository_Tags_WithLastParam(t *testing.T) {
 	}
 }
 
+func TestRepository_policyImageReference_LowerCasesHost(t *testing.T) {
+	repo, err := NewRepository("Quay.IO/secure/app")
+	if err != nil {
+		t.Fatalf("NewRepository() error = %v", err)
+	}
+	got := repo.policyImageReference("")
+	if want := "quay.io/secure/app"; got.Scope != want {
+		t.Errorf("policyImageReference().Scope = %q, want %q", got.Scope, want)
+	}
+}
+
 func TestRepository_ParseReference(t *testing.T) {
 	type args struct {
 		reference string


### PR DESCRIPTION
Fixes #1388
Fixes #1389

The registry host is case-insensitive, but `properties.NewReference` preserved it verbatim and `config.matchesPrefix` / `RewriteReference` compared it with plain string operations. Case-varying the host in a reference bypassed `policy.json` transport scopes (fell through to `default`) and `registries.conf` `blocked = true` entries, and silently dropped the entry's `insecure` / `mirrors` / `token-flow` / `location` settings.

Changes:

- `properties.NewReference` lower-cases the registry host once, so every downstream consumer (policy scope, URL construction, auth cache key, `Repository.ParseReference` mismatch check) sees a normalized value. Repository, tag and digest are left as written. This is the Tier 3 fix proposed in #1401.
- `config.matchesPrefix` and `RewriteReference` fold the host on both the reference and the prefix, since `NewRegistryProperties` consults `registries.conf` before parsing and the prefix is user-authored TOML. Only the host component is folded: a prefix naming a tag (`docker.io/nginx:latest`) still does not match `docker.io/nginx:Latest`.

Tests: mixed-case host cases in `TestNewReference`, `TestMatchesPrefix` (including a "tag case is significant" guard), `TestRegistriesConfig_IsBlocked`, `TestRegistriesConfig_RewriteReference`, plus `TestRepository_policyImageReference_LowerCasesHost` pinning the policy scope end to end.

Note for release notes: `Reference.Registry` (and `String()`) now returns a lower-cased host for mixed-case input. v3 only; `v3.0.0-rc.1` is the only tag carrying this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
