### PR TITLE
ci: use release PAT for protected tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          # Must belong to an org owner so the protected-tag ruleset bypass applies.
+          # Rotate the repository secret before its PAT expires.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
## Summary

- persist the existing `RELEASE_PAT` repository secret in the main-branch release checkout
- authenticate protected tag pushes as the ruleset-bypass-eligible token owner
- keep GoReleaser on the workflow `GITHUB_TOKEN`

This mirrors the already merged v2 fix in #1371.

## Verification

- YAML parsed successfully with PyYAML
- `.github/workflows/release.yml` remains LF-only
- `git diff --check` passed
- the three-line workflow change matches #1371 exactly
- `go test ./...` was attempted with Go 1.26; unrelated Windows-only baseline failures remain around symlink privilege, Unix file modes, XDG paths, and `file://C:\...` URL handling
- race mode is unavailable locally because CGO is disabled

The protected tag push can only be verified by the next repository release workflow.

Fixes #1411