### PR TITLE
fix(properties): reject dangling reference delimiters

### DIFF
--- a/registry/remote/properties/reference.go
+++ b/registry/remote/properties/reference.go
@@ -100,7 +100,10 @@ func NewReference(artifact string) (Reference, error) {
 		return Reference{}, fmt.Errorf("%w: missing registry or repository", errdef.ErrInvalidReference)
 	}
 
-	repository, digestStr, tag := splitRepository(path)
+	repository, digestStr, tag, err := splitRepository(path)
+	if err != nil {
+		return Reference{}, err
+	}
 
 	ref := Reference{
 		Registry:   registry,
@@ -153,7 +156,10 @@ func NewReferenceList(artifact string) ([]Reference, error) {
 		return nil, fmt.Errorf("%w: missing registry or repository", errdef.ErrInvalidReference)
 	}
 
-	repository, digestRef, tagRef := splitRepository(path)
+	repository, digestRef, tagRef, err := splitRepository(path)
+	if err != nil {
+		return nil, err
+	}
 
 	// Determine if we have tags or digests
 	references := tagRef
@@ -198,27 +204,26 @@ func NewReferenceList(artifact string) ([]Reference, error) {
 }
 
 // splitRepository splits the path into repository, digest, and tag.
-func splitRepository(path string) (repository, digestStr, tag string) {
+func splitRepository(path string) (repository, digestStr, tag string, err error) {
+	repository = path
 	if index := strings.Index(path, "@"); index != -1 {
-		// digest found; Valid Form A (if not B)
 		repository = path[:index]
 		digestStr = path[index+1:]
-
-		if index = strings.Index(repository, ":"); index != -1 {
-			// tag found since digest already present; Valid Form B
-			tag = repository[index+1:]
-			repository = repository[:index]
+		if digestStr == "" {
+			return "", "", "", fmt.Errorf("%w: missing digest", errdef.ErrInvalidReference)
 		}
-		return repository, digestStr, tag
 	}
 
-	if index := strings.Index(path, ":"); index != -1 {
-		// tag found; Valid Form C
-		return path[:index], "", path[index+1:]
+	if index := strings.Index(repository, ":"); index != -1 {
+		tag = repository[index+1:]
+		repository = repository[:index]
+		// A digest takes precedence over the tag, including an empty tag.
+		if tag == "" && digestStr == "" {
+			return "", "", "", fmt.Errorf("%w: missing tag", errdef.ErrInvalidReference)
+		}
 	}
 
-	// empty reference; Valid Form D
-	return path, "", ""
+	return repository, digestStr, tag, nil
 }
 
 func splitRegistry(artifact string) (string, string) {

--- a/registry/remote/properties/reference_test.go
+++ b/registry/remote/properties/reference_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 package properties
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/oras-project/oras-go/v3/errdef"
 )
 
 func TestNewReference(t *testing.T) {
@@ -57,6 +60,13 @@ func TestNewReference(t *testing.T) {
 			wantReg:  "localhost:5000",
 			wantRepo: "repo",
 			wantTag:  "v1",
+		},
+		{
+			name:       "empty tag with digest",
+			input:      "docker.io/library/alpine:@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantReg:    "docker.io",
+			wantRepo:   "library/alpine",
+			wantDigest: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		},
 		{
 			name:     "oci scheme",
@@ -118,6 +128,24 @@ func TestNewReference(t *testing.T) {
 			}
 			if ref.Digest != tt.wantDigest {
 				t.Errorf("Digest = %q, want %q", ref.Digest, tt.wantDigest)
+			}
+		})
+	}
+}
+
+func TestNewReference_EmptyComponents(t *testing.T) {
+	for _, input := range []string{
+		"ghcr.io/repo:",
+		"ghcr.io/repo@",
+		"ghcr.io/repo:@",
+		"ghcr.io/repo:tag@",
+	} {
+		t.Run(input, func(t *testing.T) {
+			if _, err := NewReference(input); !errors.Is(err, errdef.ErrInvalidReference) {
+				t.Errorf("NewReference(%q) error = %v, want ErrInvalidReference", input, err)
+			}
+			if _, err := NewReferenceList(input); !errors.Is(err, errdef.ErrInvalidReference) {
+				t.Errorf("NewReferenceList(%q) error = %v, want ErrInvalidReference", input, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Reject references ending in an empty tag or digest component, including `repo:`, `repo@`, `repo:@`, and `repo:tag@`. Previously these could be accepted with an empty reference or an unintended tag fallback.

Return `errdef.ErrInvalidReference` from the shared parser so both `properties.NewReference` (and its legacy `registry.ParseReference` wrapper) and `properties.NewReferenceList` reject these inputs.

Related to #1191. This deliberately preserves `repo:@sha256:<valid digest>`: existing `registry` tests explicitly accept this form because the digest takes precedence over the tag. It does not attempt to change that compatibility behavior.

## Tests

- Added regression cases for all four dangling-delimiter inputs through both single-reference and list parsing, asserting the error identity.
- Added coverage preserving an empty tag with a valid digest.
- Confirmed the dangling-delimiter regression cases fail before the fix.
- `make test` passes, including the full race-enabled suite, coverage, and encoding checks.

AI assistance was used to investigate, implement, and test this change.
