### PR TITLE
ci: trigger v2 releases from release labels

### DIFF
--- a/.github/act/release-event.json
+++ b/.github/act/release-event.json
@@ -3,11 +3,19 @@
   "pull_request": {
     "merged": true,
     "number": 999,
-    "title": "chore: prepare release v2.7.0",
+    "title": "release: v2.7.0",
     "body": "## New Features\n\n* Test feature\n\n## Bug Fixes\n\n* Test fix",
+    "labels": [
+      {
+        "name": "release"
+      }
+    ],
     "head": {
-      "ref": "release/v2.7.0",
-      "sha": "abc123def456"
+      "ref": "chore/release-v2.7.0",
+      "sha": "abc123def456",
+      "repo": {
+        "full_name": "oras-project/oras-go"
+      }
     },
     "base": {
       "ref": "v2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -41,12 +44,17 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Extract version from branch name
+      - name: Extract version from PR title
         id: version
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          BRANCH="${{ github.head_ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ ! "$TITLE" =~ ^release:[[:space:]]+(v[^[:space:]]+)[[:space:]]*$ ]]; then
+            echo "Error: PR is labelled 'release' but its title is not 'release: vX.Y.Z'"
+            echo "Title was: $TITLE"
+            exit 1
+          fi
+          echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
 
       - name: Validate semantic version
         run: |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,20 +1,25 @@
 # Releasing oras-go
 
-Releases are created via a GitOps workflow. Merging a `release/vX.Y.Z` branch
-into `v2` automatically tags the commit and publishes the GitHub Release.
+Releases are created via a GitOps workflow. Merging a pull request with the
+`release` label into `v2` automatically tags the commit and publishes the
+GitHub Release. The pull request title supplies the version to tag.
 
 ## Steps
 
 ### 1. Create a release branch
 
 The release branch needs at least one commit so GitHub will allow a PR to be
-opened. Use an empty commit as a lightweight marker:
+opened. It must live in `oras-project/oras-go`: the release workflow ignores
+pull requests from forks, so merging a fork branch will not publish a release.
+
+Use an empty commit as a lightweight marker. The branch may follow the usual
+repository naming conventions because its name does not control the release:
 
 ```bash
 git fetch upstream
-git checkout -b release/v2.7.0 upstream/v2
+git checkout -b chore/release-v2.7.0 upstream/v2
 git commit --allow-empty -s -m "chore: prepare release v2.7.0"
-git push origin release/v2.7.0
+git push upstream chore/release-v2.7.0
 ```
 
 The release does not need to contain the changes being released — those are
@@ -24,8 +29,9 @@ all prior work on the branch.
 
 ### 2. Open a pull request
 
-Open a PR from `release/v2.7.0` targeting the `v2` branch. Write the release
-notes directly in the PR description using the format from prior releases:
+Open a PR titled `release: v2.7.0` targeting the `v2` branch and add the
+`release` label. Write the release notes directly in the PR description using
+the format from prior releases:
 
 ```markdown
 ## New Features
@@ -58,15 +64,15 @@ listed in [OWNERS.md](OWNERS.md). Reviewers should verify:
 Merge the PR. The [release workflow](.github/workflows/release.yml)
 automatically:
 
-1. Extracts the version from the branch name (`release/v2.7.0` → `v2.7.0`)
+1. Extracts the version from the PR title (`release: v2.7.0` → `v2.7.0`)
 2. Creates and pushes the git tag
 3. Publishes the GitHub Release with the PR body as release notes
 
 ## Pre-releases
 
 Tags containing `-alpha`, `-beta`, or `-rc` (e.g., `v2.7.0-rc.1`) are
-automatically marked as pre-release on GitHub. Use the same branch naming
-convention: `release/v2.7.0-rc.1`.
+automatically marked as pre-release on GitHub. Use the corresponding PR title,
+for example `release: v2.7.0-rc.1`.
 
 ## Testing the workflow locally
 
@@ -99,7 +105,8 @@ act pull_request \
 This runs all steps up to and including version extraction (`version=vX.Y.Z` will
 appear in the output). The `git push` step then fails with a permission error —
 that is expected and confirms no tag was pushed. The mock event payload is at
-`.github/act/release-event.json`.
+`.github/act/release-event.json`; it carries the `release` label and a matching
+title.
 
 ## Updating the documentation site
 


### PR DESCRIPTION
## Summary

- gate the v2 release job on the existing `release` label while retaining the same-repository protection
- extract the release version from a `release: vX.Y.Z` PR title through an environment variable and fail before tagging when the title or semantic version is invalid
- document the label/title convention and same-repository branch requirement, and update the local `act` event fixture

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- parsed `.github/workflows/release.yml` with PyYAML
- parsed `.github/act/release-event.json` with Python's `json` module
- exercised the Bash title/version parser with stable and `rc` versions plus invalid prefix, leading-zero, incomplete-version, trailing-text, and case variants
- `git diff --check`

`act` and GoReleaser are not installed in this environment, so I did not run the containerized release dry-run. No tag or release was created.

Fixes #1420
