### PR TITLE
perf(content): actually use the pooled 1 MiB copy buffer

### DIFF
--- a/content/file/utils.go
+++ b/content/file/utils.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/go-digest"
+	"github.com/oras-project/oras-go/v3/internal/ioutil"
 )
 
 // tarDirectory walks the directory specified by path, and tar those files with a new
@@ -104,7 +105,7 @@ func tarDirectory(ctx context.Context, root, prefix string, w io.Writer, modTime
 				}
 			}()
 
-			if _, err := io.CopyBuffer(tw, fp, buf); err != nil {
+			if _, err := ioutil.CopyWithBuffer(tw, fp, buf); err != nil {
 				return fmt.Errorf("failed to copy to %s: %w", path, err)
 			}
 		}
@@ -362,6 +363,6 @@ func writeFile(path string, r io.Reader, perm os.FileMode, buf []byte) (err erro
 		}
 	}()
 
-	_, err = io.CopyBuffer(file, r, buf)
+	_, err = ioutil.CopyWithBuffer(file, r, buf)
 	return err
 }

--- a/internal/ioutil/io.go
+++ b/internal/ioutil/io.go
@@ -32,13 +32,25 @@ func (fn CloserFunc) Close() error {
 	return fn()
 }
 
+// CopyWithBuffer copies from src to dst through the provided buffer
+// until either EOF is reached on src, or an error occurs.
+//
+// io.CopyBuffer ignores the provided buffer whenever src implements
+// io.WriterTo or dst implements io.ReaderFrom, and falls back to an
+// internally allocated 32 KiB buffer. Both sides are therefore hidden behind
+// plain io.Reader and io.Writer wrappers so the caller's buffer is the one
+// that is used, the same technique as net/http.
+func CopyWithBuffer(dst io.Writer, src io.Reader, buf []byte) (int64, error) {
+	return io.CopyBuffer(struct{ io.Writer }{dst}, struct{ io.Reader }{src}, buf)
+}
+
 // CopyBuffer copies from src to dst through the provided buffer
 // until either EOF is reached on src, or an error occurs.
 // The copied content is verified against the size and the digest.
 func CopyBuffer(dst io.Writer, src io.Reader, buf []byte, desc ocispec.Descriptor) error {
 	// verify while copying
 	vr := content.NewVerifyReader(src, desc)
-	if _, err := io.CopyBuffer(dst, vr, buf); err != nil {
+	if _, err := CopyWithBuffer(dst, vr, buf); err != nil {
 		return fmt.Errorf("copy failed: %w", err)
 	}
 	return vr.Verify()

--- a/internal/ioutil/io_test.go
+++ b/internal/ioutil/io_test.go
@@ -134,3 +134,135 @@ func TestCopyBuffer(t *testing.T) {
 		})
 	}
 }
+
+// readRecorder records the size of the largest read served by the underlying
+// reader. It deliberately implements io.Reader only, so it never offers a
+// io.WriterTo fast path of its own.
+type readRecorder struct {
+	r       io.Reader
+	maxRead int
+}
+
+func (rr *readRecorder) Read(p []byte) (int, error) {
+	n, err := rr.r.Read(p)
+	if n > rr.maxRead {
+		rr.maxRead = n
+	}
+	return n, err
+}
+
+// writeRecorder records the size of the largest write it receives. It
+// deliberately implements io.Writer only, so it never offers an io.ReaderFrom
+// fast path of its own.
+type writeRecorder struct {
+	w        io.Writer
+	maxWrite int
+}
+
+func (wr *writeRecorder) Write(p []byte) (int, error) {
+	if len(p) > wr.maxWrite {
+		wr.maxWrite = len(p)
+	}
+	return wr.w.Write(p)
+}
+
+// tempFileWithContent creates a temporary file holding content and returns it
+// positioned at the start.
+func tempFileWithContent(t *testing.T, content []byte) *os.File {
+	t.Helper()
+	fp, err := os.CreateTemp(t.TempDir(), "content")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := fp.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
+			t.Errorf("failed to close temp file: %v", err)
+		}
+	})
+	if _, err := fp.Write(content); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	if _, err := fp.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("failed to seek temp file: %v", err)
+	}
+	return fp
+}
+
+func TestCopyWithBuffer_bufferIsUsed(t *testing.T) {
+	const bufSize = 128 * 1024
+	blob := make([]byte, 4*bufSize)
+	for i := range blob {
+		blob[i] = byte(i)
+	}
+
+	t.Run("destination implements io.ReaderFrom", func(t *testing.T) {
+		src := &readRecorder{r: bytes.NewReader(blob)}
+		dst := tempFileWithContent(t, nil)
+		buf := make([]byte, bufSize)
+
+		n, err := CopyWithBuffer(dst, src, buf)
+		if err != nil {
+			t.Fatalf("CopyWithBuffer() error = %v", err)
+		}
+		if n != int64(len(blob)) {
+			t.Errorf("CopyWithBuffer() = %d, want %d", n, len(blob))
+		}
+		if src.maxRead != bufSize {
+			t.Errorf("largest read = %d, want %d: the provided buffer was not used", src.maxRead, bufSize)
+		}
+		got, err := os.ReadFile(dst.Name())
+		if err != nil {
+			t.Fatalf("failed to read destination: %v", err)
+		}
+		if !bytes.Equal(got, blob) {
+			t.Error("destination content does not match the source content")
+		}
+	})
+
+	t.Run("source implements io.WriterTo", func(t *testing.T) {
+		src := tempFileWithContent(t, blob)
+		var sink bytes.Buffer
+		dst := &writeRecorder{w: &sink}
+		buf := make([]byte, bufSize)
+
+		n, err := CopyWithBuffer(dst, src, buf)
+		if err != nil {
+			t.Fatalf("CopyWithBuffer() error = %v", err)
+		}
+		if n != int64(len(blob)) {
+			t.Errorf("CopyWithBuffer() = %d, want %d", n, len(blob))
+		}
+		if dst.maxWrite != bufSize {
+			t.Errorf("largest write = %d, want %d: the provided buffer was not used", dst.maxWrite, bufSize)
+		}
+		if !bytes.Equal(sink.Bytes(), blob) {
+			t.Error("destination content does not match the source content")
+		}
+	})
+}
+
+func TestCopyBuffer_bufferIsUsed(t *testing.T) {
+	const bufSize = 128 * 1024
+	blob := make([]byte, 4*bufSize)
+	for i := range blob {
+		blob[i] = byte(i)
+	}
+
+	src := &readRecorder{r: bytes.NewReader(blob)}
+	dst := tempFileWithContent(t, nil)
+	buf := make([]byte, bufSize)
+
+	if err := CopyBuffer(dst, src, buf, content.NewDescriptorFromBytes("test", blob)); err != nil {
+		t.Fatalf("CopyBuffer() error = %v", err)
+	}
+	if src.maxRead != bufSize {
+		t.Errorf("largest read = %d, want %d: the provided buffer was not used", src.maxRead, bufSize)
+	}
+	got, err := os.ReadFile(dst.Name())
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Error("destination content does not match the source content")
+	}
+}


### PR DESCRIPTION
## What

`content/oci` and `content/file` each keep a `sync.Pool` of 1 MiB buffers, with a comment explaining that a large buffer means less disk I/O. The buffer never reached a copy loop.

`io.CopyBuffer` drops the caller's buffer whenever `src` implements `io.WriterTo` or `dst` implements `io.ReaderFrom`. Every call site hands it an `*os.File` (both interfaces) or a `*tar.Reader` (`io.WriterTo`), so control went to the generic fallback, which allocates its own 32 KiB buffer per call. The pool was populated and returned to for nothing, and the real buffer was fresh garbage on every copy. Tar extraction is where it adds up: `writeFile` runs once per archive entry, so an archive with 10,000 files allocated 10,000 buffers and issued 32 times the intended number of writes.

## Change

`internal/ioutil.CopyWithBuffer` hides both sides behind plain `io.Reader` and `io.Writer` wrappers, the same technique `net/http` uses, so the supplied buffer is the one used. Four call sites now go through it:

- `internal/ioutil.CopyBuffer`, which covers OCI blob ingest (`content/oci/storage.go`) and file store save (`content/file/file.go`)
- `tarDirectory` and `writeFile` in `content/file/utils.go`

Wrapping only the destination is not enough at the two direct sites: `tarDirectory` writes to an `io.MultiWriter` and the fast path there is `*os.File.WriteTo` on the source, and `writeFile` reads from a `*tar.Reader`, which is also an `io.WriterTo`.

No zero-copy path is lost in the verified path: content has to stream through the digest verifier, so `ReadFrom` could never splice there anyway.

One behavior note: extracting a sparse tar entry now writes its zero bytes rather than taking the seek-based path in `archive/tar`. File content is identical, holes are not preserved. Tarballs produced by this package contain no sparse entries.

## Tests

`internal/ioutil/io_test.go` gains three cases that record the largest read or write a copy issues:

- destination implements `io.ReaderFrom` (`*os.File`)
- source implements `io.WriterTo` (`*os.File`)
- the verified `CopyBuffer` path

With a 128 KiB buffer and 512 KiB of content, all three report 32768 before the change and 131072 after. Verified by reverting only the body of `CopyWithBuffer` to a plain `io.CopyBuffer` call and rerunning.

## Checks

`make test` (vendor, encoding check, full suite with `-race` and coverage) passes: all packages ok, no failures. `go build ./...`, `go vet ./...` and `gofmt -l` are clean. `golangci-lint` is not installed locally; the config enables `govet`, `ineffassign` and the `gofmt` formatter, and the first and third were run directly.

## Scope

This is finding 1 of https://github.com/oras-project/oras-go/issues/1395. The other findings are left for separate pull requests, so this issue is not closed here.
